### PR TITLE
/etc/apio.json and system wide packages

### DIFF
--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -31,7 +31,7 @@ To get an example, use the command:
 class Examples(object):
 
     def __init__(self):
-        self.examples_dir = join(util.get_home_dir(), 'packages', 'examples')
+        self.examples_dir = util.get_package_dir('examples')
 
     def list_examples(self):
         if isdir(self.examples_dir):

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -152,10 +152,10 @@ class SCons(object):
     def run(self, command, variables=[], board=None):
         """Executes scons for building"""
 
-        packages_dir = os.path.join(util.get_home_dir(), 'packages')
-        icestorm_dir = os.path.join(packages_dir, 'toolchain-icestorm', 'bin')
-        iverilog_dir = os.path.join(packages_dir, 'toolchain-iverilog', 'bin')
-        scons_dir = os.path.join(packages_dir, 'tool-scons', 'script')
+        icestorm_dir = os.path.join(util.get_package_dir('toolchain-icestorm'), 'bin')
+        iverilog_base_dir = util.get_package_dir('toolchain-iverilog')
+        iverilog_dir = os.path.join(iverilog_base_dir, 'bin')
+        scons_dir = os.path.join(util.get_package_dir('tool-scons'), 'script')
         sconstruct_name = 'SConstruct'
 
         # Give the priority to the packages installed by apio
@@ -163,10 +163,8 @@ class SCons(object):
             [iverilog_dir, icestorm_dir, os.environ['PATH']])
 
         # Add environment variables
-        os.environ['IVL'] = os.path.join(
-            packages_dir, 'toolchain-iverilog', 'lib', 'ivl')
-        os.environ['VLIB'] = os.path.join(
-            packages_dir, 'toolchain-iverilog', 'vlib', 'system.v')
+        os.environ['IVL'] = os.path.join(iverilog_base_dir, 'lib', 'ivl')
+        os.environ['VLIB'] = os.path.join(iverilog_base_dir, 'vlib', 'system.v')
 
         # -- Check for the SConstruct file
         if not isfile(join(util.get_project_dir(), sconstruct_name)):

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -152,7 +152,8 @@ class SCons(object):
     def run(self, command, variables=[], board=None):
         """Executes scons for building"""
 
-        icestorm_dir = os.path.join(util.get_package_dir('toolchain-icestorm'), 'bin')
+        icestorm_dir = os.path.join(util.get_package_dir('toolchain-icestorm'),
+                                    'bin')
         iverilog_base_dir = util.get_package_dir('toolchain-iverilog')
         iverilog_dir = os.path.join(iverilog_base_dir, 'bin')
         scons_dir = os.path.join(util.get_package_dir('tool-scons'), 'script')
@@ -164,7 +165,8 @@ class SCons(object):
 
         # Add environment variables
         os.environ['IVL'] = os.path.join(iverilog_base_dir, 'lib', 'ivl')
-        os.environ['VLIB'] = os.path.join(iverilog_base_dir, 'vlib', 'system.v')
+        os.environ['VLIB'] = os.path.join(iverilog_base_dir, 'vlib',
+                                          'system.v')
 
         # -- Check for the SConstruct file
         if not isfile(join(util.get_project_dir(), sconstruct_name)):
@@ -208,7 +210,7 @@ class SCons(object):
                 click.secho("-" * terminal_width, bold=True)
 
             click.secho("Executing: scons -Q {0} {1}".format(
-                            command, ' '.join(variables)))
+                        command, ' '.join(variables)))
             result = util.exec_command(
                 [
                     os.path.normpath(sys.executable),

--- a/apio/managers/system.py
+++ b/apio/managers/system.py
@@ -51,7 +51,7 @@ class System(object):  # pragma: no cover
 
     def _run(self, command):
         result = {}
-        system_dir = join(util.get_home_dir(), 'packages', 'system')
+        system_dir = util.get_package_dir('system')
 
         if isdir(system_dir):
             result = util.exec_command(

--- a/apio/util.py
+++ b/apio/util.py
@@ -107,11 +107,11 @@ class ConfigLoader:
 
 def _get_projconf_option_dir(name, default=None):
     _env_name = "APIO_%s" % name.upper()
+    if _env_name in os.environ:
+        return os.getenv(_env_name)
     from_config = ConfigLoader().config_data[_env_name];
     if from_config:
         return from_config
-    if _env_name in os.environ:
-        return os.getenv(_env_name)
     return default
 
 

--- a/apio/util.py
+++ b/apio/util.py
@@ -92,24 +92,25 @@ def get_systype():
 class ConfigLoader:
     __shared_state = {}
     loaded = 0
+
     def __init__(self):
         self.__dict__ = self.__shared_state
         if not self.loaded:
-           self.config_data = None
-           filepath = os.path.join(os.sep, 'etc', 'apio.json')
-           if isfile(filepath):
-               with open(filepath, 'r') as f:
-                   # Load the JSON file
-                   #click.echo('Loading json config\n')
-                   self.loaded = 1
-                   self.config_data = json.loads(f.read())
+            self.config_data = None
+            filepath = os.path.join(os.sep, 'etc', 'apio.json')
+            if isfile(filepath):
+                with open(filepath, 'r') as f:
+                    # Load the JSON file
+                    # click.echo('Loading json config\n')
+                    self.loaded = 1
+                    self.config_data = json.loads(f.read())
 
 
 def _get_projconf_option_dir(name, default=None):
     _env_name = "APIO_%s" % name.upper()
     if _env_name in os.environ:
         return os.getenv(_env_name)
-    from_config = ConfigLoader().config_data[_env_name];
+    from_config = ConfigLoader().config_data[_env_name]
     if from_config:
         return from_config
     return default
@@ -122,8 +123,9 @@ def _is_writable(directory):
         f.close()
         os.remove(filename)
         return True
-    except Exception as e:
+    except Exception:
         return False
+
 
 def get_home_dir():
     home_dir = _get_projconf_option_dir("home_dir", "~/.apio")
@@ -132,18 +134,18 @@ def get_home_dir():
     paths = split(home_dir, pathsep)
     for path in paths:
         if isdir(path):
-           if _is_writable(path):
-              return path
+            if _is_writable(path):
+                return path
 
     for path in paths:
         if not isdir(path):
-           try:
-               os.makedirs(path)
-               return path
-           except OSError as ioex:
-               if ioex.errno == 13:
+            try:
+                os.makedirs(path)
+                return path
+            except OSError as ioex:
+                if ioex.errno == 13:
                     click.secho('Warning: can\'t create '+home_dir,
-                         fg='yellow')
+                                fg='yellow')
                     pass
 
     click.secho('Error: no usable home directory', fg='red')
@@ -158,15 +160,15 @@ def get_package_dir(pkg_name):
     paths = split(home_dir, pathsep)
     for path in paths:
         try_name = join(path, 'packages', pkg_name)
-        #click.echo('Trying '+try_name)
+        # click.echo('Trying '+try_name)
         if isdir(try_name):
-           file_found = 1
-           break
+            file_found = 1
+            break
 
     if file_found:
-       return try_name
+        return try_name
     else:
-       return join(paths[0], 'packages', pkg_name)
+        return join(paths[0], 'packages', pkg_name)
 
 
 def get_project_dir():

--- a/apio/util.py
+++ b/apio/util.py
@@ -11,9 +11,13 @@
 import os
 import click
 import subprocess
-from os.path import expanduser, isdir, join
+import json
+import re
+from os.path import expanduser, isdir, join, isfile
+from os import pathsep
 from platform import system, uname
 from threading import Thread
+from string import split
 
 import requests
 requests.packages.urllib3.disable_warnings()
@@ -85,24 +89,84 @@ def get_systype():
     return "%s_%s" % (type_, arch) if arch else type_
 
 
+class ConfigLoader:
+    __shared_state = {}
+    loaded = 0
+    def __init__(self):
+        self.__dict__ = self.__shared_state
+        if not self.loaded:
+           self.config_data = None
+           filepath = os.path.join(os.sep, 'etc', 'apio.json')
+           if isfile(filepath):
+               with open(filepath, 'r') as f:
+                   # Load the JSON file
+                   #click.echo('Loading json config\n')
+                   self.loaded = 1
+                   self.config_data = json.loads(f.read())
+
+
 def _get_projconf_option_dir(name, default=None):
     _env_name = "APIO_%s" % name.upper()
+    from_config = ConfigLoader().config_data[_env_name];
+    if from_config:
+        return from_config
     if _env_name in os.environ:
         return os.getenv(_env_name)
     return default
 
 
+def _is_writable(directory):
+    try:
+        filename = os.path.join(directory, '__test__')
+        f = open(filename, "w")
+        f.close()
+        os.remove(filename)
+        return True
+    except Exception as e:
+        return False
+
 def get_home_dir():
-    home_dir = _get_projconf_option_dir(
-        "home_dir",
-        join(expanduser("~"), ".apio")
-    )
+    home_dir = _get_projconf_option_dir("home_dir", "~/.apio")
+    home_dir = re.sub(r'\~', expanduser("~"), home_dir)
 
-    if not isdir(home_dir):
-        os.makedirs(home_dir)
+    paths = split(home_dir, pathsep)
+    for path in paths:
+        if isdir(path):
+           if _is_writable(path):
+              return path
 
-    assert isdir(home_dir)
-    return home_dir
+    for path in paths:
+        if not isdir(path):
+           try:
+               os.makedirs(path)
+               return path
+           except OSError as ioex:
+               if ioex.errno == 13:
+                    click.secho('Warning: can\'t create '+home_dir,
+                         fg='yellow')
+                    pass
+
+    click.secho('Error: no usable home directory', fg='red')
+    return path
+
+
+def get_package_dir(pkg_name):
+    home_dir = _get_projconf_option_dir("home_dir", "~/.apio")
+    home_dir = re.sub(r'\~', expanduser("~"), home_dir)
+
+    file_found = 0
+    paths = split(home_dir, pathsep)
+    for path in paths:
+        try_name = join(path, 'packages', pkg_name)
+        #click.echo('Trying '+try_name)
+        if isdir(try_name):
+           file_found = 1
+           break
+
+    if file_found:
+       return try_name
+    else:
+       return join(paths[0], 'packages', pkg_name)
 
 
 def get_project_dir():


### PR DESCRIPTION
This patch adds:
* Added: now you can define APIO_* variables in /etc/apio.json
* Added: now APIO_HOME_DIR can be a list of directories
In this way a Debian package can install all the "packages" in /usr
The user can install its own packages, if needed, in ~/.apio