### PR TITLE
Add support for backice and TinyFPGA-B2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Apio is used by [Icestudio](https://github.com/FPGAwars/icestudio).
 | [iCEstick Evaluation Kit](http://www.pighixxx.com/test/portfolio-items/icestick/) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [icoBOARD 1.0](http://icoboard.org/about-icoboard.html) |  &nbsp;&nbsp;:white_check_mark:&nbsp;**\*** | - |  - |
 | [CAT Board](https://hackaday.io/project/7982-cat-board) | &nbsp;&nbsp;:white_check_mark:&nbsp;**\*** | - |  - |
+| [BlackIce](https://mystorm.uk/) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [TinyFPGA B2](http://tinyfpga.com/) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 **\*** Use with Raspberry Pi
 

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -75,7 +75,7 @@ class SCons(object):
         check_info = self.resources.boards[board]['check']
         # Check FTDI description
         device = self._check_ftdi(check_info, device, board)
-         # Search serial device by USB id
+        # Search serial device by USB id
         device = self._check_serial_usbid(check_info, device, board)
         if device == -1:
             # Board not detected
@@ -152,7 +152,7 @@ class SCons(object):
     def _check_serial_usbid(self, check, device, board):
         if device and device != -1:
             return device
-        if not 'serial-usbid' in check:
+        if 'serial-usbid' not in check:
             return device
 
         for item in util.get_serialports(True):

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -75,6 +75,8 @@ class SCons(object):
         check_info = self.resources.boards[board]['check']
         # Check FTDI description
         device = self._check_ftdi(check_info, device, board)
+         # Search serial device by USB id
+        device = self._check_serial_usbid(check_info, device, board)
         if device == -1:
             # Board not detected
             raise Exception('board not detected')
@@ -146,6 +148,19 @@ class SCons(object):
                 else:
                     raise Exception(
                         'incorrect platform {0}'.format(platform))
+
+    def _check_serial_usbid(self, check, device, board):
+        if device and device != -1:
+            return device
+        if not 'serial-usbid' in check:
+            return device
+
+        for item in util.get_serialports(True):
+            if check['serial-usbid'] in item['hwid']:
+                print('Found device at: %s' % item['port'])
+                return item['port']
+
+        return -1
 
     def run(self, command, variables=[], board=None, deps=[]):
         """Executes scons for building"""

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -62,5 +62,23 @@
     "check": {
       "ftdi-desc": "Milk JTAG:u"
     }
+  },
+  "blackice": {
+    "fpga": "iCE40-HX4K-TQ144",
+    "programmer": {
+      "type": "blackiceprog"
+    },
+    "check": {
+      "serial-usbid": "0483:5740"
+    }
+  },
+  "TinyFPGA-B2": {
+    "fpga": "iCE40-LP8K-CM81",
+    "programmer": {
+      "type": "tinyfpgab"
+    },
+    "check": {
+      "serial-usbid": "1209:2100"
+    }
   }
 }

--- a/apio/resources/programmers.json
+++ b/apio/resources/programmers.json
@@ -12,7 +12,7 @@
     "args": "-c"
   },
   "blackiceprog": {
-    "command": "black-iceprog.py",
+    "command": "black-iceprog",
     "args": "%D% "
   },
   "tinyfpgab": {

--- a/apio/resources/programmers.json
+++ b/apio/resources/programmers.json
@@ -10,5 +10,13 @@
   "litterbox": {
     "command": "sudo litterbox",
     "args": "-c"
+  },
+  "blackiceprog": {
+    "command": "black-iceprog.py",
+    "args": "%D% "
+  },
+  "tinyfpgab": {
+    "command": "tinyfpgab",
+    "args": "--program "
   }
 }

--- a/apio/resources/programmers.json
+++ b/apio/resources/programmers.json
@@ -17,6 +17,6 @@
   },
   "tinyfpgab": {
     "command": "tinyfpgab",
-    "args": "--program "
+    "args": "-c %D% --program "
   }
 }

--- a/apio/util.py
+++ b/apio/util.py
@@ -403,31 +403,26 @@ def decode(text):
 
 
 def get_serialports(filter_hwid=False):
+    result = []
+
     try:
         from serial.tools.list_ports import comports
     except ImportError:
         click.secho('Error: could not import pyserial', fg='red')
         click.secho('Please run:\n'
-                        '   pip install -U pyserial', fg='yellow')
-        return []
+                    '   pip install -U pyserial', fg='yellow')
+        return result
 
-    result = []
     for p, d, h in comports():
         if not p:
             continue
-        if platform.system() == "Windows":
-            try:
-                d = unicode(d, errors="ignore")
-            except TypeError:
-                pass
+        # This is isnt really needed and makes mccabe complain...
+        # if platform.system() == "Windows":
+        #     try:
+        #         d = unicode(d, errors="ignore")
+        #     except TypeError:
+        #         pass
         if not filter_hwid or "VID:PID" in h:
             result.append({"port": p, "description": d, "hwid": h})
 
-    # if filter_hwid:
-    #     return result
-
-    # fix for PySerial
-    # if not result and platform.system() == "Darwin":
-    #     for p in glob("/dev/tty.*"):
-    #         result.append({"port": p, "description": "n/a", "hwid": "n/a"})
     return result

--- a/apio/util.py
+++ b/apio/util.py
@@ -400,3 +400,34 @@ def command(function):
 
 def decode(text):
     return jwt.decode(text, 'secret', algorithm='HS256')
+
+
+def get_serialports(filter_hwid=False):
+    try:
+        from serial.tools.list_ports import comports
+    except ImportError:
+        click.secho('Error: could not import pyserial', fg='red')
+        click.secho('Please run:\n'
+                        '   pip install -U pyserial', fg='yellow')
+        return []
+
+    result = []
+    for p, d, h in comports():
+        if not p:
+            continue
+        if platform.system() == "Windows":
+            try:
+                d = unicode(d, errors="ignore")
+            except TypeError:
+                pass
+        if not filter_hwid or "VID:PID" in h:
+            result.append({"port": p, "description": d, "hwid": h})
+
+    # if filter_hwid:
+    #     return result
+
+    # fix for PySerial
+    # if not result and platform.system() == "Darwin":
+    #     for p in glob("/dev/tty.*"):
+    #         result.append({"port": p, "description": "n/a", "hwid": "n/a"})
+    return result

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
         'requests>=2.4.0,<3',
         'pyjwt>=1.5.3,<2',
         'colorama',
-        "pyserial>=3,<4,!=3.3",
+        'pyserial>=3,<4,!=3.3',
+        'tinyfpgab'
     ],
     entry_points={
         'console_scripts': ['apio=apio.__main__:cli']

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'pyjwt>=1.5.3,<2',
         'colorama',
         'pyserial>=3,<4,!=3.3',
-        'tinyfpgab'
+        'tinyfpgab',
+        'blackiceprog',
     ],
     entry_points={
         'console_scripts': ['apio=apio.__main__:cli']

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
         'semantic_version>=2.5.0',
         'requests>=2.4.0,<3',
         'pyjwt>=1.5.3,<2',
-        'colorama'
+        'colorama',
+        "pyserial>=3,<4,!=3.3",
     ],
     entry_points={
         'console_scripts': ['apio=apio.__main__:cli']


### PR DESCRIPTION
Added support for backice and TinyFPGA-B2 target boards. Boards are detected by USB id, pyserial is required in order to perform this task.

This should close #132 abd #131 at least partially.

Tested to work with linux and windows. Should also work with osx.

It requires the following tools to perform the upload:
* blackice: https://gist.github.com/jpenalbae/15cdfdf5eefa7e7cbc8afba9b7aa89b1
* TinyFPGA-B2: https://github.com/tinyfpga/TinyFPGA-B-Series/tree/master/programmer

Maybe a new apio package should be created to hold this and any other future uploader scripts.