### PR TITLE
Fixes the extra_args processing for the board's programmer

### DIFF
--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -139,8 +139,8 @@ class SCons(object):
             programmer += ' {}'.format(content.get('args'))
 
         # Add extra args
-        if content.get('extra_args'):
-            programmer += ' {}'.format(content.get('extra_args'))
+        if prog_info.get('extra_args'):
+            programmer += ' {}'.format(prog_info.get('extra_args'))
 
         # Enable SRAM programming
         if sram:


### PR DESCRIPTION
The current code doesn't add the extra_ags defined for the programmer in the selected board.
This patch gets the information from the board definition, not from the programmer definition.
I think the extra_args only has use in the board definition, otherwise you should also add a get from the programmer.