### PR TITLE
Added UP5K FPGAs and coresponding boards and programmer definitions

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -118,5 +118,60 @@
       "vid": "1209",
       "pid": "2100"
     }
+  },
+  "upduino": {
+    "name": "UPDuino v.1.0",
+    "fpga": "iCE40-UP5K-SG48",
+    "programmer": {
+      "type": "iceprog"
+    },
+    "usb": {
+      "vid": "0403",
+      "pid": "6014"
+    }
+  },
+  "upduino2": {
+    "name": "UPDuino v.2.0",
+    "fpga": "iCE40-UP5K-SG48",
+    "programmer": {
+      "type": "iceprog"
+    },
+    "usb": {
+      "vid": "0403",
+      "pid": "6014"
+    }
+  },
+  "iCEBreaker": {
+    "name": "iCEBreaker",
+    "fpga": "iCE40-UP5K-SG48",
+    "programmer": {
+      "type": "iceprog"
+    },
+    "usb": {
+      "vid": "0403",
+      "pid": "6010"
+    }
+  },
+  "iCEBreaker-bitsy": {
+    "name": "iCEBreaker bitsy",
+    "fpga": "iCE40-UP5K-SG48",
+    "programmer": {
+      "type": "iceprog"
+    },
+    "usb": {
+      "vid": "0403",
+      "pid": "6010"
+    }
+  },
+  "fpga101": {
+    "name": "FPGA 101 - Workshop Badge",
+    "fpga": "iCE40-UP5K-SG48",
+    "programmer": {
+      "type": "iceprog"
+    },
+    "usb": {
+      "vid": "0403",
+      "pid": "6014"
+    }
   }
 }

--- a/apio/resources/fpgas.json
+++ b/apio/resources/fpgas.json
@@ -123,5 +123,15 @@
     "type": "hx",
     "size": "8k",
     "pack": "ct256"
+  },
+  "iCE40-UP5K-SG48": {
+    "type": "up",
+    "size": "5k",
+    "pack": "sg48"
+  },
+  "iCE40-UP5K-UWG30": {
+    "type": "up",
+    "size": "5k",
+    "pack": "uwg30"
   }
 }


### PR DESCRIPTION
This would require toolchain-icestorm package to be updated, also note that toolchain-iverilog is using file from yosys (vlib/cells_sim.v) so that one as well need to be updated.