### PR TITLE
Added support for the iCEblink40 board.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Apio is used by [Icestudio](https://github.com/FPGAwars/icestudio).
 | [IceZUM Alhambra](https://github.com/FPGAwars/icezum) | FTDI |
 | [Nandland Go board](https://www.nandland.com/goboard/introduction.html) | FTDI |
 | [iCEstick Evaluation Kit](http://www.latticesemi.com/icestick) | FTDI |
+| [iCEblink40-HX1K](http://www.latticesemi.com/iCEblink40-HX1K) | Digilent Adept |
 
 #### HX8K
 

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -27,6 +27,17 @@
       "desc": "Lattice FTUSB Interface Cable"
     }
   },
+  "iceblink40-hx1k" : {
+    "name": "iCEblink40-HX1K", 
+    "fpga": "iCE40-HX1K-VQ100", 
+    "programmer": {
+      "type": "iCEburn"
+    }, 
+    "usb": {
+      "vid": "1443", 
+      "pid": "0007"
+    }
+  },
   "go-board": {
     "name": "Nandland Go board",
     "fpga": "iCE40-HX1K-VQ100",

--- a/apio/resources/programmers.json
+++ b/apio/resources/programmers.json
@@ -5,7 +5,7 @@
   },
   "icoprog": {
     "command": "export WIRINGPI_GPIOMEM=1; icoprog",
-    "args": "-p <"
+    "args": "-p < "
   },
   "litterbox": {
     "command": "sudo litterbox",
@@ -21,6 +21,10 @@
     "command": "tinyfpgab",
     "args": "-c ${SERIAL_PORT} --program",
     "pip_packages": [ "tinyfpgab" ]
+  }, 
+  "iCEburn": {
+    "command": "iCEburn",
+    "args": "-ew"
   },
   "tinyprog": {
     "command": "tinyprog",


### PR DESCRIPTION
The iCEDude programmer requires the filename to be a part of its argument, not a separate argument. A change to the way programmers are ran was needed.