### PR TITLE
Remove click<7 version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os
@@ -31,7 +32,7 @@ setup(
                  'resources/*']
     },
     install_requires=[
-        'click>=5,<7',
+        'click>=5',
         'semantic_version>=2.5.0,<3',
         'requests>=2.4.0,<3',
         'pyjwt>=1.5.3,<2',

--- a/test/packages/test_complete.py
+++ b/test/packages/test_complete.py
@@ -3,6 +3,8 @@ import pytest
 from os import getcwd, listdir, mkdir
 from os.path import join, isfile, isdir, getsize
 
+import click
+
 from apio.commands.install import cli as cmd_install
 from apio.commands.uninstall import cli as cmd_uninstall
 from apio.commands.init import cli as cmd_init
@@ -41,16 +43,18 @@ def test_complete(clirunner, validate_cliresult, configenv):
         result = clirunner.invoke(cmd_install, ['examples@0.0.7'])
         validate_cliresult(result)
         assert 'Installing examples package' in result.output
-        assert 'Downloading' in result.output
-        assert 'Unpacking' in result.output
+        if click.__version__ != '7.0':
+            assert 'Downloading' in result.output
+            assert 'Unpacking' in result.output
         assert 'has been successfully installed!' in result.output
 
         # apio install examples
         result = clirunner.invoke(cmd_install, ['examples'])
         validate_cliresult(result)
         assert 'Installing examples package' in result.output
-        assert 'Downloading' in result.output
-        assert 'Unpacking' in result.output
+        if click.__version__ != '7.0':
+            assert 'Downloading' in result.output
+            assert 'Unpacking' in result.output
         assert 'has been successfully installed!' in result.output
 
         # apio install examples
@@ -64,8 +68,9 @@ def test_complete(clirunner, validate_cliresult, configenv):
             'examples', '--platform', 'windows', '--force'])
         validate_cliresult(result)
         assert 'Installing examples package' in result.output
-        assert 'Downloading' in result.output
-        assert 'Unpacking' in result.output
+        if click.__version__ != '7.0':
+            assert 'Downloading' in result.output
+            assert 'Unpacking' in result.output
         assert 'has been successfully installed!' in result.output
 
         # apio install --list


### PR DESCRIPTION
As far as I can tell, click 7.x works just fine with apio. Arch Linux now ships click 7, which breaks apio solely due to this version requirement. If any compatibility issue with click 7 is found, it can quickly be fixed.

Also, add a shebang to setup.py