### PR TITLE
Added Scansion to replace Gtkwave on MacOS

### DIFF
--- a/apio/resources/SConstruct
+++ b/apio/resources/SConstruct
@@ -83,6 +83,7 @@ CHIPDB_PATH = os.path.join(ICEBOX_PATH, 'chipdb-{0}.txt'.format(FPGA_SIZE))
 VERILATOR_PATH = os.environ['VERLIB'] if 'VERLIB' in os.environ else ''
 
 isWindows = 'Windows' == system()
+isMacOS = 'Darwin' == system()
 VVP_PATH = '' if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
 IVER_PATH = '' if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 
@@ -244,8 +245,10 @@ AlwaysBuild(verify)
 sout = env.IVerilog(TARGET_SIM, src_sim)
 vcd_file = env.VCD(sout)
 
-waves = env.Alias('sim', vcd_file, 'gtkwave {0} {1}.gtkw'.format(
-    vcd_file[0], SIMULNAME))
+if (not isMacOS):
+	waves = env.Alias('sim', vcd_file, 'gtkwave {0} {1}.gtkw'.format(vcd_file[0], SIMULNAME))
+else:
+	waves = env.Alias('sim', vcd_file, 'open -a Scansion {0}'.format(vcd_file[0], SIMULNAME))
 AlwaysBuild(waves)
 
 # -- Verilator builder

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -78,7 +78,7 @@ Check your verilog code using `Icarus Verilog <http://iverilog.icarus.com/>`_
 Simulate
 ~~~~~~~~
 
-Simulate your test bench using `Icarus Verilog <http://iverilog.icarus.com/>`_ and `GTKWave <http://gtkwave.sourceforge.net/>`_
+Simulate your test bench using `Icarus Verilog <http://iverilog.icarus.com/>`_ and `GTKWave <http://gtkwave.sourceforge.net/>`_. Uses `Scansion <http://www.logicpoet.com/scansion/>`_ on MacOS.
 
 .. code::
 
@@ -88,12 +88,12 @@ Simulate your test bench using `Icarus Verilog <http://iverilog.icarus.com/>`_ a
 
 .. note::
 
-  GTKWave must be installed.
+  GTKWave must be installed on Windows and Linux. Scansion must be installed on MacOS.
 
   +---------+-------------------------+
   | Debian  | apt-get install gtkwave |
   +---------+-------------------------+
-  | Mac OSX | brew install gtkwave    |
+  | Mac OSX | Download and install `Scansion <http://www.logicpoet.com/downloads/>`_    |
   +---------+-------------------------+
   | Windows | apio install gtkwave    |
   +---------+-------------------------+

--- a/docs/source/user_guide/project_commands/cmd_sim.rst
+++ b/docs/source/user_guide/project_commands/cmd_sim.rst
@@ -15,7 +15,7 @@ Usage
 Description
 -----------
 
-Launch the verilog simulation using `GTKWave <http://gtkwave.sourceforge.net>`_ from a **verilog test bench**.
+Launch the verilog simulation using `GTKWave <http://gtkwave.sourceforge.net>`_ or `Scansion <http://www.logicpoet.com/scansion>`_ (on MacOS) from a **verilog test bench**.
 
 Required packages: ``scons``, ``iverilog``.
 
@@ -23,12 +23,12 @@ Required packages: ``scons``, ``iverilog``.
 
 .. note::
 
-  GTKWave must be installed.
+  GTKWave (Windows & Linux) or Scansion (MacOS) must be installed.
 
   +---------+-------------------------+
   | Debian  | apt-get install gtkwave |
   +---------+-------------------------+
-  | Mac OSX | brew install gtkwave    |
+  | Mac OSX | `Download <http://www.logicpoet.com/downloads/>`_ and install.    |
   +---------+-------------------------+
   | Windows | apio install gtkwave    |
   +---------+-------------------------+


### PR DESCRIPTION
On MacOS, gtkwave doesn't work nearly as well as one would expect. Scansion (http://www.logicpoet.com/scansion/) is a native MacOS application and works a lot better. This PR replaces gtkwave with Scansion on MacOS only. Documentation has also been updated.