### PR TITLE
Added production iCEBreaker USB strings.

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -197,7 +197,7 @@
       "pid": "6010"
     },
     "ftdi": {
-      "desc": "Dual RS232-HS"
+      "desc": "(?:Dual RS232-HS)|(?:iCEBreaker.*)"
     }
   },
   "iCEBreaker-bitsy": {
@@ -211,7 +211,7 @@
       "pid": "6010"
     },
     "ftdi": {
-      "desc": "Dual RS232-HS"
+      "desc": "(?:Dual RS232-HS)|(?:iCEBreaker.*)"
     }
   },
   "fpga101": {


### PR DESCRIPTION
The regex is now matching the default FTDI string and the iCEBreaker string hopefully being upward compatible to future hardware versions.

If there is a way to just ignore the FTDI strings and just match the VID:PID. That would be probably the safest way to handle this. We could set the regex to `".*"` but there might be a good reason to match the strings that I am not aware of.