### PR TITLE
Add fomu to the list of supported devices

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -255,5 +255,19 @@
     "ftdi": {
       "desc": "Alchitry Cu"
     }
+  },
+  "fomu": {
+    "name": "fomu",
+    "fpga": "iCE40-UP5K-UWG30",
+    "programmer": {
+      "type": "dfu-util"
+    },
+    "usb": {
+      "vid": "1209",
+      "pid": "5bf0"
+    },
+    "ftdi": {
+      "desc": "Fomu Hacker running DFU Bootloader v1.8.8"
+    }
   }
 }

--- a/apio/resources/programmers.json
+++ b/apio/resources/programmers.json
@@ -30,5 +30,9 @@
     "command": "tinyprog",
     "args": "--pyserial -c ${SERIAL_PORT} --program",
     "pip_packages": [ "tinyprog" ]
+  },
+  "dfu-util": {
+    "command": "sudo dfu-util",
+    "args": "-D"
   }
 }


### PR DESCRIPTION
This add basic support to apio for the [fomu](https://github.com/im-tomu/fomu-hardware) FPGA. This relies on the availability of dfu-util on the host system.

Note: @pwmarcz told me that proper support relies on https://github.com/FPGAwars/toolchain-icestorm/pull/71 being merged (due to timing issues for the USB stack). Nevertheless a basic led blink does work using this commit