### PR TITLE
drivers: Convert 'bytes' to 'str' for comparison

### DIFF
--- a/apio/managers/drivers.py
+++ b/apio/managers/drivers.py
@@ -192,7 +192,7 @@ class Drivers(object):  # pragma: no cover
 
     def _add_dialout_group(self):
         groups = subprocess.check_output('groups')
-        if 'dialout' not in groups:
+        if 'dialout' not in groups.decode():
             subprocess.call('sudo usermod -a -G dialout $USER', shell=True)
             return True
 


### PR DESCRIPTION
subprocess.check_output() returns a 'bytes' object which needs to be decoded before comparing against
a 'str' object. The `decode` method defaults to decoding to a `utf-8` string. Without this fix, using `apio drivers --serial-enable` results in a crash as seen in the following traceback:

```
~ $ apio drivers --serial-enable
Configure Serial drivers for FPGA
Traceback (most recent call last):
  File "/usr/local/bin/apio", line 10, in <module>
    sys.exit(cli())
  File "/home/gshrikant/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/gshrikant/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/gshrikant/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/gshrikant/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/gshrikant/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/gshrikant/.local/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/apio/commands/drivers.py", line 32, in cli
    exit_code = Drivers().serial_enable()
  File "/usr/local/lib/python3.7/dist-packages/apio/managers/drivers.py", line 99, in serial_enable
    return self._serial_enable_linux()
  File "/usr/local/lib/python3.7/dist-packages/apio/managers/drivers.py", line 165, in _serial_enable_linux
    group_added = self._add_dialout_group()
  File "/usr/local/lib/python3.7/dist-packages/apio/managers/drivers.py", line 195, in _add_dialout_group
    if 'dialout' not in groups:
TypeError: a bytes-like object is required, not 'str'
```