### PR TITLE
Add OrangeCrab r0.2 to boards.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Apio is used by [Icestudio](https://github.com/FPGAwars/icestudio).
 #### ECP5
 | Board name | Interface |
 |:-|:-:|
+| [OrangeCrab r0.2](https://github.com/gregdavill/OrangeCrab) | FTDI |
 | [TinyFPGA-EX-rev1](https://github.com/tinyfpga/TinyFPGA-EX) | Serial |
 | [TinyFPGA-EX-rev2](https://www.crowdsupply.com/tinyfpga/tinyfpga-ex) | Serial |
 | [ULX3S-12F](https://radiona.org/ulx3s/) | Ujprog |

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -341,7 +341,7 @@
   },
   "orangecrab-r02-25f": {
     "name": "OrangeCrab r0.2",
-    "fpga": "ECP5-LFE5U-25F-8MG285C",
+    "fpga": "ECP5-LFE5U-25F-CSFBGA285",
     "programmer": {
       "type": "dfu-util"
     },

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -339,6 +339,20 @@
       "pid": "6015"
     }
   },
+  "orangecrab-r02-25f": {
+    "name": "OrangeCrab r0.2",
+    "fpga": "ECP5-LFE5U-25F-8MG285C",
+    "programmer": {
+      "type": "dfu-util"
+    },
+    "usb": {
+      "vid": "1209",
+      "pid": "5af0"
+    },
+    "ftdi": {
+      "desc": "OrangeCrab r0.2 DFU bootloader"
+    }
+  },
   "versa": {
     "name": "ECP5 Versa",
     "fpga": "ECP5-LFE5UM-45F-CABGA381",


### PR DESCRIPTION
~~**WARNING:** don't merge it yet! It depends on the board [getting its PID allocated](https://github.com/pidcodes/pidcodes.github.com/pull/499).~~ It got allocated!

Add entry for the OrangeCrab r0.2 (the 25F variant, which is the only one offered [in the group buy](https://groupgets.com/campaigns/710-orangecrab)), to `boards.json`, as requested in #198.