### PR TITLE
added board and programmer Olimex

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -66,6 +66,18 @@
       "desc": "Lattice FTUSB Interface Cable"
     }
   },
+  "iCE40-HX8K-EVB": {
+    "name": "iCE40-HX8K-EVB Olimex",
+    "fpga": "iCE40-HX8K-CT256",
+    "programmer": {
+      "type": "iceprogduino"
+    },
+    "usb": {
+      "vid": "2341",
+      "pid": "8036"
+    }
+  },
+
   "icoboard": {
     "name": "icoBOARD 1.0",
     "fpga": "iCE40-HX8K-CT256",

--- a/apio/resources/programmers.json
+++ b/apio/resources/programmers.json
@@ -3,6 +3,10 @@
     "command": "iceprog",
     "args": "-d i:0x${VID}:0x${PID}:${FTDI_ID}"
   },
+  "iceprogduino": {
+    "command": "iceprogduino",
+    "args": ""
+  },
   "icoprog": {
     "command": "export WIRINGPI_GPIOMEM=1; icoprog",
     "args": "-p <"


### PR DESCRIPTION
Hi there,

I added board from Olimex: iCE40-HX8K-EVB
The board is programmed with "iceprogduino" which can be found in
https://github.com/OLIMEX/iCE40HX1K-EVB/tree/master/programmer

