### PR TITLE
Refactor previous attempts to add udev rules for DFU devices

### DIFF
--- a/apio/resources/80-fpga-ftdi.rules
+++ b/apio/resources/80-fpga-ftdi.rules
@@ -1,4 +1,5 @@
 ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6014", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-
+ATTRS{idVendor}=="1209", ATTRS{idProduct}=="5af0", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+ATTRS{idVendor}=="1209", ATTRS{idProduct}=="5bf0", MODE="0660", GROUP="plugdev", TAG+="uaccess"

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,10 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os
-import sys
-import subprocess
 import json
 
 from setuptools import setup
-from setuptools.command.install import install
 
 from apio import (__author__, __description__, __email__, __license__,
                   __title__, __url__, __version__)
@@ -18,49 +16,6 @@ with open(filepath, 'r') as f:
     resource = json.loads(f.read())
     pip_packages = resource.get('pip_packages', {})
     extras_require = {k: [k + v] for k, v in pip_packages.items()}
-
-# Install udev rules for the DFU boards -- Linux-only code!
-def install_udev_rules():
-    if os.geteuid() == 0:
-
-        # Gather VID/PID of DFU boards
-        dfu_boards = []
-        with open('apio/resources/boards.json', 'r') as f:
-            resource = json.loads(f.read())
-            dfu_boards = [
-                board
-                for board in resource.values()
-                if board['programmer']['type'] == 'dfu-util'
-            ]
-
-        # Generate the rules
-        rules = ''
-        for board in dfu_boards:
-            rules += ('SUBSYSTEMS=="usb",' +
-                    f'ATTRS{{idVendor}}=={board["usb"]["vid"]},' +
-                    f'ATTRS{{idProduct}}=={board["usb"]["pid"]},' +
-                    'GROUP="apio"\n')
-
-        with open('/etc/udev/rules.d/50-apio.rules', 'w') as f:
-            f.write(rules)
-
-        subprocess.call(['udevadm', 'control', '--reload-rules'])
-
-        for board in dfu_boards:
-            subprocess.call(['udevadm', 'trigger', '--subsystem-match=usb',
-                    f'--attr-match=idVendor={board["usb"]["vid"]}',
-                    f'--attr-match=idProduct={board["usb"]["pid"]}',
-                    '--action=add'])
-    else:
-        raise OSError("You must haev root privileges to install udev rules. "
-                + "Run 'sudo python3 setup.py install'")
-
-class CustomInstall(install):
-    def run(self):
-        if sys.platform == 'linux':
-            install_udev_rules()
-
-        install.run(self)
 
 setup(
     name=__title__,
@@ -119,6 +74,5 @@ setup(
         'colorama',
         'pyserial>=3,<4'
     ],
-    extras_require=extras_require,
-    cmdclass={'install': CustomInstall}
+    extras_require=extras_require
 )


### PR DESCRIPTION
I've removed the auto-generation and installation of udev rules, now these are hardcoded into apio/resources/80-fpga-ftdi.rules with the rest of the rules.

This closes #198 and #201 (as this should be enough to make dfu-util available to non-root users).