### PR TITLE
fix setup.py cp950 error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     version=__version__,
 
     description=__description__,
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     license=__license__,
     url=__url__,


### PR DESCRIPTION
This modification can fix FPGAwars/icestudio Issues #447 Unicode Decode Error.: 'cp950' can't decode....in setup.py.
