### PR TITLE
Support iCESugar-nano board.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ Apio is used by [Icestudio](https://github.com/FPGAwars/icestudio).
 | [Versa](https://www.mouser.es/new/lattice-semiconductor/lattice-lfe5um-45f-versa-evn/) | |
 
 
+#### LP1K
+
+| Board name | Interface |
+|:-|:-:|
+| [iCESugar-nano](https://github.com/wuxx/icesugar-nano/blob/main/README.md)  | FTDI |
+
+
 NOTE: all supported [Icestorm FPGAs](http://www.clifford.at/icestorm/) can be used with [--fpga or --size, --type and --pack options](http://apiodoc.readthedocs.io/en/develop/source/user_guide/project_commands/cmd_build.html#options).
 
 ## Documentation

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -481,6 +481,17 @@
       "pid": "602b"
     }
   },
+  "iCESugar-nano": {
+    "name": "iCESugar-nano",
+    "fpga": "iCE40-LP1K-CM36",
+    "programmer": {
+      "type": "icesprog"
+    },
+    "usb": {
+      "vid": "1d50",
+      "pid": "602b"
+    }
+  },
   "OK-iCE40Pro": {
     "name": "OK-iCE40Pro",
     "fpga": "iCE40-UP5K-SG48",


### PR DESCRIPTION
Adds a record for [icesugar nano](https://github.com/wuxx/icesugar-nano/) board. No extra tools required, it's the same overall setup as icesugar v1.5 board, just a new entry in `boards.json` (and in the README).