### PR TITLE
Update boards.json

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -470,6 +470,20 @@
       "desc": "Dual RS232-HS"
     }
   },
+  "OK-iCE40Pro": {
+    "name": "OK-iCE40Pro",
+    "fpga": "iCE40-UP5K-SG48",
+    "programmer": {
+      "type": "iceprog"
+    },
+    "usb": {
+      "vid": "0403",
+      "pid": "6010"
+    },
+    "ftdi": {
+      "desc": "Dual RS232-HS"
+    }
+  },
   "iCESugar_1_5": {
     "name": "iCESugar v1.5",
     "fpga": "iCE40-UP5K-SG48",


### PR DESCRIPTION
Get OK-iCE40Pro board definition BACK from accidentally removed in boards.json on 19 April by benitoss.

Please check the accidentally removal [Issue#231](https://github.com/FPGAwars/apio/issues/231): "ECP5 Colorlight Boards Added, benitoss committed on 19 Apr".

OK-iCE40Pro board [Accidentally deleted merge log](https://github.com/FPGAwars/apio/commit/f1d0ed61bf27924da11d32e085865e86abb15c05#diff-0d95e648489c00ab1ba42abfe4d18a55992de97cfcaa1cbeeccc477689e736f0)

