### PR TITLE
Solve the programmer problem in Colorlight 5A-75B

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -470,6 +470,20 @@
       "desc": "Dual RS232-HS"
     }
   },
+  "OK-iCE40Pro": {
+    "name": "OK-iCE40Pro",
+    "fpga": "iCE40-UP5K-SG48",
+    "programmer": {
+      "type": "iceprog"
+    },
+    "usb": {
+      "vid": "0403",
+      "pid": "6010"
+    },
+    "ftdi": {
+      "desc": "Dual RS232-HS"
+    }
+  },
   "iCESugar_1_5": {
     "name": "iCESugar v1.5",
     "fpga": "iCE40-UP5K-SG48",
@@ -552,21 +566,21 @@
       }
    },
     "iCESugar-Pro_(FT2232H)": {
-    "name": "iCESugar-Pro",
+    "name": "ColorLight-i5",
     "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_ft2232"
     }
   },
    "iCESugar-Pro_(FT232H)": {
-    "name": "iCESugar-Pro",
+    "name": "ColorLight-i5",
     "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_ft232"
       }
    },
    "iCESugar-Pro_(USB-Blaster)": {
-    "name": "iCESugar-Pro",
+    "name": "ColorLight-i5",
     "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_usb-blaster"

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -485,28 +485,28 @@
     "name": "ColorLight-5A-75B-V61",
     "fpga": "ECP5-LFE5U-25F-CABGA256",
     "programmer": {
-      "type": "openfpgaloader"
+      "type": "openfpgaloader_ft2232"
     }
   },
   "ColorLight-5A-75B-V7": {
     "name": "ColorLight-5A-75B-V7",
     "fpga": "ECP5-LFE5U-25F-CABGA256",
     "programmer": {
-      "type": "openfpgaloader"
+      "type": "openfpgaloader_ft2232"
     }
   },
   "ColorLight-5A-75B-V8": {
     "name": "ColorLight-5A-75B-V8",
     "fpga": "ECP5-LFE5U-25F-CABGA256",
     "programmer": {
-      "type": "openfpgaloader"
+      "type": "openfpgaloader_ft2232"
     }
   },
   "ColorLight-5A-75E-V6": {
     "name": "ColorLight-5A-75E-V6",
     "fpga": "ECP5-LFE5U-25F-CABGA256",
     "programmer": {
-      "type": "openfpgaloader"
+      "type": "openfpgaloader_ft2232"
     }
   },
   "ColorLight-5A-75E-V71_(FT2232H)": {
@@ -552,21 +552,21 @@
       }
    },
     "iCESugar-Pro_(FT2232H)": {
-    "name": "ColorLight-i5",
+    "name": "iCESugar-Pro",
     "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_ft2232"
     }
   },
    "iCESugar-Pro_(FT232H)": {
-    "name": "ColorLight-i5",
+    "name": "iCESugar-Pro",
     "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_ft232"
       }
    },
    "iCESugar-Pro_(USB-Blaster)": {
-    "name": "ColorLight-i5",
+    "name": "iCESugar-Pro",
     "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_usb-blaster"


### PR DESCRIPTION
By default the programmer to use is FT2232H