### PR TITLE
Added FleaFPGA-Ohm ECP5 board

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Find all the information on this [WIKI PAGE](https://github.com/FPGAwars/apio/wi
 | [ColorLight-5A-75E-V71](https://github.com/q3k/chubby75/blob/master/5a-75e/hardware_V7.1.md)| FT2232H, FT232H or USB-Blaster |
 | [ColorLight-i5-v7.0](https://github.com/wuxx/Colorlight-FPGA-Projects)| FT2232H, FT232H or USB-Blaster |
 | [iCESugar-Pro](https://github.com/wuxx/icesugar-pro)| FT2232H, FT232H or USB-Blaster |
-
+| [FleaFPGA-Ohm](https://github.com/Basman74/FleaFPGA-Ohm)| FT2232H, FT232H or USB-Blaster |
 
 #### LP1K
 

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -556,7 +556,7 @@
     "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_ft232"
-      }
+    }
    },
    "ColorLight-i5-v7.0_(USB-Blaster)": {
     "name": "ColorLight-i5",
@@ -577,7 +577,7 @@
     "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_ft232"
-      }
+    }
    },
    "iCESugar-Pro_(USB-Blaster)": {
     "name": "ColorLight-i5",
@@ -585,5 +585,26 @@
     "programmer": {
       "type": "openfpgaloader_usb-blaster"
       }
+   },
+   "FleaFPGA-Ohm_(FT2232H)": {
+   "name": "FleaFPGA-Ohm_(FT2232H)",
+   "fpga": "ECP5-LFE5U-25F-CABGA381",
+   "programmer": {
+      "type": "openfpgaloader_ft2232"
+    }
+   },
+   "FleaFPGA-Ohm_(FT232H)": {
+   "name": "FleaFPGA-Ohm_(FT232H)",
+   "fpga": "ECP5-LFE5U-25F-CABGA381",
+   "programmer": {
+      "type": "openfpgaloader_ft232"
+    }
+   },
+   "FleaFPGA-Ohm_(USB-Blaster)": {
+   "name": "FleaFPGA-Ohm_(USB-Blaster)",
+   "fpga": "ECP5-LFE5U-25F-CABGA381",
+   "programmer": {
+       "type": "openfpgaloader_usb-blaster"
+    }
    }
  } 


### PR DESCRIPTION
For FT2232H, FT232H and USB-blaster external JTAG programmers.