### PR TITLE
Update iCEBreaker-bitsy board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Find all the information on this [WIKI PAGE](https://github.com/FPGAwars/apio/wi
 | [Fomu](https://github.com/im-tomu/fomu-hardware) | DFU |
 | [FPGA 101 Workshop Badge Board](https://github.com/mmicko/workshop_badge) | FTDI |
 | [iCEBreaker](https://github.com/icebreaker-fpga/icebreaker) | FTDI |
-| [iCEBreaker bitsy](https://github.com/icebreaker-fpga/icebreaker) | FTDI |
+| [iCEBreaker bitsy](https://github.com/icebreaker-fpga/icebreaker#icebreaker-bitsy) | DFU |
 | [iCE40 UltraPlus Breakout Board](http://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/iCE40UltraPlusBreakoutBoard) | FTDI |
 | [UPDuino v1.0](http://gnarlygrey.atspace.cc/development-platform.html#upduino) | FTDI |
 | [UPDuino v2.0](http://gnarlygrey.atspace.cc/development-platform.html#upduino_v2) | FTDI |

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -276,14 +276,14 @@
     "name": "iCEBreaker bitsy",
     "fpga": "iCE40-UP5K-SG48",
     "programmer": {
-      "type": "iceprog"
+      "type": "dfu"
     },
     "usb": {
-      "vid": "0403",
-      "pid": "6010"
+      "vid": "1d50",
+      "pid": "6146"
     },
     "ftdi": {
-      "desc": "(?:Dual RS232-HS)|(?:iCEBreaker.*)"
+      "desc": "iCEBreaker bitsy.*"
     }
   },
   "fpga101": {

--- a/apio/resources/programmers.json
+++ b/apio/resources/programmers.json
@@ -51,7 +51,7 @@
   },
   "dfu": {
     "command": "dfu-util",
-    "args": "-d ${VID}:${PID} -D"
+    "args": "-d ${VID}:${PID} -a 0 -D"
   },
   "icesprog": {
     "command": "icesprog",


### PR DESCRIPTION
The iCEBreaker bitsy does not implement the FTDI.

It can be switched to DFU mode by pressing and holding the button on the board. Furthermore, iCEBreaker bitsy has multiple DFUs with the same path, so you need to specify that the dfu command should select the first device.

```
% dfu-util -l

dfu-util 0.10

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2020 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to http://sourceforge.net/p/dfu-util/tickets/

Found DFU: [1d50:6146] ver=0006, devnum=17, cfg=1, intf=0, path="20-4.2.3", alt=1, name="RISC-V firmware", serial="e46870a4534e0d22"
Found DFU: [1d50:6146] ver=0006, devnum=17, cfg=1, intf=0, path="20-4.2.3", alt=0, name="iCE40 bitstream", serial="e46870a4534e0d 22"
```

<details>
<summary>Execution result:</summary>

```
% apio upload -p boards/iCEBreaker-bitsy

Executing: /usr/bin/kmutil showloaded
No variant specified, falling back to release
Executing: /usr/bin/kmutil showloaded
No variant specified, falling back to release
[Sat Sep  4 01:01:04 2021] Processing iCEBreaker-bitsy
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
dfu-util -d 1d50:6146 -a 0 -D hardware.bin
dfu-util 0.10

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2020 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to http://sourceforge.net/p/dfu-util/tickets/

Opening DFU capable USB device...
ID 1d50:6146
Run-time device DFU version 0101
Claiming USB DFU Interface...
Setting Alternate Setting #0 ...
Determining device status: state = dfuIDLE, status = 0
dfuIDLE, continuing
DFU mode device DFU version 0101
Device returned transfer size 4096
Copying data from PC to DFU device

Download        [                         ]   0%            0 bytes
Download        [=                        ]   7%         8192 bytes
Download        [==                       ]  11%        12288 bytes
Download        [===                      ]  15%        16384 bytes
Download        [====                     ]  18%        20480 bytes
Download        [=====                    ]  22%        24576 bytes
Download        [======                   ]  26%        28672 bytes
Download        [=======                  ]  30%        32768 bytes
Download        [========                 ]  34%        36864 bytes
Download        [=========                ]  37%        40960 bytes
Download        [==========               ]  41%        45056 bytes
Download        [===========              ]  45%        49152 bytes
Download        [============             ]  49%        53248 bytes
Download        [=============            ]  53%        57344 bytes
Download        [==============           ]  56%        61440 bytes
Download        [===============          ]  60%        65536 bytes
Download        [================         ]  64%        69632 bytes
Download        [=================        ]  68%        73728 bytes
Download        [==================       ]  75%        81920 bytes
Download        [===================      ]  79%        86016 bytes
Download        [====================     ]  83%        90112 bytes
Download        [=====================    ]  87%        94208 bytes
Download        [======================   ]  90%        98304 bytes
Download        [=======================  ]  94%       102400 bytes
Download        [======================== ]  98%       104090 bytes
Download        [=========================] 100%       104090 bytes
Download done.
state(2) = dfuIDLE, status(0) = No error condition is present
Done!
========================================================================== [SUCCESS] Took 2.06 seconds ==========================================================================
```

</details>