### PR TITLE
ECP-5 Evaluation Board Added 

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -606,5 +606,12 @@
    "programmer": {
        "type": "openfpgaloader_usb-blaster"
     }
+   },
+   "ECP5-Evaluation-Board": {
+   "name": "ECP5-Evaluation-Board",
+   "fpga": "ECP5-LFE5UM5G-85F-CABGA381",
+   "programmer": {
+       "type": "openfpgaloader_ft2232"
+    }
    }
  } 

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -174,7 +174,7 @@ synth = Builder(
     source_scanner=list_scanner)
 
 pnr = Builder(
-    action='nextpnr-ecp5 --{1} --package {2} --json $SOURCE --textcfg $TARGET {3} {4} --timing-allow-fail'.format(
+    action='nextpnr-ecp5 --{0} --package {2} --json $SOURCE --textcfg $TARGET {3} {4} --timing-allow-fail'.format(
         FPGA_TYPE, FPGA_SIZE, FPGA_PACK, '--lpf ' + str(LPF) if LPF else '',
         '' if VERBOSE_ALL or VERBOSE_PNR else '-q'),
     suffix='.config',

--- a/apio/resources/fpgas.json
+++ b/apio/resources/fpgas.json
@@ -175,220 +175,220 @@
   },
   "ECP5-LFE5U-12F-CABGA256": {
     "arch": "ecp5",
-    "type": "lfe5u",
-    "size": "25k",
+    "type": "12k",
+    "size": "12k",
     "pack": "CABGA256",
     "idcode": "0x21111043"
   },
   "ECP5-LFE5U-12F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5u",
-    "size": "25k",
+    "type": "12k",
+    "size": "12k",
     "pack": "CABGA381",
     "idcode": "0x21111043"
   },
   "ECP5-LFE5U-12F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5u",
-    "size": "25k",
+    "type": "12k",
+    "size": "12k",
     "pack": "CSFBGA285",
     "idcode": "0x21111043"
   },
   "ECP5-LFE5U-25F-CABGA256": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "25k",
     "size": "25k",
     "pack": "CABGA256"
   },
   "ECP5-LFE5U-25F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "25k",
     "size": "25k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5U-25F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "25k",
     "size": "25k",
     "pack": "CSFBGA285"
   },
   "ECP5-LFE5U-45F-CABGA256": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "45k",
     "size": "45k",
     "pack": "CABGA256"
   },
   "ECP5-LFE5U-45F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "45k",
     "size": "45k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5U-45F-CABGA554": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "45k",
     "size": "45k",
     "pack": "CABGA554"
   },
   "ECP5-LFE5U-45F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "45k",
     "size": "45k",
     "pack": "CSFBGA285"
   },
   "ECP5-LFE5U-85F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "85k",
     "size": "85k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5U-85F-CABGA554": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "85k",
     "size": "85k",
     "pack": "CABGA554"
   },
   "ECP5-LFE5U-85F-CABGA756": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "85k",
     "size": "85k",
     "pack": "CABGA756"
   },
   "ECP5-LFE5U-85F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5u",
+    "type": "85k",
     "size": "85k",
     "pack": "CSFBGA285"
   },
   "ECP5-LFE5UM-25F-CABGA256": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-25k",
     "size": "25k",
     "pack": "CABGA256"
   },
   "ECP5-LFE5UM-25F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-25k",
     "size": "25k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5UM-25F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-25k",
     "size": "25k",
     "pack": "CSFBGA285"
   },
   "ECP5-LFE5UM-45F-CABGA256": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-45k",
     "size": "45k",
     "pack": "CABGA256"
   },
   "ECP5-LFE5UM-45F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-45k",
     "size": "45k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5UM-45F-CABGA554": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-45k",
     "size": "45k",
     "pack": "CABGA554"
   },
   "ECP5-LFE5UM-45F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-45k",
     "size": "45k",
     "pack": "CSFBGA285"
   },
   "ECP5-LFE5UM-85F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-85k",
     "size": "85k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5UM-85F-CABGA554": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-85k",
     "size": "85k",
     "pack": "CABGA554"
   },
   "ECP5-LFE5UM-85F-CABGA756": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-85k",
     "size": "85k",
     "pack": "CABGA756"
   },
   "ECP5-LFE5UM-85F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5um",
+    "type": "um-85k",
     "size": "85k",
     "pack": "CSFBGA285"
   },
   "ECP5-LFE5UM5G-25F-CABGA256": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-25k",
     "size": "25k",
     "pack": "CABGA256"
   },
   "ECP5-LFE5UM5G-25F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-25k",
     "size": "25k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5UM5G-25F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-25k",
     "size": "25k",
     "pack": "CSFBGA285"
   },
   "ECP5-LFE5UM5G-45F-CABGA256": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-45k",
     "size": "45k",
     "pack": "CABGA256"
   },
   "ECP5-LFE5UM5G-45F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-45k",
     "size": "45k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5UM5G-45F-CABGA554": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-45k",
     "size": "45k",
     "pack": "CABGA554"
   },
   "ECP5-LFE5UM5G-45F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-45k",
     "size": "45k",
     "pack": "CSFBGA285"
   },
   "ECP5-LFE5UM5G-85F-CABGA381": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-85k",
     "size": "85k",
     "pack": "CABGA381"
   },
   "ECP5-LFE5UM5G-85F-CABGA554": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-85k",
     "size": "85k",
     "pack": "CABGA554"
   },
   "ECP5-LFE5UM5G-85F-CABGA756": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-85k",
     "size": "85k",
     "pack": "CABGA756"
   },
   "ECP5-LFE5UM5G-85F-CSFBGA285": {
     "arch": "ecp5",
-    "type": "lfe5um5g",
+    "type": "um5g-85k",
     "size": "85k",
     "pack": "CSFBGA285"
   } 


### PR DESCRIPTION
Additionally I have solved the support for ECP5-LFE5UM and ECP5-LFE5UM5G models.
There was a mistake in the generation of the bit file. Apio considered all boards as ECP5-LFE5U model
Now is solved for the rest of the ECP5 models