### PR TITLE
Synthesis of bitstream for ECP5 12K finally solved

### DIFF
--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -83,7 +83,7 @@ IVER_PATH = '' if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 
 IDCODE_PARAM = '' if not FPGA_IDCODE else '--idcode {0}'.format(FPGA_IDCODE)
 
-FPGA_TYPE_PARAM = '' if (FPGA_TYPE=="12k") else '--{0}'.format(FPGA_TYPE)
+FPGA_TYPE_PARAM = '25k' if (FPGA_TYPE=="12k") else '{0}'.format(FPGA_TYPE)
 
 # -- Target name
 TARGET = 'hardware'
@@ -176,7 +176,7 @@ synth = Builder(
     source_scanner=list_scanner)
 
 pnr = Builder(
-    action='nextpnr-ecp5 {0} --package {2} --json $SOURCE --textcfg $TARGET {3} {4} --timing-allow-fail --force'.format(
+    action='nextpnr-ecp5 --{0} --package {2} --json $SOURCE --textcfg $TARGET {3} {4} --timing-allow-fail --force'.format(
         FPGA_TYPE_PARAM, FPGA_SIZE, FPGA_PACK, '--lpf ' + str(LPF) if LPF else '',
         '' if VERBOSE_ALL or VERBOSE_PNR else '-q'),
     suffix='.config',


### PR DESCRIPTION
ECP5 12k boards are really 25k but with one special idcode

I was following the tutorial of https://gojimmypi.blogspot.com/2019/02/notes-on-ulx3s-fpga-yosys-verilog-vhdl.html
We need to synthetize the 12K board as 25k board.
In ecppack the command --idcode 0x21111043 is already added.

