### PR TITLE
add butterstick support (and fix small orangecrab typo)

### DIFF
--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -287,13 +287,21 @@ class SCons:
 
         programmer = content.get("command")
 
-        # Add args
-        if content.get("args"):
-            programmer += " {}".format(content.get("args"))
+        #dfu-util needs extra args first
+        if programmer.startswith("dfu-util"):
+            if prog_info.get("extra_args"):
+                programmer += " {}".format(prog_info.get("extra_args"))
+                
+            if content.get("args"):
+                programmer += " {}".format(content.get("args"))
+        else:
+            # Add args
+            if content.get("args"):
+                programmer += " {}".format(content.get("args"))
 
-        # Add extra args
-        if prog_info.get("extra_args"):
-            programmer += " {}".format(prog_info.get("extra_args"))
+            # Add extra args
+            if prog_info.get("extra_args"):
+                programmer += " {}".format(prog_info.get("extra_args"))
 
         # Enable SRAM programming
         if sram:

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -404,7 +404,7 @@
     "name": "OrangeCrab r0.2",
     "fpga": "ECP5-LFE5U-25F-CSFBGA285",
     "programmer": {
-      "type": "dfu-util"
+      "type": "dfu"
     },
     "usb": {
       "vid": "1209",
@@ -412,6 +412,21 @@
     },
     "ftdi": {
       "desc": "OrangeCrab r0.2 DFU bootloader"
+    }
+  },
+  "butterStick-r1.0-2G-85F": {
+    "name": "butterstick r1.0",
+    "fpga": "ECP5-LFE5UM5G-85F-CABGA381",
+    "programmer": {
+      "type": "dfu",
+      "extra_args": "--reset"
+    },
+    "usb": {
+      "vid": "1209",
+      "pid": "5af1"
+    },
+    "ftdi": {
+      "desc": "butterstick (dfu v1.1)"
     }
   },
   "versa": {


### PR DESCRIPTION
These changes add butterstick (from @gregdavill) support to apio.

They also fix a small typo in the boards.json file affecting the orangecrab.

Note: currently this won't work on MacOS because the way dfu-util --reset works on darwin. This is a libusb bug that hopefully will be fixed on the next libusb release. See: https://github.com/libusb/libusb/pull/1035

Even after that is fixed, dfu-util will work but return an error code when the reenumeration times out. scons treats this as a failure, but it is cosmetic.