### PR TITLE
Fix Uploading to the `Lattice iCE40UP5K Breakout` Board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 .tox/
 .cache/
 .pytest_cache/
+.vscode/
+.venv/
 build/
 dist/
 htmlcov/

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -438,7 +438,8 @@ class SCons:
             raise Exception("board " + board + " not available")
         for ftdi_device in ftdi_devices:
             index = ftdi_device.get("index")
-            if ext_ftdi_id and ext_ftdi_id != index:
+            # ftdi device indices can start at zero 
+            if ext_ftdi_id is not None and ext_ftdi_id != index:
                 # If the --device options is set but it doesn't match
                 # with the detected index, skip the port.
                 continue

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -354,7 +354,7 @@
       "pid": "6010"
     },
     "ftdi": {
-      "desc": "(USB <-> Serial Converter | Lattice iCE40UP5K Breakout)"
+      "desc": "(?:USB <-> Serial Converter)|(?:Lattice iCE40UP5K Breakout)"
     }
   },
   "TinyFPGA-EX-rev1": {

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -354,7 +354,7 @@
       "pid": "6010"
     },
     "ftdi": {
-      "desc": "Lattice iCE40UP5K Breakout"
+      "desc": "(USB <-> Serial Converter | Lattice iCE40UP5K Breakout)"
     }
   },
   "TinyFPGA-EX-rev1": {


### PR DESCRIPTION
## Overview

It looks like Lattice didn't program the description of the FTDI chip to `Lattice iCE40UP5K Breakout` for some of their new boards. My board's ftdi chip returns `USB <-> Serial Converter` as the description. That was causing a `board not found` error when I tried to upload. Also the FTDI index on my computer is 0 which was also causing the `SCons._check_ftdi` to return None so I fixed that as well.

## Work Done

- Updated .gitignore to include vscode specific private folders
- Change the board.json `Lattice iCE40UP5K Breakout` description to be a regex for matching with the default FTDI chips description `USB <-> Serial Converter`
- Allow an 0 index position for the FTDI chip

## POP


<img width="1265" alt="Screen Shot 2022-09-25 at 5 55 02 PM" src="https://user-images.githubusercontent.com/26232349/192167317-603edaf0-c71d-4c18-b695-12eeaf469e79.png">

