### PR TITLE
Error in Colorlight 5A-75B V6.1 Hardware

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -551,7 +551,7 @@
   },
   "ColorLight-5A-75B-V61": {
     "name": "ColorLight-5A-75B-V61",
-    "fpga": "ECP5-LFE5U-25F-CABGA256",
+    "fpga": "ECP5-LFE5U-25F-CABGA381",
     "programmer": {
       "type": "openfpgaloader_ft2232"
     }


### PR DESCRIPTION
Error in the FPGA model of Colorlight 5A-75B V6.1 in Apio. It is LFE5U-25F-6BG381C instead LFE5U-25F-6BG256C