### PR TITLE
add colorligth i9 usb-blaster

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -703,5 +703,12 @@
     "programmer": {
       "type": "openfpgaloader_ft2232"
     }
+   },
+  "ColorLight-i9-v7.2_(USB-Blaster)": {
+    "name": "ColorLight-i9",
+    "fpga": "ECP5-LFE5U-45F-CABGA381",
+    "programmer": {
+      "type": "openfpgaloader_usb-blaster"
+    }
   }
  } 


### PR DESCRIPTION
add support to program the colorligth i9 with an usb-blaster