### PR TITLE
Update ftdi id regex for icestick, as recent board has Dual RS232 HS…

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -25,7 +25,7 @@
       "pid": "6010"
     },
     "ftdi": {
-      "desc": "Lattice FTUSB Interface Cable"
+      "desc": "(?:Dual RS232-HS)|(?:Lattice FTUSB Interface Cable)"
     }
   },
   "iceblink40-hx1k" : {


### PR DESCRIPTION
Este cambio resuelve #305 .

Parece ser que las icestick recientes (dic-2022) se registran con la descripción "Dual RS232-HS". 

Translation: 
Resolves #305. It seems that recent icestick boards use "Dual RS232-HS" as description text.

