### PR TITLE
Added the support of the Pico-Ice board

### DIFF
--- a/apio/resources/80-fpga-ftdi.rules
+++ b/apio/resources/80-fpga-ftdi.rules
@@ -18,3 +18,6 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="5bf0", MODE="0664"
 
 # -- for USB-Blaster JTAG Programmer
 ATTRS{idVendor}=="09FB", ATTRS{idProduct}=="6001", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+
+# -- for pico-ice board
+ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b1c0", MODE="0660", GROUP="plugdev", TAG+="uaccess"

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -553,6 +553,21 @@
       "desc": "Dual RS232-HS"
     }
   },
+  "pico-ice": {
+    "name": "pico-ice",
+    "fpga": "iCE40-UP5K-SG48",
+    "programmer": {
+      "type": "dfu",
+      "extra_args": "--reset"
+    },
+    "usb": {
+      "vid": "1209",
+      "pid": "b1c0"
+    },
+    "ftdi": {
+      "desc": "DFU flash"
+    }
+  },
   "iCESugar_1_5": {
     "name": "iCESugar v1.5",
     "fpga": "iCE40-UP5K-SG48",


### PR DESCRIPTION
The pico-ice is a small, low cost board with the Raspberry Pi Pico processor (RP2040) and a Lattice Semiconductor iCE40UP5K FPGA.
More info here: https://github.com/tinyvision-ai-inc/pico-ice

NOTE: I have already sent a pull request to ICeStudio to support this board