### PR TITLE
Update boards.json with package for iCESugar-Pro

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -651,21 +651,21 @@
    },
     "iCESugar-Pro_(FT2232H)": {
     "name": "ColorLight-i5",
-    "fpga": "ECP5-LFE5U-25F-CABGA381",
+    "fpga": "ECP5-LFE5U-25F-CABGA256",
     "programmer": {
       "type": "openfpgaloader_ft2232"
     }
   },
    "iCESugar-Pro_(FT232H)": {
     "name": "ColorLight-i5",
-    "fpga": "ECP5-LFE5U-25F-CABGA381",
+    "fpga": "ECP5-LFE5U-25F-CABGA256",
     "programmer": {
       "type": "openfpgaloader_ft232"
     }
    },
    "iCESugar-Pro_(USB-Blaster)": {
     "name": "ColorLight-i5",
-    "fpga": "ECP5-LFE5U-25F-CABGA381",
+    "fpga": "ECP5-LFE5U-25F-CABGA256",
     "programmer": {
       "type": "openfpgaloader_usb-blaster"
       }


### PR DESCRIPTION
https://github.com/FPGAwars/apio/issues/312

The iCESugar-Pro board definition appears to specify the incorrect part. apio currently has it specified as ECP5-LFE5U-25F-CABGA381

The schematic at https://github.com/wuxx/icesugar-pro/tree/master/schematic specifies it as LFE5U-25F-6B-G256C

I was able to get it working with apio by changing my boards.json to ECP5-LFE5U-25F-CABGA256