### PR TITLE
Wrong type of quotes used. Caused JSON decoder error

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -357,9 +357,9 @@
       "desc": "(?:USB <-> Serial Converter)|(?:Lattice iCE40UP5K Breakout)"
     }
   },
-  "iCE40-UL1K”: {
+  "iCE40-UL1K": {
     "name": "iCE40-UL1K UltraLite Breakout Board",
-    "fpga": "iCE40-UL1K-CM36A”,
+    "fpga": "iCE40-UL1K-CM36A",
     "programmer": {
       "type": "iceprog"
     },


### PR DESCRIPTION
First time contributing to an open source project. On develop branch I found that the wrong quotes were used.
