### PR TITLE
Add fpga for iCE40-UL1K-CM36A

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -357,7 +357,7 @@
       "desc": "(?:USB <-> Serial Converter)|(?:Lattice iCE40UP5K Breakout)"
     }
   },
-  "iCE40-UL1K": {
+  "iCE40-UL1K-Breakout": {
     "name": "iCE40-UL1K UltraLite Breakout Board",
     "fpga": "iCE40-UL1K-CM36A",
     "programmer": {

--- a/apio/resources/fpgas.json
+++ b/apio/resources/fpgas.json
@@ -17,6 +17,12 @@
     "size": "1k",
     "pack": "cm36"
   },
+  "iCE40-UL1K-CM36A": {
+    "arch": "ice40",
+    "type": "ul",
+    "size": "1k",
+    "pack": "cm36a"
+  },
   "iCE40-LP384-CM49": {
     "arch": "ice40",
     "type": "lp",


### PR DESCRIPTION
I forgot to add the fpga for the board file to the commit, which caused errors when apio ran a board --list. Added more specificity, "Breakout", to the board name. The makefile probably needs to be adapted for python3 and pip3.