### PR TITLE
apio build verbose fix

### DIFF
--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -205,6 +205,11 @@ bitstream = env.Bin(TARGET, asc)
 build = env.Alias('build', bitstream)
 AlwaysBuild(build)
 
+if(VERBOSE_ALL or VERBOSE_YOSYS):
+    AlwaysBuild(blif)
+if(VERBOSE_ALL or VERBOSE_PNR):
+    AlwaysBuild(asc)
+
 # -- Upload the bitstream into FPGA
 upload = env.Alias('upload', bitstream, '{0} $SOURCE'.format(PROG))
 AlwaysBuild(upload)


### PR DESCRIPTION
Had an issue where `apio build -v` didn't show output from yosys and nextpnr even with -v set.