### PR TITLE
apio build --top-module option added

### DIFF
--- a/apio/commands/build.py
+++ b/apio/commands/build.py
@@ -50,6 +50,8 @@ from apio.managers.scons import SCons
 @click.option(
     "--verbose-pnr", is_flag=True, help="Show the pnr output of the command."
 )
+@click.option("--top-module", type=str, metavar="top_module", help="Set the top level module (w/o .v ending) for build.",
+)
 def cli(
     ctx,
     board,
@@ -61,6 +63,7 @@ def cli(
     verbose,
     verbose_yosys,
     verbose_pnr,
+    top_module,
 ):
     """Synthesize the bitstream."""
 
@@ -84,6 +87,7 @@ def cli(
                 "yosys": verbose_yosys,
                 "pnr": verbose_pnr,
             },
+            "top-module": top_module,
         }
     )
 

--- a/apio/managers/arguments.py
+++ b/apio/managers/arguments.py
@@ -33,6 +33,7 @@ def process_arguments(args, resources):  # noqa
         var_pack = args.get("pack")
         var_idcode = args.get("idcode")
         var_verbose = args.get("verbose")
+        var_topmodule = args.get("top-module")
     else:
         var_board = None
         var_arch = None
@@ -42,6 +43,7 @@ def process_arguments(args, resources):  # noqa
         var_pack = None
         var_idcode = None
         var_verbose = {}
+        var_topmodule= None
 
     if var_board:
         if isfile("apio.ini"):
@@ -249,6 +251,7 @@ def process_arguments(args, resources):  # noqa
             "verbose_all": var_verbose.get("all"),
             "verbose_yosys": var_verbose.get("yosys"),
             "verbose_pnr": var_verbose.get("pnr"),
+            "top_module": var_topmodule,
         }
     )
 

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -20,6 +20,7 @@ PROG = ARGUMENTS.get('prog', '')
 FPGA_SIZE = ARGUMENTS.get('fpga_size', '')
 FPGA_TYPE = ARGUMENTS.get('fpga_type', '')
 FPGA_PACK = ARGUMENTS.get('fpga_pack', '')
+YOSYS_TOP = ARGUMENTS.get('top_module', '')
 VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
 VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
 VERBOSE_PNR = ARGUMENTS.get('verbose_pnr', False)
@@ -166,7 +167,8 @@ except IndexError:
 
 # -- Define the Sintesizing Builder
 synth = Builder(
-    action='yosys -p \"synth_ice40 -json $TARGET\" {} $SOURCES'.format(
+    action='yosys -p \"synth_ice40 {0} -json $TARGET\" {1} $SOURCES'.format(
+        ('-top '+YOSYS_TOP) if YOSYS_TOP else '',
         '' if VERBOSE_ALL or VERBOSE_YOSYS else '-q'
     ),
     suffix='.json',

--- a/docs/source/user_guide/project_commands/cmd_build.rst
+++ b/docs/source/user_guide/project_commands/cmd_build.rst
@@ -59,6 +59,11 @@ Show the yosys output of the command.
 
 Show the arachne output of the command.
 
+.. option::
+    --top-module
+
+Set the top level module name used for build. Otherwise Yosys will auto select. 
+
 .. note::
 
   All available boards, FPGAs, sizes, types and packs are showed in :ref:`cmd_boards`


### PR DESCRIPTION
Adding an option to `apio build` that allows the user to specify the top level module in Yosys. 

Without it, Yosys will auto detect and sometimes choose the wrong one #162 
updated docs to reflect new option