### PR TITLE
Add suport for the Theta Machines ETH4K board

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -774,5 +774,19 @@
     "programmer": {
       "type": "openfpgaloader_usb-blaster"
     }
+  },
+  "ThetaMachines-ETH4K": {
+    "name": "Theta Machines ETH4K",
+    "fpga": "iCE40-HX4K-TQ144",
+    "programmer": {
+      "type": "iceprog"
+    },
+    "usb": {
+      "vid": "0403",
+      "pid": "6010"
+    },
+    "ftdi": {
+      "desc": "ETH4K"
+    }
   }
  } 


### PR DESCRIPTION
Add support for the Theta Machines ETH4K board. 

ETH4K is a completely open-source FPGA development board based on the iCE40HX4K. The board includes several robust communication methods such as Ethernet, USB, and abundant GPIO. https://www.thetamachines.com/shop/eth4k/
