### PR TITLE
Added to the apio sim an optional -testbench flag 

### DIFF
--- a/apio/commands/sim.py
+++ b/apio/commands/sim.py
@@ -18,8 +18,15 @@ from apio.managers.scons import SCons
     metavar="path",
     help="Set the target directory for the project.",
 )
-def cli(ctx, project_dir):
+@click.option(
+    "-t",
+    "--testbench",
+    type=str,
+    metavar="testbench",
+    help="Specify the testbench file to simulate.",
+)
+def cli(ctx, project_dir, testbench):
     """Launch the verilog simulation."""
 
-    exit_code = SCons(project_dir).sim()
+    exit_code = SCons(project_dir).sim({"testbench": testbench})
     ctx.exit(exit_code)

--- a/apio/managers/arguments.py
+++ b/apio/managers/arguments.py
@@ -27,6 +27,7 @@ ALL = "all"  # -- Key for Verbose all
 YOSYS = "yosys"  # -- Key for Verbose-yosys
 PNR = "pnr"  # -- Key for Verbose-pnr
 TOP_MODULE = "top-module"  # -- Key for top-module
+TESTBENCH = "testbench"  # -- Key for testbench file name
 
 
 def debug_params(fun):
@@ -120,6 +121,7 @@ def process_arguments(
         IDCODE: None,
         VERBOSE: {ALL: False, "yosys": False, "pnr": False},
         TOP_MODULE: None,
+        TESTBENCH: None
     }
 
     # -- Merge the initial configuration to the current configuration
@@ -218,6 +220,7 @@ def process_arguments(
             "verbose_yosys": config[VERBOSE][YOSYS],
             "verbose_pnr": config[VERBOSE][PNR],
             "top_module": config[TOP_MODULE],
+            "testbench" : config[TESTBENCH],
         }
     )
 
@@ -299,6 +302,7 @@ def print_configuration(config: dict) -> None:
     print(f"  pack: {config[PACK]}")
     print(f"  idcode: {config[IDCODE]}")
     print(f"  top-module: {config[TOP_MODULE]}")
+    print(f"  testbench: {config[TESTBENCH]}")
     print("  verbose:")
     print(f"    all: {config[VERBOSE][ALL]}")
     print(f"    yosys: {config[VERBOSE][YOSYS]}")

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -106,13 +106,15 @@ class SCons:
         )
 
     @util.command
-    def sim(self):
+    def sim(self, args):
         """DOC: TODO"""
 
-        __, __, arch = process_arguments(None, self.resources)
+        # -- Split the arguments
+        var, _, arch = process_arguments(args, self.resources)
+        
         return self.run(
             "sim",
-            variables=[],
+            variables=var,
             arch=arch,
             packages=["oss-cad-suite", "gtkwave"],
         )

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -25,6 +25,7 @@ FPGA_IDCODE = ARGUMENTS.get('fpga_idcode', '')
 VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
 VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
 VERBOSE_PNR = ARGUMENTS.get('verbose_pnr', False)
+TESTBENCH = ARGUMENTS.get('testbench', '')
 VERILATOR_ALL = ARGUMENTS.get('all', False)
 VERILATOR_NO_STYLE = ARGUMENTS.get('nostyle', False)
 VERILATOR_NO_WARN = ARGUMENTS.get('nowarn', '').split(',')
@@ -104,23 +105,31 @@ list_scanner = env.Scanner(function=list_files_scan)
 # -- Get a list of all the verilog files in the src folfer, in ASCII, with
 # -- the full path. All these files are used for the simulation
 v_nodes = Glob('*.v')
-src_sim = [str(f) for f in v_nodes]
+v_files = [str(f) for f in v_nodes]
 
-# --------- Get the Testbench file (there should be only 1)
-# -- Create a list with all the files finished in _tb.v. It should contain
-# -- the test bench
-list_tb = [f for f in src_sim if f[-5:].upper() == '_TB.V']
+# Create lists of module and testbench files. Test benches are assumed
+# to end with '_tb.v', case insensitive.
+src_sim = [f for f in v_files if f[-5:].upper() != '_TB.V']
+list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-if len(list_tb) > 1:
-    print('Warning: more than one testbenches used')
+# Handle the testbench selection, if any. 
+testbench = None
 
-# -- Error checking
-try:
+if TESTBENCH:
+  # Here when --testbench was specified.
+  testbench = TESTBENCH
+else:
+  # Here when --testbench was not specified so we use the default behavior
+  # for backward compatibility. Currently we pick arbitrarily the first
+  # testbench in the Glob order.
+  if len(list_tb) > 1:
+    print('Warning: more than one testbench found.')
+  if len(list_tb) > 0:
     testbench = list_tb[0]
 
-# -- there is no testbench
-except IndexError:
-    testbench = None
+# Add the testbench to the list of compiled files.
+if testbench:
+  src_sim.append(testbench)
 
 SIMULNAME = ''
 TARGET_SIM = ''

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -24,6 +24,7 @@ YOSYS_TOP = ARGUMENTS.get('top_module', '')
 VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
 VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
 VERBOSE_PNR = ARGUMENTS.get('verbose_pnr', False)
+TESTBENCH = ARGUMENTS.get('testbench', '')
 VERILATOR_ALL = ARGUMENTS.get('all', False)
 VERILATOR_NO_STYLE = ARGUMENTS.get('nostyle', False)
 VERILATOR_NO_WARN = ARGUMENTS.get('nowarn', '').split(',')
@@ -102,23 +103,31 @@ list_scanner = env.Scanner(function=list_files_scan)
 # -- Get a list of all the verilog files in the src folfer, in ASCII, with
 # -- the full path. All these files are used for the simulation
 v_nodes = Glob('*.v')
-src_sim = [str(f) for f in v_nodes]
+v_files = [str(f) for f in v_nodes]
 
-# --------- Get the Testbench file (there should be only 1)
-# -- Create a list with all the files finished in _tb.v. It should contain
-# -- the test bench
-list_tb = [f for f in src_sim if f[-5:].upper() == '_TB.V']
+# Create lists of module and testbench files. Test benches are assumed
+# to end with '_tb.v', case insensitive.
+src_sim = [f for f in v_files if f[-5:].upper() != '_TB.V']
+list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-if len(list_tb) > 1:
-    print('Warning: more than one testbenches used')
+# Handle the testbench selection, if any. 
+testbench = None
 
-# -- Error checking
-try:
+if TESTBENCH:
+  # Here when --testbench was specified.
+  testbench = TESTBENCH
+else:
+  # Here when --testbench was not specified so we use the default behavior
+  # for backward compatibility. Currently we pick arbitrarily the first
+  # testbench in the Glob order.
+  if len(list_tb) > 1:
+    print('Warning: more than one testbench found.')
+  if len(list_tb) > 0:
     testbench = list_tb[0]
 
-# -- there is no testbench
-except IndexError:
-    testbench = None
+# Add the testbench to the list of compiled files.
+if testbench:
+  src_sim.append(testbench)
 
 SIMULNAME = ''
 TARGET_SIM = ''


### PR DESCRIPTION
This PR adds an optional --testbench flag to the apio sim command. It introduces support for a multi testbench project, and allow to select the testbench to simulate. If the --testbench flag is not specified, the sim command maintains the old behavior of picking the first testbench that was listed by the Glob function.

If and when this PR will get approved and checked in, I can do the following additional changes:

1. The sim command will fail if --testbench flag is not specified an more than one testbench is found (instead of picking the first one in the Glob order).

2. Have the apio clean command cleaning all the tb.out and tb.vcd files rather than just of one testbench.  Alternatively, the .out and .vcd can have a fixed name that is independent of the testbench name, similar to the generated hardware.x files. 