### PR TITLE
Apio verify/lint commands now process also all the testbench files.

### DIFF
--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -220,7 +220,7 @@ vcd = Builder(
 env.Append(BUILDERS={'IVerilog': iverilog, 'VCD': vcd})
 
 # --- Verify
-vout = env.IVerilog(TARGET, src_synth)
+vout = env.IVerilog(TARGET, src_synth + list_tb)
 
 verify = env.Alias('verify', vout)
 AlwaysBuild(verify)
@@ -249,7 +249,7 @@ verilator = Builder(
 env.Append(BUILDERS={'Verilator': verilator})
 
 # --- Lint
-lout = env.Verilator(TARGET, src_synth)
+lout = env.Verilator(TARGET, src_synth + list_tb)
 
 lint = env.Alias('lint', lout)
 AlwaysBuild(lint)

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -225,7 +225,7 @@ vcd = Builder(
 env.Append(BUILDERS={'IVerilog': iverilog, 'VCD': vcd})
 
 # --- Verify
-vout = env.IVerilog(TARGET, src_synth)
+vout = env.IVerilog(TARGET, src_synth + list_tb)
 
 verify = env.Alias('verify', vout)
 AlwaysBuild(verify)
@@ -253,7 +253,7 @@ verilator = Builder(
 env.Append(BUILDERS={'Verilator': verilator})
 
 # --- Lint
-lout = env.Verilator(TARGET, src_synth)
+lout = env.Verilator(TARGET, src_synth + list_tb)
 
 lint = env.Alias('lint', lout)
 AlwaysBuild(lint)


### PR DESCRIPTION
Before this PR, ``apio verify`` and ``apio lint`` commands processed only the verilog module files (.v files which are not testbenches). This PR adds also all the testbench files. I believe that this is more useful and it was also the case before the adding support for  multiple testbenches. 

NOTE: for the link command, I don't have a verilator installed so tested until the point it invokes the verilator.

```
--> DEBUG!. Function process_arguments(). END
     Returns: 
      * ['fpga_arch=ice40', 'fpga_size=5k', 'fpga_type=up', 'fpga_pack=sg48', 'top_module=main']
      * upduino31
      * ice40

verilator --lint-only -Wno-TIMESCALEMOD deserializer.v main.v queue.v queue_pusher.v sensor_timing.v deserializer_tb.v queue_tb.v sensor_timing_tb.v
sh: verilator: command not found
scons: *** [hardware] Error 127
```