### PR TITLE
Fixing the apio time command.

### DIFF
--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -199,8 +199,8 @@ AlwaysBuild(upload)
 
 # -- Target time: calculate the time
 rpt = env.Time(config_out)
+AlwaysBuild(rpt)
 t = env.Alias('time', rpt)
-AlwaysBuild(t)
 
 # -- Icarus Verilog builders
 iverilog = Builder(

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -204,8 +204,8 @@ AlwaysBuild(upload)
 
 # -- Target time: calculate the time
 rpt = env.Time(asc)
+AlwaysBuild(rpt) 
 t = env.Alias('time', rpt)
-AlwaysBuild(t)
 
 # -- Icarus Verilog builders
 iverilog = Builder(


### PR DESCRIPTION
Before this change, when running the apio time command multiple time, the timing information were shown only on the first run which actually run nextpnr.  With this change, nextpnr is forced to run each time resulting with time report as expected.