### PR TITLE
Tweaking the verify command warnings.

### DIFF
--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -181,11 +181,17 @@ t = env.Alias('time', rpt)
 def iverilog_generator(source, target, env, for_signature):
     """Constructs dynamically a commands for iverlog targets builders. """
     target_name, _  = os.path.splitext(str(target[0]))  # E.g. "my_module" or"my_module_tb"
+    # Testbenches use the value macro VCD_OUTPUT to know the name of the waves output file.
+    # We also pass a dummy when the verify command to avoid a warning about the undefined macro. 
     is_testbench = target_name.upper().endswith("_TB")
-    # If running a testbench with the sim command, we pass to the benchmark a macro that
-    # will allow it to supress assertions so we can examine the waves. For example, with 
-    # an assertion macro like this one that fails when running apio test.
-    #
+    is_verify = 'verify' in COMMAND_LINE_TARGETS
+    vcd_output_flag = (
+        f'-D VCD_OUTPUT=dummy_vcd_output'  if is_verify 
+        else  f'-D VCD_OUTPUT={target_name}' if is_testbench 
+        else  "")
+    # If running a testbench with the sim command, we define the macro INTERACTIVE_SIM that
+    # allows the testbench to supress assertions so we can examine the waves in gtkwave. 
+    # For example, with an assertion macro like this one that fails when running apio test.
     # `define EXPECT(signal, value) \
     #     if (signal !== value) begin \
     #         $display("ASSERTION FAILED in %m: signal != value"); \
@@ -193,11 +199,10 @@ def iverilog_generator(source, target, env, for_signature):
     #             $fatal; \
     #         `endif \
     #     end
-    is_interactive = is_testbench and 'sim' in COMMAND_LINE_TARGETS
-    vcd_output_flag = f'-D VCD_OUTPUT={target_name}' if is_testbench else ""
-    interactive_flag = f'-D INTERACTIVE_SIM' if is_interactive else ""
+    is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
+    interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
     result = 'iverilog {0} -o $TARGET {1} {2} -D NO_INCLUDES "{3}/ecp5/cells_sim.v" $SOURCES'.format(
-        IVER_PATH, vcd_output_flag, interactive_flag, YOSYS_PATH)
+        IVER_PATH, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
     return result
 
 iverilog = Builder(
@@ -218,9 +223,8 @@ env.Append(BUILDERS={'IVerilog': iverilog, 'VCD': vcd})
 
 # --- Verify
 vout = env.IVerilog(TARGET, src_synth + list_tb)
-
+AlwaysBuild(vout)
 verify = env.Alias('verify', vout)
-AlwaysBuild(verify)
 
 # --- Simulation
 # Since the simulation targets are dynamic due to the testbench selection, we 

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -186,11 +186,17 @@ t = env.Alias('time', rpt)
 def iverilog_generator(source, target, env, for_signature):
     """Constructs dynamically a commands for iverlog targets builders. """
     target_name, _  = os.path.splitext(str(target[0]))  # E.g. "my_module" or"my_module_tb"
+    # Testbenches use the value macro VCD_OUTPUT to know the name of the waves output file.
+    # We also pass a dummy when the verify command to avoid a warning about the undefined macro. 
     is_testbench = target_name.upper().endswith("_TB")
-    # If running a testbench with the sim command, we pass to the benchmark a macro that
-    # will allow it to supress assertions so we can examine the waves. For example, with 
-    # an assertion macro like this one that fails when running apio test.
-    #
+    is_verify = 'verify' in COMMAND_LINE_TARGETS
+    vcd_output_flag = (
+        f'-D VCD_OUTPUT=dummy_vcd_output'  if is_verify 
+        else  f'-D VCD_OUTPUT={target_name}' if is_testbench 
+        else  "")
+    # If running a testbench with the sim command, we define the macro INTERACTIVE_SIM that
+    # allows the testbench to supress assertions so we can examine the waves in gtkwave. 
+    # For example, with an assertion macro like this one that fails when running apio test.
     # `define EXPECT(signal, value) \
     #     if (signal !== value) begin \
     #         $display("ASSERTION FAILED in %m: signal != value"); \
@@ -198,11 +204,10 @@ def iverilog_generator(source, target, env, for_signature):
     #             $fatal; \
     #         `endif \
     #     end
-    is_interactive = is_testbench and 'sim' in COMMAND_LINE_TARGETS
-    vcd_output_flag = f'-D VCD_OUTPUT={target_name}' if is_testbench else ""
-    interactive_flag = f'-D INTERACTIVE_SIM' if is_interactive else ""
+    is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
+    interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
     result = 'iverilog {0} -o $TARGET {1} {2} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{3}/ice40/cells_sim.v" $SOURCES'.format(
-        IVER_PATH, vcd_output_flag, interactive_flag, YOSYS_PATH)
+        IVER_PATH, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
     return result
 
 iverilog = Builder(
@@ -223,9 +228,8 @@ env.Append(BUILDERS={'IVerilog': iverilog, 'VCD': vcd})
 
 # --- Verify
 vout = env.IVerilog(TARGET, src_synth + list_tb)
-
+AlwaysBuild(vout)
 verify = env.Alias('verify', vout)
-AlwaysBuild(verify)
 
 # --- Simulation
 # Since the simulation targets are dynamic due to the testbench selection, we 


### PR DESCRIPTION
This PR introduces two changes regarding code warnings generated by apio verify command:

1. Now it always runs iverilog such that the user can see if there are any warnings.

2. It defines to macro ``-D VCD_OUTPUT=dummy_vcd_output`` to avoid verify warnings from testbenches that refer to that macro.