### PR TITLE
Added the alias -h to the existing --help flag.

### DIFF
--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -99,7 +99,7 @@ class ApioCLI(click.MultiCommand):
 # -- This function is executed when apio is executed without
 # -- any parameter. The help is shown
 # ------------------------------------------------------------------
-@click.command(cls=ApioCLI, invoke_without_command=True)
+@click.command(cls=ApioCLI, invoke_without_command=True, context_settings=util.context_settings())
 @click.pass_context
 @click.version_option()
 def cli(ctx):

--- a/apio/commands/boards.py
+++ b/apio/commands/boards.py
@@ -8,9 +8,10 @@
 import click
 
 from apio.resources import Resources
+from apio import util
 
 
-@click.command("boards")
+@click.command("boards", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-l", "--list", is_flag=True, help="List all supported FPGA boards."

--- a/apio/commands/build.py
+++ b/apio/commands/build.py
@@ -9,13 +9,14 @@
 import click
 
 from apio.managers.scons import SCons
+from apio import util
 
 
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
 # pylint: disable=W0622
 # pylint: disable=R0801
-@click.command("build")
+@click.command("build", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-b", "--board", type=str, metavar="board", help="Set the board."

--- a/apio/commands/clean.py
+++ b/apio/commands/clean.py
@@ -8,9 +8,10 @@
 import click
 
 from apio.managers.scons import SCons
+from apio import util
 
 
-@click.command("clean")
+@click.command("clean", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-p",

--- a/apio/commands/config.py
+++ b/apio/commands/config.py
@@ -8,10 +8,11 @@
 import click
 
 from apio.profile import Profile
+from apio import util
 
 
 # pylint: disable=W0622
-@click.command("config")
+@click.command("config", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-l", "--list", is_flag=True, help="List all configuration parameters."

--- a/apio/commands/drivers.py
+++ b/apio/commands/drivers.py
@@ -8,9 +8,10 @@
 import click
 
 from apio.managers.drivers import Drivers
+from apio import util
 
 
-@click.command("drivers")
+@click.command("drivers", context_settings=util.context_settings())
 @click.pass_context
 @click.option("--ftdi-enable", is_flag=True, help="Enable FTDI drivers.")
 @click.option("--ftdi-disable", is_flag=True, help="Disable FTDI drivers.")

--- a/apio/commands/examples.py
+++ b/apio/commands/examples.py
@@ -8,12 +8,13 @@
 import click
 
 from apio.managers.examples import Examples
+from apio import util
 
 
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
 # pylint: disable=W0622
-@click.command("examples")
+@click.command("examples", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-l", "--list", is_flag=True, help="List all available examples."

--- a/apio/commands/init.py
+++ b/apio/commands/init.py
@@ -8,11 +8,12 @@
 import click
 
 from apio.managers.project import Project
+from apio import util
 
 
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
-@click.command("init")
+@click.command("init", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-b",

--- a/apio/commands/install.py
+++ b/apio/commands/install.py
@@ -10,6 +10,7 @@ import click
 
 from apio.managers.installer import Installer
 from apio.resources import Resources
+from apio import util
 
 # R0801: Similar lines in 2 files
 # pylint: disable=R0801
@@ -30,7 +31,7 @@ platforms = [
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
 # pylint: disable=W0622
-@click.command("install")
+@click.command("install", context_settings=util.context_settings())
 @click.pass_context
 @click.argument("packages", nargs=-1)
 @click.option("-a", "--all", is_flag=True, help="Install all packages.")

--- a/apio/commands/lint.py
+++ b/apio/commands/lint.py
@@ -8,12 +8,13 @@
 import click
 
 from apio.managers.scons import SCons
+from apio import util
 
 
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
 # pylint: disable=W0622
-@click.command("lint")
+@click.command("lint", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-a",

--- a/apio/commands/raw.py
+++ b/apio/commands/raw.py
@@ -10,7 +10,7 @@ import click
 from apio import util
 
 
-@click.command("raw")
+@click.command("raw", context_settings=util.context_settings())
 @click.pass_context
 @click.argument("cmd")
 def cli(ctx, cmd):

--- a/apio/commands/sim.py
+++ b/apio/commands/sim.py
@@ -7,9 +7,10 @@
 
 import click
 from apio.managers.scons import SCons
+from apio import util
 
 
-@click.command("sim")
+@click.command("sim", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-p",

--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -7,11 +7,12 @@
 
 import click
 
+from apio import util
 from apio.util import get_systype
 from apio.managers.system import System
 
 
-@click.command("system")
+@click.command("system", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "--lsftdi", is_flag=True, help="List all connected FTDI devices."

--- a/apio/commands/test.py
+++ b/apio/commands/test.py
@@ -7,9 +7,10 @@
 
 import click
 from apio.managers.scons import SCons
+from apio import util
 
 
-@click.command("test")
+@click.command("test", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-p",

--- a/apio/commands/time.py
+++ b/apio/commands/time.py
@@ -8,12 +8,13 @@
 import click
 
 from apio.managers.scons import SCons
+from apio import util
 
 
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
 # pylint: disable=W0622
-@click.command("time")
+@click.command("time", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-b", "--board", type=str, metavar="board", help="Set the board."

--- a/apio/commands/uninstall.py
+++ b/apio/commands/uninstall.py
@@ -10,6 +10,7 @@ import click
 from apio.managers.installer import Installer
 from apio.resources import Resources
 from apio.profile import Profile
+from apio import util
 
 platforms = [
     "linux_x86_64",
@@ -23,7 +24,7 @@ platforms = [
 
 
 # pylint: disable=W0622
-@click.command("uninstall")
+@click.command("uninstall", context_settings=util.context_settings())
 @click.pass_context
 @click.argument("packages", nargs=-1)
 @click.option("-a", "--all", is_flag=True, help="Uninstall all packages.")

--- a/apio/commands/upgrade.py
+++ b/apio/commands/upgrade.py
@@ -10,9 +10,10 @@ import click
 
 from packaging import version
 from apio.util import get_pypi_latest_version
+from apio import util
 
 
-@click.command("upgrade")
+@click.command("upgrade", context_settings=util.context_settings())
 @click.pass_context
 def cli(ctx):
     """Check the latest Apio version."""

--- a/apio/commands/upload.py
+++ b/apio/commands/upload.py
@@ -9,11 +9,12 @@ import click
 
 from apio.managers.scons import SCons
 from apio.managers.drivers import Drivers
+from apio import util
 
 
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
-@click.command("upload")
+@click.command("upload", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-b", "--board", type=str, metavar="board", help="Set the board."

--- a/apio/commands/verify.py
+++ b/apio/commands/verify.py
@@ -8,9 +8,10 @@
 import click
 
 from apio.managers.scons import SCons
+from apio import util
 
 
-@click.command("verify")
+@click.command("verify", context_settings=util.context_settings())
 @click.pass_context
 @click.option(
     "-p",

--- a/apio/util.py
+++ b/apio/util.py
@@ -807,3 +807,8 @@ def get_python_version():
     """Return a string with the python version"""
 
     return f"{sys.version_info[0]}.{sys.version_info[1]}"
+
+def context_settings():
+    """Return a common Click command settings that adds the alias -h to --help"""
+    # Per https://github.com/pallets/click/issues/2132
+    return dict(help_option_names=['-h', '--help'])

--- a/apio/util.py
+++ b/apio/util.py
@@ -810,5 +810,5 @@ def get_python_version():
 
 def context_settings():
     """Return a common Click command settings that adds the alias -h to --help"""
-    # Per https://github.com/pallets/click/issues/2132
+    # Per https://click.palletsprojects.com/en/8.1.x/documentation/#help-parameter-customization
     return dict(help_option_names=['-h', '--help'])


### PR DESCRIPTION
This PR adds to the alias -h to the --help flag. No other change in behavior. This will help the exploration of apio's commands.

Based on the documentation here.
https://click.palletsprojects.com/en/8.1.x/documentation/#help-parameter-customization

A single global change is not available per this issue.
https://github.com/pallets/click/issues/2132