### PR TITLE
Added the 'apio graph' command which generates a svg graph of the verilog code.

### DIFF
--- a/apio/commands/graph.py
+++ b/apio/commands/graph.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# -- This file is part of the Apio project
+# -- (C) 2016-2019 FPGAwars
+# -- Author Jesús Arroyo
+# -- Licence GPLv2
+"""TODO"""
+
+import click
+
+from apio.managers.scons import SCons
+from apio import util
+
+
+@click.command("graph", context_settings=util.context_settings())
+@click.pass_context
+@click.option(
+    "-p",
+    "--project-dir",
+    type=str,
+    metavar="path",
+    help="Set the target directory for the project.",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Show the entire output of the command.",
+)
+@click.option(
+    "--top-module",
+    type=str,
+    metavar="top_module",
+    help="Set the top level module (w/o .v ending) to graph.",
+)
+def cli(ctx, project_dir, verbose, top_module):
+    """Generate a a visual graph of the verilog code."""
+
+    # -- Crete the scons object
+    scons = SCons(project_dir)
+
+    # -- Graph the project with the given parameters
+    exit_code = scons.graph(
+        {
+            "verbose": {"all": verbose, "yosys": False, "pnr": False},
+            "top-module": top_module
+        }
+    )
+
+    # -- Done!
+    ctx.exit(exit_code)

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -78,6 +78,22 @@ class SCons:
             arch=arch,
             packages=["oss-cad-suite"],
         )
+    
+    @util.command
+    def graph(self, args):
+        """Executes scons for visual graph generation"""
+
+        # -- Split the arguments
+        var, _, arch = process_arguments(args, self.resources)
+
+        # -- Execute scons!!!
+        # -- The packages to check are passed
+        return self.run(
+            "graph",
+            variables=var,
+            arch=arch,
+            packages=["oss-cad-suite"],
+        )
 
     @util.command
     def lint(self, args):

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -211,6 +211,26 @@ iverilog = Builder(
     suffix='.out',
     src_suffix='.v',
     source_scanner=list_scanner)
+env.Append(BUILDERS={'IVerilog': iverilog})
+
+dot_builder = Builder(
+    action='yosys -p \"show -format dot -colors 1 -prefix hardware {0}\" {1} $SOURCES'.format(
+        # YOSYS_TOP if YOSYS_TOP else 'top',
+        YOSYS_TOP if YOSYS_TOP else 'unknown_top',
+        '' if VERBOSE_ALL else '-q'
+    ),
+    suffix='.dot',
+    src_suffix='.v',
+    source_scanner=list_scanner)
+env.Append(BUILDERS={'DOT': dot_builder})
+
+svg_builder = Builder(
+    # Expecting graphviz dot to be installed and in the path.
+    action='dot -Tsvg $SOURCES -o $TARGET',
+    suffix='.svg',
+    src_suffix='.dot',
+    source_scanner=list_scanner)
+env.Append(BUILDERS={'SVG': svg_builder})
 
 # NOTE: output file name is defined in the iverilog call using VCD_OUTPUT macro
 vcd = Builder(
@@ -218,13 +238,19 @@ vcd = Builder(
         VVP_PATH),
     suffix='.vcd',
     src_suffix='.out')
-
-env.Append(BUILDERS={'IVerilog': iverilog, 'VCD': vcd})
+env.Append(BUILDERS={'VCD': vcd})
 
 # --- Verify
 vout = env.IVerilog(TARGET, src_synth + list_tb)
 AlwaysBuild(vout)
 verify = env.Alias('verify', vout)
+
+# --- Graph
+dot_target = env.DOT(TARGET, src_synth)
+AlwaysBuild(dot_target)
+svg_target = env.SVG(TARGET, dot_target)
+AlwaysBuild(svg_target)
+graph_target = env.Alias('graph', svg_target)
 
 # --- Simulation
 # Since the simulation targets are dynamic due to the testbench selection, we 
@@ -328,4 +354,4 @@ if GetOption('clean'):
         for node in Glob(glob_pattern):
             env.Clean(t, str(node))
 
-    env.Default([t, build, json_out, config_out])
+    env.Default([t, build, json_out, config_out, graph_target])

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -216,6 +216,26 @@ iverilog = Builder(
     suffix='.out',
     src_suffix='.v',
     source_scanner=list_scanner)
+env.Append(BUILDERS={'IVerilog': iverilog})
+
+dot_builder = Builder(
+    action='yosys -p \"show -format dot -colors 1 -prefix hardware {0}\" {1} $SOURCES'.format(
+        # YOSYS_TOP if YOSYS_TOP else 'top',
+        YOSYS_TOP if YOSYS_TOP else 'unknown_top',
+        '' if VERBOSE_ALL else '-q'
+    ),
+    suffix='.dot',
+    src_suffix='.v',
+    source_scanner=list_scanner)
+env.Append(BUILDERS={'DOT': dot_builder})
+
+svg_builder = Builder(
+    # Expecting graphviz dot to be installed and in the path.
+    action='dot -Tsvg $SOURCES -o $TARGET',
+    suffix='.svg',
+    src_suffix='.dot',
+    source_scanner=list_scanner)
+env.Append(BUILDERS={'SVG': svg_builder})
 
 # NOTE: output file name is defined in the iverilog call using VCD_OUTPUT macro
 vcd = Builder(
@@ -223,13 +243,20 @@ vcd = Builder(
         VVP_PATH),
     suffix='.vcd',
     src_suffix='.out')
-
-env.Append(BUILDERS={'IVerilog': iverilog, 'VCD': vcd})
+env.Append(BUILDERS={'VCD': vcd})
 
 # --- Verify
 vout = env.IVerilog(TARGET, src_synth + list_tb)
 AlwaysBuild(vout)
 verify = env.Alias('verify', vout)
+
+# --- Graph
+# TODO: Launch some portable SVG (or differentn format) viewer.
+dot_target = env.DOT(TARGET, src_synth)
+AlwaysBuild(dot_target)
+svg_target = env.SVG(TARGET, dot_target)
+AlwaysBuild(svg_target)
+graph_target = env.Alias('graph', svg_target)
 
 # --- Simulation
 # Since the simulation targets are dynamic due to the testbench selection, we 
@@ -332,4 +359,4 @@ if GetOption('clean'):
         for node in Glob(glob_pattern):
             env.Clean(t, str(node))
 
-    env.Default([t, build, vout])
+    env.Default([t, build, vout, graph_target])

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -89,6 +89,7 @@ Project Commands
 
     project_commands/cmd_build
     project_commands/cmd_clean
+    project_commands/cmd_graph
     project_commands/cmd_lint
     project_commands/cmd_sim
     project_commands/cmd_test

--- a/test/code_commands/test_graph.py
+++ b/test/code_commands/test_graph.py
@@ -1,0 +1,25 @@
+"""
+  Test for the "apio graph" command
+"""
+
+# -- apio graph entry point
+from apio.commands.graph import cli as cmd_graph
+
+
+def test_graph(clirunner, configenv):
+    """Test: apio graph
+    when no apio.ini file is given
+    No additional parameters are given
+    """
+
+    with clirunner.isolated_filesystem():
+
+        # -- Config the environment (conftest.configenv())
+        configenv()
+
+        # -- Execute "apio graph"
+        result = clirunner.invoke(cmd_graph, ['--board', 'icezum'])
+
+        # -- Check the result
+        assert result.exit_code != 0
+        assert 'apio install oss-cad-suite' in result.output


### PR DESCRIPTION
Added a new 'apio graph' command which uses yosys to generate, a hardware.svg file with a  visual representation of a verilog module. By default it shows the top module and this can be changed with the --top-module flag.

This is the yosys command that generates the graph
https://yosyshq.readthedocs.io/projects/yosys/en/manual-rewrite/cmd/show.html

Caveats
1. The command requires the graphviz dot command to be in the path. Ideally this can auto installed in future versions of apio.

2. The command generates the hardware.svg file but doesn't launch automatically a viewer (any web browser would do). Need to find a cross platform way to do that.

3. The graphs are not perfect, but hopefully will be improved over time. For example per this feature request https://github.com/YosysHQ/yosys/issues/4236 or with additions of post optimization graphs.