### PR TITLE
Update SConstruct to link ecp5/cells_bb.v

### DIFF
--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -203,7 +203,7 @@ def iverilog_generator(source, target, env, for_signature):
     #     end
     is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
     interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
-    result = 'iverilog {0} -o $TARGET {1} {2} -D NO_INCLUDES "{3}/ecp5/cells_sim.v" $SOURCES'.format(
+    result = 'iverilog {0} -o $TARGET {1} {2} -D NO_INCLUDES "{3}/ecp5/cells_bb.v" "{3}/ecp5/cells_sim.v" $SOURCES'.format(
         IVER_PATH, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
     return result
 


### PR DESCRIPTION
iverilog fails compilation when working with ECP5 primitives such as EHXPLLL. Issue is documented here: https://github.com/FPGAwars/icestudio/issues/542

I'm not sure if this is the 'correct' fix, but linking `ecp5/cells_bb.v` (since that's where the EHXPLLL definition is) appears to allow compilation to proceed. Feel free to refactor if there's a better or more longstanding change that would better amend this. This is otherwise not desirable behavior for `apio verify` to fail when using ecp5 primitives.