### PR TITLE
Fixed broken build test. 

### DIFF
--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -33,9 +33,9 @@ class Project:
 
     def __init__(self):
         # TODO(zapta): Make these __private and provide getter methods.
-        self.board = None
-        self.top_module = None
-        self.exe_mode = None
+        self.board: str = None
+        self.top_module: str = None
+        self.native_exe_mode: bool = None
 
     def create_sconstruct(self, project_dir: Path, arch=None, sayyes=False):
         """Creates a default SConstruct file"""
@@ -220,7 +220,8 @@ class Project:
         self.top_module = self._parse_top_module(
             config_parser, parsed_attributes
         )
-        self.exe_mode = self._parse_exe_mode(config_parser, parsed_attributes)
+        exe_mode = self._parse_exe_mode(config_parser, parsed_attributes) 
+        self.native_exe_mode = {"default": False, "native": True}[exe_mode]
 
         # Verify that the project file (api.ini) doesn't contain additional
         # (illegal) keys that where not parsed

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -888,8 +888,12 @@ class SCons:
             # -- We are using our custom SConstruct file
             click.secho("Info: use custom SConstruct file")
 
-        # -- Check the configuration mode
-        if self.proj.exe_mode == "default":
+        # -- Verify necessary packages if needed.
+        # TODO(zapta): Can we drop the 'native' mode for simplicity?
+        if self.proj.native_exe_mode:
+             # Assuming blindly that the binaries we need are on the path.
+             click.secho("Warning: native exe mode (binaries should be on path)")
+        else:
             # Run on `default` config mode
             # -- Check if the necessary packages are installed
             if not util.resolve_packages(
@@ -899,8 +903,7 @@ class SCons:
             ):
                 # Exit if a package is not installed
                 raise AttributeError("Package not installed")
-        else:
-            click.secho("Info: native exe mode")
+        
 
         # -- Execute scons
         return self._execute_scons(command, variables, board)

--- a/test/env_commands/test_config.py
+++ b/test/env_commands/test_config.py
@@ -22,6 +22,3 @@ def test_config(clirunner, validate_cliresult, configenv):
         result = clirunner.invoke(cmd_config, ['--list'])
         validate_cliresult(result)
 
-        # -- Execute "apio config --exe native"
-        result = clirunner.invoke(cmd_config, ['--exe', 'native'])
-        validate_cliresult(result)


### PR DESCRIPTION
The issue that without apio.ini, the effective default behavior was of 'native' rather than 'default' which resulted in different error messages that expected by some tests. I also changed the variable exe_mode from string to a boolean. All tests can run now on my system.

Juan, is the 'native' mode necessary or can we remove it for simplicity?

