### PR TITLE
Allows users to define custom boards.json and fpga.json in the project file.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,44 @@
+# APIO Developers Hints
+
+This file is not intended for APIO users.
+
+## Pre commit tests
+Before submitting a new commit, make sure the following commands runs successfuly (in the repository root):
+
+```shell
+make lint
+make tox
+```
+
+## Running an individual APIO test
+
+Run from the repo root. Replace with the path to the desire test.
+
+```shell
+test/code_commands/test_build.py
+```
+
+## Running APIO in a debugger
+
+Set the debugger to run the ``apio_run.py`` main with the regular ``apio`` arguments. Set the project directory ot the project file or use the ``--project_dir`` apio argument to point to the project directory.
+
+Example of an equivalent manual command:
+```
+python apio_run.py build --project_dir ~/projects/fpga/repo/hdl
+```
+
+## Running APIO commands using a dev repo
+
+One way is to link the pip package to the dev repository. Something along these lines. Adjust patches to match your system. The ``pip show`` command shows the directory where the stock pip package is installed.
+
+NOTE: This make the command ``apio init --scons`` opsolete since the scons files can be edited in the dev repository.
+
+```
+pip install apio
+pip show apio
+cd /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages
+mv apio apio.original
+ln -s ~/projects/apio_dev/repo/apio
+```
+
+

--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -29,7 +29,7 @@ class ApioCLI(click.MultiCommand):
         # -- Ex. /home/obijuan/Develop/(...)/apio/commands
         # -- Every apio command (Ex. apio build, apio upload...) is a
         # -- separate .py file located in the commands folder
-        self.commands_folder = util.get_full_path("commands")
+        self.commands_folder = util.get_apio_full_path("commands")
 
         self._cls = [None]
         super().__init__(*args, **kwargs)

--- a/apio/commands/boards.py
+++ b/apio/commands/boards.py
@@ -7,6 +7,7 @@
 # -- Licence GPLv2
 """Main implementation of APIO BOARDS command"""
 
+from pathlib import Path
 import click
 from apio.resources import Resources
 from apio import util
@@ -15,12 +16,20 @@ from apio import util
 # -- CONSTANTS
 # ------------------
 CMD = "boards"  # -- Comand name
+PROJECT_DIR = "project_dir"  # -- Option
 LIST = "list"  # -- Option
 FPGA = "fpga"  # -- Option
 
 
 @click.command(CMD, context_settings=util.context_settings())
 @click.pass_context
+@click.option(
+    "-p",
+    "--project-dir",
+    type=Path,
+    metavar="str",
+    help="Set the target directory for the project.",
+)
 @click.option(
     "-l",
     f"--{LIST}",
@@ -34,11 +43,12 @@ def cli(ctx, **kwargs):
     """Manage FPGA boards."""
 
     # -- Extract the arguments
+    project_dir = kwargs[PROJECT_DIR]  # -- str
     _list = kwargs[LIST]  # -- bool
     fpga = kwargs[FPGA]  # -- bool
 
     # -- Access to the apio resources
-    resources = Resources()
+    resources = Resources(project_dir=project_dir)
 
     # -- Option 1: List boards
     if _list:

--- a/apio/commands/init.py
+++ b/apio/commands/init.py
@@ -67,26 +67,26 @@ def cli(ctx, **kwargs):
     top_module = kwargs[TOP_MODULE]
 
     # -- Create a project
-    project = Project()
+    project = Project(project_dir)
 
     # -- scons option: Create default SConstruct file
     if scons:
-        project.create_sconstruct(project_dir, "ice40", sayyes)
+        project.create_sconstruct("ice40", sayyes)
 
-    # -- Create the apio.ini file
+    # -- Create the project file apio.ini
     elif board:
         # -- Set the default top_module when creating the ini file
         if not top_module:
             top_module = "main"
 
         # -- Create the apio.ini file
-        project.create_ini(board, top_module, project_dir, sayyes)
+        project.create_ini(board, top_module, sayyes)
 
     # -- Add the top_module to the apio.ini file
     elif top_module:
 
         # -- Update the apio.ini file
-        project.update_ini(top_module, project_dir)
+        project.update_ini(top_module)
 
     # -- No options: show help
     else:

--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -7,15 +7,19 @@
 # -- Licence GPLv2
 """Main implementation of APIO SYSTEM command"""
 
+from pathlib import Path
 import click
 from apio import util
 from apio.util import get_systype
 from apio.managers.system import System
+from apio.resources import Resources
+
 
 # ------------------
 # -- CONSTANTS
 # ------------------
 CMD = "system"  # -- Comand name
+PROJECT_DIR = "project_dir"  # -- Option
 LSFTDI = "lsftdi"  # -- Option
 LSUSB = "lsusb"  # -- Option
 LSSERIAL = "lsserial"  # -- Option
@@ -24,6 +28,13 @@ INFO = "info"  # -- Option
 
 @click.command(CMD, context_settings=util.context_settings())
 @click.pass_context
+@click.option(
+    "-p",
+    "--project-dir",
+    type=Path,
+    metavar="str",
+    help="Set the target directory for the project.",
+)
 @click.option(
     f"--{LSFTDI}", is_flag=True, help="List all connected FTDI devices."
 )
@@ -39,13 +50,17 @@ def cli(ctx, **kwargs):
     """System tools."""
 
     # -- Extract the arguments
+    project_dir = kwargs[PROJECT_DIR]
     lsftdi = kwargs[LSFTDI]
     lsusb = kwargs[LSUSB]
     lsserial = kwargs[LSSERIAL]
     info = kwargs[INFO]
 
+    # Load the various resource files.
+    resources = Resources(project_dir=project_dir)
+
     # -- Create the system object
-    system = System()
+    system = System(resources)
 
     # -- List all connected ftdi devices
     if lsftdi:

--- a/apio/managers/arguments.py
+++ b/apio/managers/arguments.py
@@ -84,7 +84,7 @@ def debug_params(fun):
 # pylint: disable=R0912
 # @debug_params
 def process_arguments(
-    config_ini: dict, resources: type[Resources]
+    config_ini: dict, resources: type[Resources], project: type[Project]
 ) -> tuple:  # noqa
     """Get the final CONFIGURATION, depending on the board and
     arguments passed in the command line.
@@ -102,6 +102,7 @@ def process_arguments(
            'top-module`: str  //-- Top module name
          }
        * Resources: Object for accessing the apio resources
+       * Project: the contentn of apio.ini, possibly empty if does not exist.
     * OUTPUT:
       * Return a tuple (flags, board, arch)
         - flags: A list of strings with the flags valures:
@@ -129,10 +130,6 @@ def process_arguments(
     # -- Merge the initial configuration to the current configuration
     config.update(config_ini)
 
-    # -- Read the apio project file (apio.ini)
-    proj = Project()
-    proj.read()
-
     # -- proj.board:
     # --   * None: No apio.ini file
     # --   * "name": Board name (str)
@@ -151,18 +148,18 @@ def process_arguments(
         # -- If there is a project file (apio.ini) the board
         # -- given by command line overrides it
         # -- (command line has the highest priority)
-        if proj.board:
+        if project.board:
 
             # -- As the command line has more priority, and the board
             # -- given in args is different than the one in the project,
             # -- inform the user
-            if config[BOARD] != proj.board:
+            if config[BOARD] != project.board:
                 click.secho("Info: ignore apio.ini board", fg="yellow")
 
     # -- Board name given in the project file
     else:
         # -- ...read it from the apio.ini file
-        config[BOARD] = proj.board
+        config[BOARD] = project.board
 
     # -- The board is given (either by arguments or by project file)
     if config[BOARD]:
@@ -214,8 +211,8 @@ def process_arguments(
 
         # -- Priority 2: Use the top module in the apio.ini file
         # -- if it exists...
-        if proj.top_module:
-            config[TOP_MODULE] = proj.top_module
+        if project.top_module:
+            config[TOP_MODULE] = project.top_module
 
         # -- NO top-module specified!! Warn the user
         else:
@@ -358,11 +355,14 @@ def perror_insuficient_arguments():
         fg="red",
     )
     click.secho(
-        "You have two options:\n"
-        "  1) Execute your command with\n"
-        "       `--board <boardname>`\n"
-        "  2) Create an ini file using\n"
-        "       `apio init --board <boardname>`",
+        "You have a few options:\n"
+        "  1) Change to a project directory with an apio.ini file\n"
+        "  2) Specify the directory of a project with an apio.ini file\n"
+        "       `--project-dir <projectdir>\n"
+        "  3) Create a project file apio.ini manually or using\n"
+        "       `apio init --board <boardname>`\n"
+        "  4) Execute your command with the flag\n"
+        "       `--board <boardname>`",
         fg="yellow",
     )
 

--- a/apio/managers/drivers.py
+++ b/apio/managers/drivers.py
@@ -64,7 +64,7 @@ class Drivers:
     # -- to the /etc/udev/rules.d folder
 
     # -- FTDI source rules file paths
-    resources = util.get_full_path("resources")
+    resources = util.get_apio_full_path("resources")
     ftdi_rules_local_path = resources / "80-fpga-ftdi.rules"
 
     # -- Target rule file

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -21,7 +21,7 @@ Use `apio examples -l` for listing all the available examples"""
 
 EXAMPLE_OF_USE_CAD = """
 Example of use:
-   apio examples -f leds
+   apio examples -f icezum/leds
 Copy the leds example files to the current directory\n"""
 
 EXAMPLE_DIR_FILE = """
@@ -154,7 +154,7 @@ class Examples:
             return 1
 
         # -- Get the working dir (current or given)
-        project_dir = util.check_dir(project_dir)
+        project_dir = util.get_project_dir(project_dir, create_if_missing=True)
 
         # -- Build the destination example path
         dst_example_path = project_dir / example
@@ -218,7 +218,9 @@ class Examples:
             return 1
 
         # -- Get the working dir (current or given)
-        dst_example_path = util.check_dir(project_dir)
+        dst_example_path = util.get_project_dir(
+            project_dir, create_if_missing=True
+        )
 
         # -- Build the source example path (where the example was installed)
         src_example_path = self.examples_dir / example

--- a/apio/managers/system.py
+++ b/apio/managers/system.py
@@ -12,18 +12,14 @@ import click
 
 from apio import util
 from apio.profile import Profile
-from apio.resources import Resources
 
 
 class System:  # pragma: no cover
     """System class. Managing and execution of the system commands"""
 
-    def __init__(self):
+    def __init__(self, resources: dict):
         # -- Read the profile from the file
         profile = Profile()
-
-        # -- Read the resources from the corresponding files
-        resources = Resources()
 
         # -- This command is called system
         self.name = "system"

--- a/apio/util.py
+++ b/apio/util.py
@@ -99,8 +99,8 @@ class AsyncPipe(Thread):
         self.join()
 
 
-def get_full_path(folder: str) -> Path:
-    """Get the full path to the given folder
+def get_apio_full_path(folder: str) -> Path:
+    """Get the full path to the given folder in the apio package.
     Inputs:
       * folder: String with the folder name
 
@@ -693,39 +693,40 @@ def print_exception_developers(e):
     click.secho(f"{e}\n", fg="yellow")
 
 
-def check_dir(_dir: Path) -> Path:
+def get_project_dir(_dir: Path, create_if_missing: bool = False) -> Path:
     """Check if the given path is a folder. It it does not exists
-    the folder is created. If no path is given the current working
-    directory is used
+    and create_if_missing is true, folder is created, otherwise a fatal error.
+    If no path is given the current working directory is used.
       * INPUTS:
-        * _dir: The Path to check
+        * _dir: The Path to check.
       * OUTPUT:
-        * The new path (if not given)
+        * The effective path (same if given)
     """
-
     # -- If no path is given, get the current working directory
     if not _dir:
         _dir = Path.cwd()
 
-    # -- Check if the path is a file or a folder
+    # -- Make sure the folder doesn't exist as a file.
     if _dir.is_file():
-        # -- It is a file! Error! Exit!
         click.secho(
             f"Error: project directory is already a file: {_dir}", fg="red"
         )
-
         sys.exit(1)
 
     # -- If the folder does not exist....
     if not _dir.exists():
-        # -- Warning
-        click.secho(f"Warning: The path does not exist: {_dir}", fg="yellow")
-
-        # -- Create the folder
-        click.secho(f"Creating folder: {_dir}")
-        _dir.mkdir()
+        if create_if_missing:
+            click.secho(
+                f"Warning: The path does not exist: {_dir}", fg="yellow"
+            )
+            click.secho(f"Creating folder: {_dir}")
+            _dir.mkdir()
+        else:
+            click.secho(f"Error: the path does not exist: {_dir}", fg="red")
+            sys.exit(1)
 
     # -- Return the path
+    # print(f"*** get_project_dir() {_temp} -> {_dir}")
     return _dir
 
 


### PR DESCRIPTION
This change allows users to define custom resource files by placing a resource file of the same name in their project directory. Currently it is enabled only for boards.json and fpga.json but can easily be enabled for other resources. With this change, users can use their own custom board without having to burden the stock resource files with niche boards. If a custom resource file is used, an info message is printed to the console.

The bulk of the change is around making the project dir known in resources.py when the resources are loaded into a Resources object.

