### PR TITLE
Fixed a typo in the upduino3x board definition.

### DIFF
--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -270,7 +270,7 @@
       "pid": "6014"
     },
     "ftdi": {
-      "desc": "UPduino v3.0"
+      "desc": "UPduino v3\\.0"
     }
   },
     "upduino31": {
@@ -284,7 +284,7 @@
       "pid": "6014"
     },
     "ftdi": {
-      "desc": "UPduino v3.1"
+      "desc": "UPduino v3\\.1"
     }
   },
   "iCEBreaker": {


### PR DESCRIPTION
Fixed a typo in upduino board regex.  Escaped the '.' to match exactly a dot rather than any character. 

It's not obvious that the "desc" field is a regex rather than a string. Would be nice to able able to add comments to a jason file.