### PR TITLE
Encoding in util.py

### DIFF
--- a/apio/util.py
+++ b/apio/util.py
@@ -67,7 +67,7 @@ class AsyncPipe(Thread):
         self.outcallback = outcallback
 
         self._fd_read, self._fd_write = os.pipe()
-        self._pipe_reader = os.fdopen(self._fd_read)
+        self._pipe_reader = os.fdopen(self._fd_read, encoding="UTF-8")
         self._buffer = []
 
         self.start()


### PR DESCRIPTION
When calling `apio upload` on Windows 10 for a TinyFPGA-BX, I get a `UnicodeDecodeError`, but the upload is still a success.

With the correct encoding, I get the loading bar during upload.

Tested only with a TinyFPGA-BX on Windows 10 and Linux.

<details>
  <summary>Without the fix</summary>

```[Mon Sep  2 11:52:58 2024] Processing TinyFPGA-BX
---------------------------------------------------------------------------------------------------------------------------------------------tinyprog --pyserial -c COM4 --program hardware.bin

TinyProg CLI
------------
Using device id 1d50:6130
Programming COM4 with hardware.bin
Programming at addr 028000
Waking up SPI flash
135100 bytes to program
Exception in thread Thread-6:
Traceback (most recent call last):
  File "C:\Program Files\Python312\Lib\threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "C:\Users\super\.icestudio\venv\Lib\site-packages\apio\util.py", line 88, in run
    for line in iter(self._pipe_reader.readline, ""):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 27: character maps to <undefined>
Success!

======================================================== [SUCCESS] Took 2.48 seconds ========================================================
 ```

</details>

<details>
  <summary>With the fix</summary>

```[Mon Sep  2 12:04:26 2024] Processing TinyFPGA-BX
---------------------------------------------------------------------------------------------------------------------------------------------tinyprog --pyserial -c COM4 --program hardware.bin

TinyProg CLI
------------
Using device id 1d50:6130
Programming COM4 with hardware.bin
Programming at addr 028000
Waking up SPI flash
135100 bytes to program
Erasing: 100%|██████████| 135k/135k [00:00<00:00, 188kB/s]
Writing: 100%|██████████| 135k/135k [00:00<00:00, 194kB/s]
Success!
Reading:  98%|█████████▊| 133k/135k [00:00<00:00, 437kB/s]
Reading: 100%|██████████| 135k/135k [00:00<00:00, 437kB/s]
======================================================== [SUCCESS] Took 2.44 seconds ========================================================
 ```

</details>