### PR TITLE
Added supression of verilator MULTITOP warnings in apio lint command. 

### DIFF
--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -327,7 +327,7 @@ if 'test' in COMMAND_LINE_TARGETS:
 
 # -- Verilator builder
 verilator_builder = Builder(
-    action='verilator --lint-only --timing -Wno-TIMESCALEMOD -v {0}/ecp5/cells_sim.v {1} {2} {3} {4} $SOURCES'.format(
+    action='verilator --lint-only --timing -Wno-TIMESCALEMOD -Wno-MULTITOP -v {0}/ecp5/cells_sim.v {1} {2} {3} {4} $SOURCES'.format(
         YOSYS_PATH,
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -335,7 +335,7 @@ if 'test' in COMMAND_LINE_TARGETS:
 
 # -- Verilator builder
 verilator_builder = Builder(
-    action='verilator --lint-only --timing -Wno-TIMESCALEMOD {0} {1} {2} {3} $SOURCES'.format(
+    action='verilator --lint-only --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES'.format(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
         VERILATOR_PARAM_STR if VERILATOR_PARAM_STR else '',

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -332,7 +332,7 @@ if 'test' in COMMAND_LINE_TARGETS:
 
 # -- Verilator builder
 verilator_builder = Builder(
-    action='verilator --lint-only --timing -Wno-TIMESCALEMOD {0} {1} {2} {3} $SOURCES'.format(
+    action='verilator --lint-only --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES'.format(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
         VERILATOR_PARAM_STR if VERILATOR_PARAM_STR else '',


### PR DESCRIPTION
When having testbenches files in the project, verilator considers each one of them to be a top module and issues a warning. One alternative would be to add to the verilator command line a --top-module flag but that would suppress the linting of the testbenches.

I tested it with an ice40 project but it seems to be low risk for the ecp5 and gowin as well.