### PR TITLE
Refactored the command options.

### DIFF
--- a/apio/commands/boards.py
+++ b/apio/commands/boards.py
@@ -11,51 +11,46 @@ from pathlib import Path
 import click
 from apio.resources import Resources
 from apio import util
+from apio.commands import options
 
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "boards"  # -- Comand name
-PROJECT_DIR = "project_dir"  # -- Option
-LIST = "list"  # -- Option
-FPGA = "fpga"  # -- Option
-
-
-@click.command(CMD, context_settings=util.context_settings())
-@click.pass_context
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="str",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-l",
-    f"--{LIST}",
+# ---------------------------
+# -- COMMAND SPECIFIC OPTIONS
+# ---------------------------
+list_fpgas_option = click.option(
+    "fpgas",  # Var name
+    "-f",
+    "--fpga",
     is_flag=True,
-    help="List all supported FPGA boards.",
+    help="List all supported FPGA chips.",
 )
-@click.option(
-    "-f", f"--{FPGA}", is_flag=True, help="List all supported FPGA chips."
-)
-def cli(ctx, **kwargs):
-    """Manage FPGA boards."""
 
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]  # -- str
-    _list = kwargs[LIST]  # -- bool
-    fpga = kwargs[FPGA]  # -- bool
+
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+@click.command("boards", context_settings=util.context_settings())
+@click.pass_context
+@options.project_dir_option
+@options.list_option_gen(help="List all supported FPGA boards.")
+@list_fpgas_option
+def cli(
+    ctx,
+    # Options
+    project_dir: Path,
+    list_: bool,
+    fpgas: bool,
+):
+    """Manage FPGA boards."""
 
     # -- Access to the apio resources
     resources = Resources(project_dir=project_dir)
 
     # -- Option 1: List boards
-    if _list:
+    if list_:
         resources.list_boards()
 
     # -- Option 2: List fpgas
-    elif fpga:
+    elif fpgas:
         resources.list_fpgas()
 
     # -- No options: show help

--- a/apio/commands/build.py
+++ b/apio/commands/build.py
@@ -7,38 +7,45 @@
 # -- Licence GPLv2
 """Main implementation of APIO BUILD command"""
 
-
+from pathlib import Path
 import click
 from apio.managers.scons import SCons
 from apio import util
 from apio.commands import options
 
 
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+# R0913: Too many arguments (11/5)
+# pylint: disable=R0913
 @click.command("build", context_settings=util.context_settings())
 @click.pass_context
-@options.board
-@options.fpga
-@options.size
-@options.type_
-@options.pack
-@options.project_dir
-@options.verbose
-@options.verbose_yosys
-@options.verbose_pnr
-@options.top_module
-def cli(ctx, **kwargs):
+@options.board_option_gen()
+@options.fpga_option
+@options.size_option
+@options.type_option
+@options.pack_option
+@options.project_dir_option
+@options.verbose_option
+@options.verbose_yosys_option
+@options.verbose_pnr_option
+@options.top_module_option_gen()
+def cli(
+    ctx,
+    # Options
+    board: str,
+    fpga: str,
+    size: str,
+    type_: str,
+    pack: str,
+    project_dir: Path,
+    verbose: bool,
+    verbose_yosys: bool,
+    verbose_pnr: bool,
+    top_module: str,
+):
     """Synthesize the bitstream."""
-    # -- Extract the arguments
-    project_dir = kwargs[options.PROJECT_DIR]
-    board = kwargs[options.BOARD]
-    fpga = kwargs[options.FPGA]
-    pack = kwargs[options.PACK]
-    _type = kwargs[options.TYPE]
-    size = kwargs[options.SIZE]
-    verbose = kwargs[options.VERBOSE]
-    verbose_yosys = kwargs[options.VERBOSE_YOSYS]
-    verbose_pnr = kwargs[options.VERBOSE_PNR]
-    top_module = kwargs[options.TOP_MODULE]
 
     # The bitstream is generated from the source files (verilog)
     # by means of the scons tool
@@ -55,7 +62,7 @@ def cli(ctx, **kwargs):
             "board": board,
             "fpga": fpga,
             "size": size,
-            "type": _type,
+            "type": type_,
             "pack": pack,
             "verbose": {
                 "all": verbose,

--- a/apio/commands/clean.py
+++ b/apio/commands/clean.py
@@ -7,46 +7,29 @@
 # -- Licence GPLv2
 """Main implementation of APIO CLEAN command"""
 
-
 from pathlib import Path
 import click
 from apio.managers.scons import SCons
 from apio import util
-
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "clean"  # -- Comand name
-BOARD = "board"  # -- Option
-PROJECT_DIR = "project_dir"  # -- Option
-VERBOSE = "verbose"  # -- Option
+from apio.commands import options
 
 
-@click.command(CMD, context_settings=util.context_settings())
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+@click.command("clean", context_settings=util.context_settings())
 @click.pass_context
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="str",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-b", f"--{BOARD}", type=str, metavar="str", help="Set the board."
-)
-@click.option(
-    "-v",
-    f"--{VERBOSE}",
-    is_flag=True,
-    help="Show the entire output of the command.",
-)
-def cli(ctx, **kwargs):
+@options.project_dir_option
+@options.board_option_gen()
+@options.verbose_option
+def cli(
+    ctx,
+    # Options
+    project_dir: Path,
+    board: str,
+    verbose: bool,
+):
     """Clean the previous generated files."""
-
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    board = kwargs[BOARD]
-    verbose = kwargs[VERBOSE]
 
     # -- Create the scons object
     scons = SCons(project_dir)

--- a/apio/commands/config.py
+++ b/apio/commands/config.py
@@ -10,42 +10,47 @@
 import click
 from apio.profile import Profile
 from apio import util
-
-# -----------------
-# -- CONSTANTS
-# -----------------
-CMD = "config"  # -- Comand name
-LIST = "list"  # -- Option
-VERBOSE = "verbose"  # -- Option
-EXE = "exe"  # -- Option
+from apio.commands import options
 
 
-@click.command(CMD, context_settings=util.context_settings())
-@click.pass_context
-@click.option(
-    "-l",
-    f"--{LIST}",
-    is_flag=True,
-    help="List all configuration parameters.",
-)
-@click.option(
+# ---------------------------
+# -- COMMAND SPECIFIC OPTIONS
+# ---------------------------
+
+
+# W0511: TODO
+# pylint: disable=W0511
+# TODO: Consolidate this numeric option with the shared boolean
+# 'verbose' option in options.py.
+verbose_option = click.option(
+    "verbose",  # Var name
     "-v",
-    f"--{VERBOSE}",
+    "--verbose",
     type=click.Choice(["0", "1"]),
     help="Verbose mode: `0` General, `1` Information.",
 )
-def cli(ctx, **kwargs):
-    """Apio configuration."""
 
-    # -- Extract the arguments
-    _list = kwargs[LIST]
-    verbose = kwargs[VERBOSE]
+
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+@click.command("config", context_settings=util.context_settings())
+@click.pass_context
+@options.list_option_gen(help="List all configuration parameters.")
+@verbose_option
+def cli(
+    ctx,
+    # Options
+    list_: bool,
+    verbose: str,
+):
+    """Apio configuration."""
 
     # -- Access to the profile file
     profile = Profile()
 
     # -- List configuration parameters
-    if _list:
+    if list_:
         profile.list()
 
     # -- Configure verbose mode

--- a/apio/commands/drivers.py
+++ b/apio/commands/drivers.py
@@ -11,30 +11,56 @@ import click
 from apio.managers.drivers import Drivers
 from apio import util
 
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "drivers"  # -- Comand name
-FTDI_ENABLE = "ftdi_enable"  # -- Option
-FTDI_DISABLE = "ftdi_disable"  # -- Option
-SERIAL_ENABLE = "serial_enable"  # -- Option
-SERIAL_DISABLE = "serial_disable"  # -- Option
+# ---------------------------
+# -- COMMAND SPECIFIC OPTIONS
+# ---------------------------
+frdi_enable_option = click.option(
+    "ftdi_enable",  # Var name.
+    "--ftdi-enable",
+    is_flag=True,
+    help="Enable FTDI drivers.",
+)
+
+ftdi_disable_option = click.option(
+    "ftdi_disable",  # Var name.
+    "--ftdi-disable",
+    is_flag=True,
+    help="Disable FTDI drivers.",
+)
+
+serial_enable_option = click.option(
+    "serial_enable",  # Var name.
+    "--serial-enable",
+    is_flag=True,
+    help="Enable Serial drivers.",
+)
+
+serial_disable_option = click.option(
+    "serial_disable",  # Var name.
+    "--serial-disable",
+    is_flag=True,
+    help="Disable Serial drivers.",
+)
 
 
-@click.command(CMD, context_settings=util.context_settings())
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+@click.command("drivers", context_settings=util.context_settings())
 @click.pass_context
-@click.option("--ftdi-enable", is_flag=True, help="Enable FTDI drivers.")
-@click.option("--ftdi-disable", is_flag=True, help="Disable FTDI drivers.")
-@click.option("--serial-enable", is_flag=True, help="Enable Serial drivers.")
-@click.option("--serial-disable", is_flag=True, help="Disable Serial drivers.")
-def cli(ctx, **kwargs):
+@frdi_enable_option
+@ftdi_disable_option
+@serial_enable_option
+@serial_disable_option
+def cli(
+    ctx,
+    # Options:
+    ftdi_enable: bool,
+    ftdi_disable: bool,
+    serial_enable: bool,
+    serial_disable: bool,
+):
     """Manage FPGA boards drivers."""
-
-    # -- Extract the arguments
-    ftdi_enable = kwargs[FTDI_ENABLE]
-    ftdi_disable = kwargs[FTDI_DISABLE]
-    serial_enable = kwargs[SERIAL_ENABLE]
-    serial_disable = kwargs[SERIAL_DISABLE]
 
     # -- Access to the Drivers
     drivers = Drivers()

--- a/apio/commands/examples.py
+++ b/apio/commands/examples.py
@@ -11,74 +11,64 @@ from pathlib import Path
 import click
 from apio.managers.examples import Examples
 from apio import util
+from apio.commands import options
 
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "examples"  # -- Comand name
-LIST = "list"  # -- Option
-DIR = "dir"  # -- Option
-FILES = "files"  # -- Option
-PROJECT_DIR = "project_dir"  # -- Option
-SAYNO = "sayno"  # -- Option
-
-
-# R0913: Too many arguments (6/5)
-# pylint: disable=R0913
-# pylint: disable=W0622
-@click.command(CMD, context_settings=util.context_settings())
-@click.pass_context
-@click.option(
-    "-l", f"--{LIST}", is_flag=True, help="List all available examples."
-)
-@click.option(
+# ---------------------------
+# -- COMMAND SPECIFIC OPTIONS
+# ---------------------------
+dir_option = click.option(
+    "dir_",  # Var name. Deconflicting with python builtin 'dir'.
     "-d",
-    f"--{DIR}",
+    "--dir",
     type=str,
     metavar="name",
     help="Copy the selected example directory.",
 )
-@click.option(
+
+files_option = click.option(
+    "files",  # Var name.
     "-f",
-    f"--{FILES}",
+    "--files",
     type=str,
     metavar="name",
     help="Copy the selected example files.",
 )
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="project_dir",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-n",
-    f"--{SAYNO}",
-    is_flag=True,
-    help="Automatically answer NO to all the questions.",
-)
-def cli(ctx, **kwargs):
+
+
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+# R0913: Too many arguments (6/5)
+# pylint: disable=R0913
+@click.command("examples", context_settings=util.context_settings())
+@click.pass_context
+@options.list_option_gen(help="List all available examples.")
+@dir_option
+@files_option
+@options.project_dir_option
+@options.sayno
+def cli(
+    ctx,
+    # Options
+    list_: bool,
+    dir_: str,
+    files: str,
+    project_dir: Path,
+    sayno: bool,
+):
     """Manage verilog examples.\n
     Install with `apio install examples`"""
-
-    # -- Extract the arguments
-    _list = kwargs[LIST]
-    dir = kwargs[DIR]
-    files = kwargs[FILES]
-    project_dir = kwargs[PROJECT_DIR]
-    sayno = kwargs[SAYNO]
 
     # -- Access to the Drivers
     examples = Examples()
 
     # -- Option: List all the available examples
-    if _list:
+    if list_:
         exit_code = examples.list_examples()
 
     # -- Option: Copy the directory
-    elif dir:
-        exit_code = examples.copy_example_dir(dir, project_dir, sayno)
+    elif dir_:
+        exit_code = examples.copy_example_dir(dir_, project_dir, sayno)
 
     # -- Option: Copy only the example files (not the initial folders)
     elif files:

--- a/apio/commands/graph.py
+++ b/apio/commands/graph.py
@@ -11,44 +11,25 @@ from pathlib import Path
 import click
 from apio.managers.scons import SCons
 from apio import util
-
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "graph"  # -- Comand name
-PROJECT_DIR = "project_dir"  # -- Option
-TOP_MODULE = "top_module"  # -- Option
-VERBOSE = "verbose"  # -- Option
+from apio.commands import options
 
 
-@click.command(CMD, context_settings=util.context_settings())
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+@click.command("graph", context_settings=util.context_settings())
 @click.pass_context
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="path",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-v",
-    f"--{VERBOSE}",
-    is_flag=True,
-    help="Show the entire output of the command.",
-)
-@click.option(
-    "--top-module",
-    type=str,
-    metavar="top_module",
-    help="Set the top level module (w/o .v ending) to graph.",
-)
-def cli(ctx, **kwargs):
+@options.project_dir_option
+@options.verbose_option
+@options.top_module_option_gen()
+def cli(
+    ctx,
+    # Options
+    project_dir: Path,
+    verbose: bool,
+    top_module: str,
+):
     """Generate a a visual graph of the verilog code."""
-
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    verbose = kwargs[VERBOSE]
-    top_module = kwargs[TOP_MODULE]
 
     # -- Crete the scons object
     scons = SCons(project_dir)

--- a/apio/commands/init.py
+++ b/apio/commands/init.py
@@ -11,60 +11,44 @@ from pathlib import Path
 import click
 from apio.managers.project import Project
 from apio import util
-
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "init"  # -- Comand name
-BOARD = "board"  # -- Option
-SCONS = "scons"  # -- Option
-PROJECT_DIR = "project_dir"  # -- Option
-SAYYES = "sayyes"  # -- Option
-TOP_MODULE = "top_module"  # -- Option
+from apio.commands import options
 
 
-@click.command(CMD, context_settings=util.context_settings())
-@click.pass_context
-@click.option(
-    "-b",
-    f"--{BOARD}",
-    type=str,
-    metavar="str",
-    help="Create init file with the selected board.",
-)
-@click.option(
-    "-t",
-    "--top-module",
-    type=str,
-    metavar="top_module",
-    help="Set the top_module in the init file",
-)
-@click.option(
-    "-s", f"--{SCONS}", is_flag=True, help="Create default SConstruct file."
-)
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="project_dir",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-y",
-    f"--{SAYYES}",
+# ---------------------------
+# -- COMMAND SPECIFIC OPTIONS
+# ---------------------------
+scons_option = click.option(
+    "scons",  # Var name.
+    "-s",
+    "--scons",
     is_flag=True,
-    help="Automatically answer YES to all the questions.",
+    help="Create default SConstruct file.",
 )
-def cli(ctx, **kwargs):
+
+
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+# R0913: Too many arguments (6/5)
+# pylint: disable=R0913
+@click.command("init", context_settings=util.context_settings())
+@click.pass_context
+@options.board_option_gen(help="Create init file with the selected board.")
+@options.top_module_option_gen(help="Set the top_module in the init file")
+@scons_option
+@options.project_dir_option
+@options.sayyes
+def cli(
+    ctx,
+    # Options
+    board: str,
+    top_module: str,
+    scons: bool,
+    project_dir: Path,
+    sayyes: bool,
+):
     # def cli(ctx, board, top_module, scons, project_dir, sayyes):
     """Manage apio projects."""
-
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    scons = kwargs[SCONS]
-    board = kwargs[BOARD]
-    sayyes = kwargs[SAYYES]
-    top_module = kwargs[TOP_MODULE]
 
     # -- Create a project
     project = Project(project_dir)

--- a/apio/commands/install.py
+++ b/apio/commands/install.py
@@ -12,17 +12,7 @@ import click
 from apio.managers.installer import Installer, list_packages
 from apio.resources import Resources
 from apio import util
-
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "install"  # -- Comand name
-PROJECT_DIR = "project_dir"  # -- Option
-PACKAGES = "packages"  # -- Argument
-ALL = "all"  # -- Option
-LIST = "list"  # -- Option
-FORCE = "force"  # -- Option
-PLATFORM = "platform"  # -- Option
+from apio.commands import options
 
 
 def install_packages(
@@ -45,42 +35,31 @@ def install_packages(
         installer.install()
 
 
-@click.command(CMD, context_settings=util.context_settings())
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+# R0913: Too many arguments (7/5)
+# pylint: disable=R0913
+@click.command("install", context_settings=util.context_settings())
 @click.pass_context
-@click.argument(PACKAGES, nargs=-1)
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="str",
-    help="Set the target directory for the project.",
-)
-@click.option("-a", f"--{ALL}", is_flag=True, help="Install all packages.")
-@click.option(
-    "-l", f"--{LIST}", is_flag=True, help="List all available packages."
-)
-@click.option(
-    "-f", f"--{FORCE}", is_flag=True, help="Force the packages installation."
-)
-@click.option(
-    "-p",
-    f"--{PLATFORM}",
-    type=click.Choice(util.PLATFORMS),
-    help=(
-        f"Set the platform [{', '.join(util.PLATFORMS)}] "
-        "(Advanced, for developers)."
-    ),
-)
-def cli(ctx, **kwargs):
+@click.argument("packages", nargs=-1)
+@options.project_dir_option
+@options.all_option_gen(help="Install all packages.")
+@options.list_option_gen(help="List all available packages.")
+@options.force_option_gen(help="Force the packages installation.")
+@options.platform_option
+def cli(
+    ctx,
+    # Arguments
+    packages,
+    # Options
+    project_dir: Path,
+    all_: bool,
+    list_: bool,
+    force: bool,
+    platform: str,
+):
     """Install apio packages."""
-
-    # -- Extract the arguments
-    packages = kwargs[PACKAGES]  # -- tuple
-    project_dir = kwargs[PROJECT_DIR]  # -- str
-    platform = kwargs[PLATFORM]  # -- str
-    _all = kwargs[ALL]  # -- bool
-    _list = kwargs[LIST]  # -- bool
-    force = kwargs[FORCE]  # -- bool
 
     # -- Load the resources.
     resources = Resources(platform=platform, project_dir=project_dir)
@@ -90,12 +69,12 @@ def cli(ctx, **kwargs):
         install_packages(packages, platform, resources, force)
 
     # -- Install all the available packages (if any)
-    elif _all:
+    elif all_:
         # -- Install all the available packages for this platform!
         install_packages(resources.packages, platform, resources, force)
 
     # -- List all the packages (installed or not)
-    elif _list:
+    elif list_:
         list_packages(platform)
 
     # -- Invalid option. Just show the help

--- a/apio/commands/lint.py
+++ b/apio/commands/lint.py
@@ -11,58 +11,63 @@ from pathlib import Path
 import click
 from apio.managers.scons import SCons
 from apio import util
-
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "lint"  # -- Comand name
-ALL = "all"  # -- Option
-TOP_MODULE = "top_module"  # -- Option
-NOSTYLE = "nostyle"  # -- Option
-NOWARN = "nowarn"  # -- Option
-WARN = "warn"  # -- Option
-PROJECT_DIR = "project_dir"  # -- Option
+from apio.commands import options
 
 
-@click.command(CMD, context_settings=util.context_settings())
-@click.pass_context
-@click.option(
-    "-a",
-    f"--{ALL}",
+# ---------------------------
+# -- COMMAND SPECIFIC OPTIONS
+# ---------------------------
+nostyle_option = click.option(
+    "nostyle",  # Var name
+    "--nostyle",
     is_flag=True,
-    help="Enable all warnings, including code style warnings.",
+    help="Disable all style warnings.",
 )
-@click.option(
-    "-t", "--top-module", type=str, metavar="str", help="Set top module."
-)
-@click.option(f"--{NOSTYLE}", is_flag=True, help="Disable all style warnings.")
-@click.option(
-    f"--{NOWARN}",
+
+
+nowarn_option = click.option(
+    "nowarn",  # Var name
+    "--nowarn",
     type=str,
     metavar="nowarn",
     help="Disable specific warning(s).",
 )
-@click.option(
-    f"--{WARN}", type=str, metavar="warn", help="Enable specific warning(s)."
-)
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="path",
-    help="Set the target directory for the project.",
-)
-def cli(ctx, **kwargs):
-    # def cli(ctx, all, top, nostyle, nowarn, warn, project_dir):
-    """Lint the verilog code."""
 
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    _all = kwargs[ALL]
-    top_module = kwargs[TOP_MODULE]
-    nostyle = kwargs[NOSTYLE]
-    nowarn = kwargs[NOWARN]
-    warn = kwargs[WARN]
+warn_option = click.option(
+    "warn",  # Var name
+    "--warn",
+    type=str,
+    metavar="warn",
+    help="Enable specific warning(s).",
+)
+
+
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+# R0913: Too many arguments (7/5)
+# pylint: disable=R0913
+@click.command("lint", context_settings=util.context_settings())
+@click.pass_context
+@options.all_option_gen(
+    help="Enable all warnings, including code style warnings."
+)
+@options.top_module_option_gen()
+@nostyle_option
+@nowarn_option
+@warn_option
+@options.project_dir_option
+def cli(
+    ctx,
+    # Options
+    all_: bool,
+    top_module: str,
+    nostyle: bool,
+    nowarn: str,
+    warn: str,
+    project_dir: Path,
+):
+    """Lint the verilog code."""
 
     # -- Create the scons object
     scons = SCons(project_dir)
@@ -70,7 +75,7 @@ def cli(ctx, **kwargs):
     # -- Lint the project with the given parameters
     exit_code = scons.lint(
         {
-            "all": _all,
+            "all": all_,
             "top": top_module,
             "nostyle": nostyle,
             "nowarn": nowarn,

--- a/apio/commands/options.py
+++ b/apio/commands/options.py
@@ -9,94 +9,217 @@
 
 from pathlib import Path
 import click
+from apio import util
 
-# APIO command options in alphabetial order.
+
 # The design is based on the idea here https://stackoverflow.com/a/77732441.
-#
-# Each option is defined by two values:
-# 1. (UPPER CASE) The python key for the option value.
-# 2. (lower_case) The click decoration that defines the option.
+# It contains shared command line options in two forms, dynamic option
+# which can be customized for specific use cases and fixed static options
+# with fixed attributes. Options that are too specific to a single command
+# not not listed here and defined instead in the command itself.
+# Both type of options are listed in an alphabetical order.
 
-# -- Board
-BOARD = "board"
-board = click.option(
-    "-b",
-    "--board",
-    BOARD,
+
+# ----------------------------------
+# -- Customizeable option generators
+# ----------------------------------
+
+
+# W0622: Redefining built-in 'help'
+# pylint: disable=W0622
+def all_option_gen(*, help: str):
+    """Generate an --all option with given help text."""
+    return click.option(
+        "all_",  # Var name. Deconflicting from Python'g builtin 'all'.
+        "-a",
+        "--all",
+        is_flag=True,
+        help=help,
+    )
+
+
+# W0622: Redefining built-in 'help'
+# pylint: disable=W0622
+def force_option_gen(*, help: str):
+    """Generate a --force option with given help text."""
+    return click.option(
+        "force",  # Var name
+        "-f",
+        "--force",
+        is_flag=True,
+        help=help,
+    )
+
+
+# W0622: Redefining built-in 'help'
+# pylint: disable=W0622
+def list_option_gen(*, help: str):
+    """Generate a --list option with given help text."""
+    return click.option(
+        "list_",  # Var name. Deconflicting from python builtin 'list'.
+        "-l",
+        "--list",
+        is_flag=True,
+        help=help,
+    )
+
+
+# W0622: Redefining built-in 'help'
+# pylint: disable=W0622
+def board_option_gen(*, help: str = "Set the board."):
+    """Generate a --board option with given help text."""
+    return click.option(
+        "board",  # Var name.
+        "-b",
+        "--board",
+        type=str,
+        metavar="str",
+        help=help,
+    )
+
+
+# W0622: Redefining built-in 'help'
+# pylint: disable=W0622
+def top_module_option_gen(
+    *,
+    help: str = "Set the top level verilog module name (e.g. my_main).",
+):
+    """Generate a --top-module option with given help text."""
+    return click.option(
+        "top_module",  # Var name.
+        "-t",
+        "--top-module",
+        type=str,
+        metavar="name",
+        help=help,
+    )
+
+
+# ---------------------------
+# -- Static options
+# ---------------------------
+
+
+fpga_option = click.option(
+    "fpga",  # Var name.
+    "--fpga",
     type=str,
     metavar="str",
-    help="Set the board.",
+    help="Set the FPGA.",
 )
 
-# -- FPGA model.
-FPGA = "fpga"
-fpga = click.option(
-    "--fpga", FPGA, type=str, metavar="str", help="Set the FPGA."
+ftdi_id = click.option(
+    "ftdi_id",  # Var name.
+    "--ftdi-id",
+    type=str,
+    metavar="ftdi-id",
+    help="Set the FTDI id.",
 )
 
-# -- FPGA package.
-PACK = "pack"
-pack = click.option(
-    "--pack", PACK, type=str, metavar="str", help="Set the FPGA package."
+pack_option = click.option(
+    "pack",  # Var name
+    "--pack",
+    type=str,
+    metavar="str",
+    help="Set the FPGA package.",
 )
 
-# -- Project dir
-PROJECT_DIR = "project_dir"
-project_dir = click.option(
+
+platform_option = click.option(
+    "platform",  # Var name.
+    "-p",
+    "--platform",
+    type=click.Choice(util.PLATFORMS),
+    help=(
+        f"Set the platform [{', '.join(util.PLATFORMS)}] "
+        "(Advanced, for developers)."
+    ),
+)
+
+
+project_dir_option = click.option(
+    "project_dir",  # Var name.
     "-p",
     "--project-dir",
-    PROJECT_DIR,
     type=Path,
-    metavar="str",
+    metavar="path",
     help="Set the target directory for the project.",
 )
 
-# -- FPGA size.
-SIZE = "size"
-size = click.option(
-    "--size", SIZE, type=str, metavar="str", help="Set the FPGA type (1k/8k)."
+
+sayno = click.option(
+    "sayno",  # Var name.
+    "-n",
+    "--sayno",
+    is_flag=True,
+    help="Automatically answer NO to all the questions.",
 )
 
-# -- Top Verilog module.
-TOP_MODULE = "top_module"
-top_module = click.option(
-    "--top-module",
-    TOP_MODULE,
+sayyes = click.option(
+    "sayyes",  # Var name.
+    "-y",
+    "--sayyes",
+    is_flag=True,
+    help="Automatically answer YES to all the questions.",
+)
+
+serial_port_option = click.option(
+    "serial_port",  # Var name.
+    "--serial-port",
+    type=str,
+    metavar="serial-port",
+    help="Set the serial port.",
+)
+
+
+size_option = click.option(
+    "size",  # Var name
+    "--size",
     type=str,
     metavar="str",
-    help="Set the top level module (w/o .v ending) for build.",
+    help="Set the FPGA type (1k/8k).",
 )
 
-# -- FPGA type.
-TYPE = "type"
-type_ = click.option(
-    "--type", TYPE, type=str, metavar="str", help="Set the FPGA type (hx/lp)."
+
+testbench = click.option(
+    "testbench",  # Var name.
+    "-t",
+    "--testbench",
+    type=str,
+    metavar="file_name",
+    help="Set the name of the testbench file to use. E.g. my_module_tb.h",
 )
 
-# -- Verbose.
-VERBOSE = "verbose"
-verbose = click.option(
+
+type_option = click.option(
+    "type_",  # Var name. Deconflicting from Python's builtin 'type'.
+    "--type",
+    type=str,
+    metavar="str",
+    help="Set the FPGA type (hx/lp).",
+)
+
+
+verbose_option = click.option(
+    "verbose",  # Var name.
     "-v",
     "--verbose",
-    VERBOSE,
     is_flag=True,
     help="Show the entire output of the command.",
 )
 
-# -- Verbose place and route.
-VERBOSE_PNR = "verbose_pnr"
-verbose_pnr = click.option(
+
+verbose_pnr_option = click.option(
+    "verbose_pnr",  # Var name.
     "--verbose-pnr",
-    VERBOSE_PNR,
     is_flag=True,
     help="Show the pnr output of the command.",
 )
 
-# -- Verbose Yosys.
-VERBOSE_YOSYS = "verbose_yosys"
-verbose_yosys = click.option(
+
+verbose_yosys_option = click.option(
+    "verbose_yosys",  # Var name.
     "--verbose-yosys",
-    VERBOSE_YOSYS,
     is_flag=True,
     help="Show the yosys output of the command.",
 )

--- a/apio/commands/raw.py
+++ b/apio/commands/raw.py
@@ -11,10 +11,17 @@ import click
 from apio import util
 
 
+# ---------------------------
+# -- COMMAND
+# ---------------------------
 @click.command("raw", context_settings=util.context_settings())
 @click.pass_context
 @click.argument("cmd")
-def cli(ctx, cmd):
+def cli(
+    ctx,
+    # Arguments
+    cmd: str,
+):
     """Execute commands directly from the Apio packages"""
 
     exit_code = util.call(cmd)

--- a/apio/commands/sim.py
+++ b/apio/commands/sim.py
@@ -11,26 +11,23 @@ from pathlib import Path
 import click
 from apio.managers.scons import SCons
 from apio import util
+from apio.commands import options
 
 
+# ---------------------------
+# -- COMMAND
+# ---------------------------
 @click.command("sim", context_settings=util.context_settings())
 @click.pass_context
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="path",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-t",
-    "--testbench",
-    type=str,
-    metavar="testbench",
-    help="Specify the testbench file to simulate.",
-)
-def cli(ctx, project_dir, testbench):
-    """Launch the verilog simulation."""
+@options.project_dir_option
+@options.testbench
+def cli(
+    ctx,
+    # Options
+    project_dir: Path,
+    testbench: str,
+):
+    """Simulate a single module."""
 
     # -- Create the scons object
     scons = SCons(project_dir)

--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -13,48 +13,63 @@ from apio import util
 from apio.util import get_systype
 from apio.managers.system import System
 from apio.resources import Resources
+from apio.commands import options
+
+# ---------------------------
+# -- COMMAND SPECIFIC OPTIONS
+# ---------------------------
+lsftdi_option = click.option(
+    "lsftdi",  # Var name.
+    "--lsftdi",
+    is_flag=True,
+    help="List all connected FTDI devices.",
+)
+
+lsusb_option = click.option(
+    "lsusb",  # Var name.
+    "--lsusb",
+    is_flag=True,
+    help="List all connected USB devices.",
+)
+
+lsserial_option = click.option(
+    "lsserial",  # App name.
+    "--lsserial",
+    is_flag=True,
+    help="List all connected Serial devices.",
+)
+
+info_option = click.option(
+    "info",  # Var name.
+    "-i",
+    "--info",
+    is_flag=True,
+    help="Show system information.",
+)
 
 
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "system"  # -- Comand name
-PROJECT_DIR = "project_dir"  # -- Option
-LSFTDI = "lsftdi"  # -- Option
-LSUSB = "lsusb"  # -- Option
-LSSERIAL = "lsserial"  # -- Option
-INFO = "info"  # -- Option
-
-
-@click.command(CMD, context_settings=util.context_settings())
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+# R0913: Too many arguments (6/5)
+# pylint: disable=R0913
+@click.command("system", context_settings=util.context_settings())
 @click.pass_context
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="str",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    f"--{LSFTDI}", is_flag=True, help="List all connected FTDI devices."
-)
-@click.option(
-    f"--{LSUSB}", is_flag=True, help="List all connected USB devices."
-)
-@click.option(
-    f"--{LSSERIAL}", is_flag=True, help="List all connected Serial devices."
-)
-@click.option("-i", f"--{INFO}", is_flag=True, help="Show system information.")
-def cli(ctx, **kwargs):
-    # def cli(ctx, lsftdi, lsusb, lsserial, info):
+@options.project_dir_option
+@lsftdi_option
+@lsusb_option
+@lsserial_option
+@info_option
+def cli(
+    ctx,
+    # Options
+    project_dir: Path,
+    lsftdi: bool,
+    lsusb: bool,
+    lsserial: bool,
+    info: bool,
+):
     """System tools."""
-
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    lsftdi = kwargs[LSFTDI]
-    lsusb = kwargs[LSUSB]
-    lsserial = kwargs[LSSERIAL]
-    info = kwargs[INFO]
 
     # Load the various resource files.
     resources = Resources(project_dir=project_dir)

--- a/apio/commands/test.py
+++ b/apio/commands/test.py
@@ -11,38 +11,24 @@ from pathlib import Path
 import click
 from apio.managers.scons import SCons
 from apio import util
-
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "test"  # -- Comand name
-PROJECT_DIR = "project_dir"  # -- Option
-TESTBENCH = "testbench"  # -- Option
+from apio.commands import options
 
 
-@click.command(CMD, context_settings=util.context_settings())
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+@click.command("test", context_settings=util.context_settings())
 @click.pass_context
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="path",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-t",
-    f"--{TESTBENCH}",
-    type=str,
-    metavar="testbench",
-    help="Test only this testbench file.",
-)
-def cli(ctx, **kwargs):
+@options.project_dir_option
+@options.testbench
+def cli(
+    ctx,
+    # Options
+    project_dir: Path,
+    testbench: str,
+):
     # def cli(ctx, project_dir, testbench):
-    """Launch the verilog testbench testing."""
-
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    testbench = kwargs[TESTBENCH]
+    """Test all or a single verilog testbench module."""
 
     # -- Create the scons object
     scons = SCons(project_dir)

--- a/apio/commands/time.py
+++ b/apio/commands/time.py
@@ -11,74 +11,41 @@ from pathlib import Path
 import click
 from apio.managers.scons import SCons
 from apio import util
-
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "time"  # -- Comand name
-BOARD = "board"  # -- Option
-FPGA = "fpga"  # -- Option
-SIZE = "size"  # -- Option
-PACK = "pack"  # -- Option
-TYPE = "type"  # -- Option
-PROJECT_DIR = "project_dir"  # -- Option
-VERBOSE = "verbose"  # -- Option
-VERBOSE_YOSYS = "verbose_yosys"  # -- Option
-VERBOSE_PNR = "verbose_pnr"  # -- Option
-TOP_MODULE = "top_module"  # -- Option
+from apio.commands import options
 
 
+# ---------------------------
+# -- COMMAND
+# ---------------------------
 # R0801: Similar lines in 2 files
 # pylint: disable=R0801
-@click.command(CMD, context_settings=util.context_settings())
+# R0913: Too many arguments (10/5)
+# pylint: disable=R0913
+@click.command("time", context_settings=util.context_settings())
 @click.pass_context
-@click.option(
-    "-b", f"--{BOARD}", type=str, metavar="str", help="Set the board."
-)
-@click.option(f"--{FPGA}", type=str, metavar="str", help="Set the FPGA.")
-@click.option(
-    f"--{SIZE}", type=str, metavar="str", help="Set the FPGA type (1k/8k)."
-)
-@click.option(
-    f"--{TYPE}", type=str, metavar="str", help="Set the FPGA type (hx/lp)."
-)
-@click.option(
-    f"--{PACK}", type=str, metavar="str", help="Set the FPGA package."
-)
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="path",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-v",
-    f"--{VERBOSE}",
-    is_flag=True,
-    help="Show the entire output of the command.",
-)
-@click.option(
-    "--verbose-yosys",
-    is_flag=True,
-    help="Show the yosys output of the command.",
-)
-@click.option(
-    "--verbose-pnr", is_flag=True, help="Show the pnr output of the command."
-)
-def cli(ctx, **kwargs):
-    """Bitstream timing analysis."""
-
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    board = kwargs[BOARD]
-    fpga = kwargs[FPGA]
-    pack = kwargs[PACK]
-    _type = kwargs[TYPE]
-    size = kwargs[SIZE]
-    verbose = kwargs[VERBOSE]
-    verbose_yosys = kwargs[VERBOSE_YOSYS]
-    verbose_pnr = kwargs[VERBOSE_PNR]
+@options.board_option_gen()
+@options.fpga_option
+@options.size_option
+@options.type_option
+@options.pack_option
+@options.project_dir_option
+@options.verbose_option
+@options.verbose_yosys_option
+@options.verbose_pnr_option
+def cli(
+    ctx,
+    # Options
+    board: str,
+    fpga: str,
+    size: str,
+    type_: str,
+    pack: str,
+    project_dir: Path,
+    verbose: bool,
+    verbose_yosys: bool,
+    verbose_pnr: bool,
+):
+    """Analyze and design and report timing."""
 
     # -- Create the scons object
     scons = SCons(project_dir)
@@ -89,7 +56,7 @@ def cli(ctx, **kwargs):
             "board": board,
             "fpga": fpga,
             "size": size,
-            "type": _type,
+            "type": type_,
             "pack": pack,
             "verbose": {
                 "all": verbose,

--- a/apio/commands/upgrade.py
+++ b/apio/commands/upgrade.py
@@ -14,13 +14,10 @@ from apio.util import get_pypi_latest_version
 from apio import util
 
 
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "upgrade"  # -- Comand name
-
-
-@click.command(CMD, context_settings=util.context_settings())
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+@click.command("upgrade", context_settings=util.context_settings())
 @click.pass_context
 def cli(ctx):
     """Check the latest Apio version."""

--- a/apio/commands/upload.py
+++ b/apio/commands/upload.py
@@ -12,101 +12,60 @@ import click
 from apio.managers.scons import SCons
 from apio.managers.drivers import Drivers
 from apio import util
+from apio.commands import options
 
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "upload"  # -- Comand name
-BOARD = "board"  # -- Option
-PROJECT_DIR = "project_dir"  # -- Option
-SERIAL_PORT = "serial_port"  # -- Option
-FTDI_ID = "ftdi_id"  # -- Option
-SRAM = "sram"  # -- Option
-FLASH = "flash"  # -- Option
-VERBOSE = "verbose"  # -- Option
-VERBOSE_YOSYS = "verbose_yosys"  # -- Option
-VERBOSE_PNR = "verbose_pnr"  # -- Option
-TOP_MODULE = "top_module"  # -- Option
+
+# ---------------------------
+# -- COMMAND SPECIFIC OPTIONS
+# ---------------------------
+sram_option = click.option(
+    "sram",  # Var name.
+    "-s",
+    "--sram",
+    is_flag=True,
+    help="Perform SRAM programming.",
+)
+
+flash_option = click.option(
+    "flash",  # Var name.
+    "-f",
+    "--flash",
+    is_flag=True,
+    help="Perform FLASH programming.",
+)
 
 
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
 # R0914: Too many local variables (16/15) (too-many-locals)
 # pylint: disable=R0914
-@click.command(CMD, context_settings=util.context_settings())
+@click.command("upload", context_settings=util.context_settings())
 @click.pass_context
-@click.option(
-    "-b", f"--{BOARD}", type=str, metavar="board", help="Set the board."
-)
-@click.option(
-    "--serial-port",
-    type=str,
-    metavar="serial-port",
-    help="Set the serial port.",
-)
-@click.option(
-    "--ftdi-id", type=str, metavar="ftdi-id", help="Set the FTDI id."
-)
-@click.option(
-    "-s", f"--{SRAM}", is_flag=True, help="Perform SRAM programming."
-)
-@click.option(
-    "-f", f"--{FLASH}", is_flag=True, help="Perform FLASH programming."
-)
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="path",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-v",
-    f"--{VERBOSE}",
-    is_flag=True,
-    help="Show the entire output of the command.",
-)
-@click.option(
-    "--verbose-yosys",
-    is_flag=True,
-    help="Show the yosys output of the command.",
-)
-@click.option(
-    "--verbose-pnr", is_flag=True, help="Show the pnr output of the command."
-)
-@click.option(
-    "--top-module",
-    type=str,
-    metavar="top_module",
-    help="Set the top level module (w/o .v ending) for build.",
-)
-def cli(ctx, **kwargs):
-    # def cli(
-    #     ctx,
-    #     board: str,  # -- Board name
-    #     serial_port: str,  # -- Serial port name
-    #     ftdi_id: str,  # -- ftdi id
-    #     sram: bool,  # -- Perform SRAM programming
-    #     flash: bool,  # -- Perform Flash programming
-    #     project_dir,
-    #     verbose,
-    #     verbose_yosys,
-    #     verbose_pnr,
-    #     top_module,
-    # ):
+@options.board_option_gen()
+@options.serial_port_option
+@options.ftdi_id
+@sram_option
+@flash_option
+@options.project_dir_option
+@options.verbose_option
+@options.verbose_yosys_option
+@options.verbose_pnr_option
+@options.top_module_option_gen()
+def cli(
+    ctx,
+    # Options
+    board: str,
+    serial_port: str,
+    ftdi_id: str,
+    sram: bool,
+    flash: bool,
+    project_dir: Path,
+    verbose: bool,
+    verbose_yosys: bool,
+    verbose_pnr: bool,
+    top_module: str,
+):
     """Upload the bitstream to the FPGA."""
-
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    board = kwargs[BOARD]
-    verbose = kwargs[VERBOSE]
-    verbose_yosys = kwargs[VERBOSE_YOSYS]
-    verbose_pnr = kwargs[VERBOSE_PNR]
-    top_module = kwargs[TOP_MODULE]
-    serial_port = kwargs[SERIAL_PORT]
-    ftdi_id = kwargs[FTDI_ID]
-    sram = kwargs[SRAM]
-    flash = kwargs[FLASH]
 
     # -- Create a drivers object
     drivers = Drivers()

--- a/apio/commands/verify.py
+++ b/apio/commands/verify.py
@@ -11,41 +11,25 @@ from pathlib import Path
 import click
 from apio.managers.scons import SCons
 from apio import util
-
-# ------------------
-# -- CONSTANTS
-# ------------------
-CMD = "verify"  # -- Comand name
-BOARD = "board"  # -- Option
-VERBOSE = "verbose"  # -- Option
-PROJECT_DIR = "project_dir"  # -- Option
+from apio.commands import options
 
 
-@click.command(CMD, context_settings=util.context_settings())
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+@click.command("verify", context_settings=util.context_settings())
 @click.pass_context
-@click.option(
-    "-p",
-    "--project-dir",
-    type=Path,
-    metavar="path",
-    help="Set the target directory for the project.",
-)
-@click.option(
-    "-b", f"--{BOARD}", type=str, metavar="board", help="Set the board."
-)
-@click.option(
-    "-v",
-    f"--{VERBOSE}",
-    is_flag=True,
-    help="Show the entire output of the command.",
-)
-def cli(ctx, **kwargs):
-    """Verify the verilog code."""
-
-    # -- Extract the arguments
-    project_dir = kwargs[PROJECT_DIR]
-    board = kwargs[BOARD]
-    verbose = kwargs[VERBOSE]
+@options.project_dir_option
+@options.board_option_gen()
+@options.verbose_option
+def cli(
+    ctx,
+    # Options
+    project_dir: Path,
+    board: str,
+    verbose: bool,
+):
+    """Verify project's verilog code."""
 
     # -- Crete the scons object
     scons = SCons(project_dir)


### PR DESCRIPTION
Shared commands are now in apio/commands/options.py and command specific options are in the respective command files. Also cleaned up a few of the commands and options help texts.

This pull request is intended to be refactoring only with no semantic change.