### PR TITLE
Now preserving leading whitespaces in stderr and stdout of subprocesses

### DIFF
--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -11,8 +11,8 @@
 # --------------------------------------------
 
 import string
-import click
 import re
+import click
 
 from apio import util
 
@@ -128,7 +128,8 @@ def cli(ctx):
         # -- We later split the command lines into command groups.
         index = help_lines.index("Commands:")
         header_lines = help_lines[:index]
-        command_lines = help_lines[index + 1 :]
+        index += 1  # Skip the Commands: line.
+        command_lines = help_lines[index:]
 
         # -- Select project commands:
         project_help = select_commands_help(

--- a/apio/util.py
+++ b/apio/util.py
@@ -86,7 +86,8 @@ class AsyncPipe(Thread):
         """DOC: TODO"""
 
         for line in iter(self._pipe_reader.readline, ""):
-            line = line.strip()
+            # We do preserve trailing whitespace and indentation.
+            line = line.rstrip()
             self._buffer.append(line)
             if self.outcallback:
                 self.outcallback(line)


### PR DESCRIPTION
Now preserving leading whitespace in stderr and stdout of subprocesses. This improved readability in tools output that include indentation.  Also, fixed a lint warning in __main__.py.

``apio lint`` output before:
<img width="673" alt="image" src="https://github.com/user-attachments/assets/db64a939-1ba1-4138-82c5-caf905b0c325">


``apio lint`` output now:
<img width="672" alt="image" src="https://github.com/user-attachments/assets/467e88be-1cc7-4339-bd7c-ff3be005a3ee">
