### PR TITLE
Fixed extra_args issue with dfu-util programmer

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -12,11 +12,12 @@ make tox
 
 ## Running an individual APIO test
 
-Run from the repo root. Replace with the path to the desire test.
+Run from the repo root. Replace with the path to the desire test. Running ``pytest`` alone runs all the tests.
 
 ```shell
-test/code_commands/test_build.py
+pytest test/code_commands/test_build.py
 ```
+
 
 ## Running APIO in a debugger
 

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -170,7 +170,9 @@ build_target = env.Alias('build', bitstream_target)
 AlwaysBuild(build_target)
 
 # -- Upload the bitstream into FPGA
-upload_target = env.Alias('upload', bitstream_target, '{0} $SOURCE'.format(PROG))
+assert "${SOURCE}" in PROG
+programmer = PROG.replace("${SOURCE}", "$SOURCE")
+upload_target = env.Alias('upload', bitstream_target)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -178,7 +178,9 @@ if(VERBOSE_ALL or VERBOSE_PNR):
     AlwaysBuild(asc_target)
 
 # -- Upload the bitstream into FPGA
-upload_target = env.Alias('upload', bitstream_target, '{0} $SOURCE'.format(PROG))
+assert "${SOURCE}" in PROG
+programmer = PROG.replace("${SOURCE}", "$SOURCE")
+upload_target = env.Alias('upload', bitstream_target, programmer)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -175,7 +175,9 @@ if(VERBOSE_ALL or VERBOSE_PNR):
     AlwaysBuild(asc_target)
 
 # -- Upload the bitstream into FPGA
-upload_target = env.Alias('upload', bitstream_target, '{0} $SOURCE'.format(PROG))
+assert "${SOURCE}" in PROG
+programmer = PROG.replace("${SOURCE}", "$SOURCE")
+upload_target = env.Alias('upload', bitstream_target, programmer)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time


### PR DESCRIPTION
Fixed issue #377.  Now extra args are added after the bitstream file name. This is done by passing to scons a ${SOURCE} placeholder that indicates where to insert the bitstream file name.