### PR TITLE
Updated the commands help texts.

### DIFF
--- a/apio/commands/boards.py
+++ b/apio/commands/boards.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.resources import Resources
 from apio import util
 from apio.commands import options
@@ -21,7 +22,7 @@ list_fpgas_option = click.option(
     "-f",
     "--fpga",
     is_flag=True,
-    help="List all supported FPGA chips.",
+    help="List supported FPGA chips.",
 )
 
 
@@ -29,20 +30,19 @@ list_fpgas_option = click.option(
 # -- COMMAND
 # ---------------------------
 HELP = """
-The apio boards commands provides information about the FPAG boards that are
-supported by apio. To view the list of all supported boards use the command
+The boards commands lists the FPGA boards and chips that are
+supported by apio.
+The commands is typically used in the root directory
+of the project that that contains the apio.ini file.
 
-  apio boards --list
+\b
+Examples:
+  apio boards --list  # List boards
+  apio boards --fpga  # List FPGAs
 
-To list the supported FPGAs, replace the --list option with the
---fpga option.
-
-Hint: apio comes with example projects for some boards. See the apio examples
-command for more information.
-
-Advanced: Boards with wide availability can be added by contacting the
-apio team. You can also add a custon one-of board definition to your apio
-project by placing a custom boards.json file in your apio project.
+[Advanced] Boards with wide availability can be added by contacting the
+apio team. A custom one-of board can be added to your project by
+placing a boards.json file next to apio.ini.
 """
 
 
@@ -54,10 +54,10 @@ project by placing a custom boards.json file in your apio project.
 )
 @click.pass_context
 @options.project_dir_option
-@options.list_option_gen(help="List all supported FPGA boards.")
+@options.list_option_gen(help="List supported FPGA boards.")
 @list_fpgas_option
 def cli(
-    ctx,
+    ctx: Context,
     # Options
     project_dir: Path,
     list_: bool,
@@ -66,6 +66,12 @@ def cli(
     """Implements the 'boards' command which lists supported boards
     and FPGAs.
     """
+
+    # pylint: disable=fixme
+    # TODO: Exit with error status if both --list and --fpga are specified.
+
+    # pylint: disable=fixme
+    # TODO: rename options --list, --fpga to --boards, --fpgas.
 
     # -- Access to the apio resources
     resources = Resources(project_dir=project_dir)

--- a/apio/commands/build.py
+++ b/apio/commands/build.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.scons import SCons
 from apio import util
 from apio.commands import options
@@ -17,35 +18,61 @@ from apio.commands import options
 # ---------------------------
 # -- COMMAND
 # ---------------------------
+
+HELP = """
+The build command reads the project source files
+and generates a bitstream file that you can uploaded to your FPGA.
+The commands is typically used in the root directory
+of the project that that contains the apio.ini file.
+
+\b
+Examples:
+  apio build
+  apio build -v
+
+[Note] The flags marked with (deprecated) are not recomanded.
+Instead, use an apio.ini project config file and if neaded, add
+to the project custom boards.json and fpga.json files.
+"""
+
+
 # R0913: Too many arguments (11/5)
 # pylint: disable=R0913
-@click.command("build", context_settings=util.context_settings())
+@click.command(
+    "build",
+    short_help="Synthesize the bitstream.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
-@options.board_option_gen()
-@options.fpga_option
-@options.size_option
-@options.type_option
-@options.pack_option
 @options.project_dir_option
 @options.verbose_option
 @options.verbose_yosys_option
 @options.verbose_pnr_option
 @options.top_module_option_gen()
+@options.board_option_gen()
+@options.fpga_option
+@options.size_option
+@options.type_option
+@options.pack_option
 def cli(
-    ctx,
+    ctx: Context,
     # Options
+    project_dir: Path,
+    verbose: bool,
+    verbose_yosys: bool,
+    verbose_pnr: bool,
+    # Deprecated options
+    top_module: str,
     board: str,
     fpga: str,
     size: str,
     type_: str,
     pack: str,
-    project_dir: Path,
-    verbose: bool,
-    verbose_yosys: bool,
-    verbose_pnr: bool,
-    top_module: str,
 ):
-    """Synthesize the bitstream."""
+    """Implements the apio build command. It invokes the toolchain
+    to syntesize the source files into a bitstream file.
+    """
 
     # The bitstream is generated from the source files (verilog)
     # by means of the scons tool

--- a/apio/commands/clean.py
+++ b/apio/commands/clean.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.scons import SCons
 from apio import util
 from apio.commands import options
@@ -18,12 +19,20 @@ from apio.commands import options
 # -- COMMAND
 # ---------------------------
 HELP = """
-The apio clean command deletes the files that were generated
-in the FPGA project directory by previous apio commands.  For example:
+The clean command deletes the temporary files that were generated
+in the project directory by previous apio commands.
+The commands is typically used in the root directory
+of the project that that contains the apio.ini file.
 
+\b
+Example:
   apio clean
 
-Hint: if you are using a git repository, add a .gitignore file with
+[Note] The flags marked with (deprecated) are not recomanded.
+Instead, use an apio.ini project config file and if neaded, add
+to the project custom boards.json and fpga.json files.
+
+[Hint] If you are using a git repository, add a .gitignore file with
 the temporary apio file names.
 """
 
@@ -36,14 +45,15 @@ the temporary apio file names.
 )
 @click.pass_context
 @options.project_dir_option
-@options.board_option_gen()
 @options.verbose_option
+@options.board_option_gen()
 def cli(
-    ctx,
+    ctx: Context,
     # Options
     project_dir: Path,
-    board: str,
     verbose: bool,
+    # Deprecated options.
+    board: str,
 ):
     """Implements the apio clean command. It deletes temporary files generated
     by apio commands.

--- a/apio/commands/drivers.py
+++ b/apio/commands/drivers.py
@@ -8,6 +8,7 @@
 """Main implementation of APIO DRIVERS command"""
 
 import click
+from click.core import Context
 from apio.managers.drivers import Drivers
 from apio import util
 
@@ -46,24 +47,49 @@ serial_disable_option = click.option(
 # ---------------------------
 # -- COMMAND
 # ---------------------------
-@click.command("drivers", context_settings=util.context_settings())
+
+HELP = """
+The drivers command allows to install or uninstall operating system
+drivers that are used to program the FPGA boards. This command is global
+and affects all the projects on the local host.
+
+\b
+Examples:
+  apio drivers --ftdi_enable     # Install FTDI driver
+  apio drivers --ftdi_disable    # Uninstall FTDI driver
+  apio drivers --serial_enable   # Install serial driver
+  apio drivers --serial_disable  # Uninstall serial driver
+
+  Do not specify more than flag per command invocation.
+"""
+
+
+@click.command(
+    "drivers",
+    short_help="Manage the operating system drivers.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
 @frdi_enable_option
 @ftdi_disable_option
 @serial_enable_option
 @serial_disable_option
 def cli(
-    ctx,
+    ctx: Context,
     # Options:
     ftdi_enable: bool,
     ftdi_disable: bool,
     serial_enable: bool,
     serial_disable: bool,
 ):
-    """Manage FPGA boards drivers."""
+    """Implements the drivers command."""
 
     # -- Access to the Drivers
     drivers = Drivers()
+
+    # pylint: disable=fixme
+    # TODO: Exit with an error if more than one flag is is specified.
 
     # -- FTDI enable option
     if ftdi_enable:

--- a/apio/commands/examples.py
+++ b/apio/commands/examples.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.examples import Examples
 from apio import util
 from apio.commands import options
@@ -38,9 +39,27 @@ files_option = click.option(
 # ---------------------------
 # -- COMMAND
 # ---------------------------
+HELP = """
+The examples command allows to list the project examples provided by api
+and to copy them to a local directory. Each examples is identified by
+board/name where board is the board id and name is the example name.
+
+\b
+Examples:
+  apio example --list             # List all examples
+  apio examples -d icezum         # Fetch all board examples
+  apio examples -d icezum/leds    # Fetch a single board example
+"""
+
+
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
-@click.command("examples", context_settings=util.context_settings())
+@click.command(
+    "examples",
+    short_help="List and fetch apio examples.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
 @options.list_option_gen(help="List all available examples.")
 @dir_option
@@ -48,7 +67,7 @@ files_option = click.option(
 @options.project_dir_option
 @options.sayno
 def cli(
-    ctx,
+    ctx: Context,
     # Options
     list_: bool,
     dir_: str,

--- a/apio/commands/graph.py
+++ b/apio/commands/graph.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.scons import SCons
 from apio import util
 from apio.commands import options
@@ -17,19 +18,44 @@ from apio.commands import options
 # ---------------------------
 # -- COMMAND
 # ---------------------------
-@click.command("graph", context_settings=util.context_settings())
+HELP = """
+The graph command generates a graphical representation of the
+verilog code in the project.
+The commands is typically used in the root directory
+of the project that that contains the apio.ini file.
+
+\b
+Examples:
+  apio graph
+
+The graph command generates the graph in .dot format and then invokes
+the dot command from the path to convert it to a .svg format. The dot
+command is not included with the apio distribution and needed to be
+installed seperatly. See https://graphviz.org for more details.
+
+[Hint] If you need the graph in other formats, convert the .dot file
+to the desired format using the dot command.
+"""
+
+
+@click.command(
+    "graph",
+    short_help="Generate a visual graph of the code.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
 @options.project_dir_option
-@options.verbose_option
 @options.top_module_option_gen()
+@options.verbose_option
 def cli(
-    ctx,
+    ctx: Context,
     # Options
     project_dir: Path,
     verbose: bool,
     top_module: str,
 ):
-    """Generate a visual graph of the verilog code."""
+    """Implements the apio graph command."""
 
     # -- Crete the scons object
     scons = SCons(project_dir)

--- a/apio/commands/init.py
+++ b/apio/commands/init.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.project import Project
 from apio import util
 from apio.commands import options
@@ -22,33 +23,55 @@ scons_option = click.option(
     "-s",
     "--scons",
     is_flag=True,
-    help="Create default SConstruct file.",
+    help="(Advanced, for developers) Create default SConstruct file.",
 )
 
 
 # ---------------------------
 # -- COMMAND
 # ---------------------------
+HELP = """
+[Note] This command is DEPRECATED. To create a new project use the
+examples command and fetch an example of your FPGA board.
+To modify the configuration of an existing project, edit its
+apio.ini file manually.
+
+[Developers] To develope an SConstruct file either symlink the
+pip apio package to the apio directory of your dev directory
+(recommanded), or copy SConstruct to the project dir and it will
+be fetched from there (make sure copy the correct SConstruct file for
+your FPGA board)
+
+The command is preserved for now to backward compatibility and
+may be eliminated in a future release.
+"""
+
+
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
-@click.command("init", context_settings=util.context_settings())
+@click.command(
+    "init",
+    short_help="(deprecated) Manage apio projects.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
 @options.board_option_gen(help="Create init file with the selected board.")
 @options.top_module_option_gen(help="Set the top_module in the init file")
-@scons_option
 @options.project_dir_option
 @options.sayyes
+@scons_option
 def cli(
-    ctx,
+    ctx: Context,
     # Options
     board: str,
     top_module: str,
-    scons: bool,
     project_dir: Path,
     sayyes: bool,
+    scons: bool,
 ):
     # def cli(ctx, board, top_module, scons, project_dir, sayyes):
-    """Manage apio projects."""
+    """[deprecated] Manage apio projects."""
 
     # -- Create a project
     project = Project(project_dir)

--- a/apio/commands/install.py
+++ b/apio/commands/install.py
@@ -8,7 +8,9 @@
 """Main implementation of APIO INSTALL command"""
 
 from pathlib import Path
+from typing import Tuple
 import click
+from click.core import Context
 from apio.managers.installer import Installer, list_packages
 from apio.resources import Resources
 from apio import util
@@ -38,28 +40,49 @@ def install_packages(
 # ---------------------------
 # -- COMMAND
 # ---------------------------
+HELP = """
+The install command lists and installs the apio packages.
+
+\b
+Examples:
+  apio install --list    # List packages
+  apio install --all     # Install all packages
+  apio install --all -f  # Force the re/installation of all packages
+  apio install examples  # Install the examples package
+
+For packages uninstallation see the apio uninstall command.
+"""
+
+
 # R0913: Too many arguments (7/5)
 # pylint: disable=R0913
-@click.command("install", context_settings=util.context_settings())
+@click.command(
+    "install",
+    short_help="Install apio packages.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
-@click.argument("packages", nargs=-1)
-@options.project_dir_option
-@options.all_option_gen(help="Install all packages.")
+@click.argument("packages", nargs=-1, required=False)
 @options.list_option_gen(help="List all available packages.")
+@options.all_option_gen(help="Install all packages.")
 @options.force_option_gen(help="Force the packages installation.")
+@options.project_dir_option
 @options.platform_option
 def cli(
-    ctx,
+    ctx: Context,
     # Arguments
-    packages,
+    packages: Tuple[str],
     # Options
-    project_dir: Path,
-    all_: bool,
     list_: bool,
+    all_: bool,
     force: bool,
     platform: str,
+    project_dir: Path,
 ):
-    """Install apio packages."""
+    """Implements the install command which allows to
+    manage the installation of apio packages.
+    """
 
     # -- Load the resources.
     resources = Resources(platform=platform, project_dir=project_dir)

--- a/apio/commands/lint.py
+++ b/apio/commands/lint.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.scons import SCons
 from apio import util
 from apio.commands import options
@@ -45,20 +46,41 @@ warn_option = click.option(
 # ---------------------------
 # -- COMMAND
 # ---------------------------
+HELP = """
+The lint command scans the project's
+verilog code and flags errors, inconsistencies, and style violations,
+and is a useful tool for improving the code quality. The command uses
+the verilator tool which is installed as park of the apio installation.
+The commands is typically used in the root directory
+of the project that that contains the apio.ini file.
+
+\b
+Examples:
+  apio lint
+
+[Note] The flags marked with (deprecated) are not recomanded for use.
+"""
+
+
 # R0913: Too many arguments (7/5)
 # pylint: disable=R0913
-@click.command("lint", context_settings=util.context_settings())
+@click.command(
+    "lint",
+    short_help="Lint the verilog code.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
 @options.all_option_gen(
     help="Enable all warnings, including code style warnings."
 )
-@options.top_module_option_gen()
 @nostyle_option
 @nowarn_option
 @warn_option
 @options.project_dir_option
+@options.top_module_option_gen()
 def cli(
-    ctx,
+    ctx: Context,
     # Options
     all_: bool,
     top_module: str,

--- a/apio/commands/options.py
+++ b/apio/commands/options.py
@@ -66,7 +66,7 @@ def list_option_gen(*, help: str):
 
 # W0622: Redefining built-in 'help'
 # pylint: disable=W0622
-def board_option_gen(*, help: str = "Set the board."):
+def board_option_gen(*, help: str = "(deprecated) Set the board."):
     """Generate a --board option with given help text."""
     return click.option(
         "board",  # Var name.
@@ -82,7 +82,7 @@ def board_option_gen(*, help: str = "Set the board."):
 # pylint: disable=W0622
 def top_module_option_gen(
     *,
-    help: str = "Set the top level verilog module name (e.g. my_main).",
+    help: str = "(deprecated) Set the top level module name.",
 ):
     """Generate a --top-module option with given help text."""
     return click.option(
@@ -105,7 +105,7 @@ fpga_option = click.option(
     "--fpga",
     type=str,
     metavar="str",
-    help="Set the FPGA.",
+    help="(deprecated) Set the FPGA.",
 )
 
 ftdi_id = click.option(
@@ -121,7 +121,7 @@ pack_option = click.option(
     "--pack",
     type=str,
     metavar="str",
-    help="Set the FPGA package.",
+    help="(deprecated) Set the FPGA package.",
 )
 
 
@@ -130,10 +130,7 @@ platform_option = click.option(
     "-p",
     "--platform",
     type=click.Choice(util.PLATFORMS),
-    help=(
-        f"Set the platform [{', '.join(util.PLATFORMS)}] "
-        "(Advanced, for developers)."
-    ),
+    help=("(Advanced, for developers) Set the platform."),
 )
 
 
@@ -143,7 +140,7 @@ project_dir_option = click.option(
     "--project-dir",
     type=Path,
     metavar="path",
-    help="Set the target directory for the project.",
+    help="Set the root directory for the project.",
 )
 
 
@@ -177,17 +174,7 @@ size_option = click.option(
     "--size",
     type=str,
     metavar="str",
-    help="Set the FPGA type (1k/8k).",
-)
-
-
-testbench = click.option(
-    "testbench",  # Var name.
-    "-t",
-    "--testbench",
-    type=str,
-    metavar="file_name",
-    help="Set the name of the testbench file to use. E.g. my_module_tb.h",
+    help="(deprecated) Set the FPGA type (1k/8k).",
 )
 
 
@@ -196,7 +183,7 @@ type_option = click.option(
     "--type",
     type=str,
     metavar="str",
-    help="Set the FPGA type (hx/lp).",
+    help="(deprecated) Set the FPGA type (hx/lp).",
 )
 
 
@@ -213,7 +200,7 @@ verbose_pnr_option = click.option(
     "verbose_pnr",  # Var name.
     "--verbose-pnr",
     is_flag=True,
-    help="Show the pnr output of the command.",
+    help="Show the pnr output.",
 )
 
 
@@ -221,5 +208,5 @@ verbose_yosys_option = click.option(
     "verbose_yosys",  # Var name.
     "--verbose-yosys",
     is_flag=True,
-    help="Show the yosys output of the command.",
+    help="Show the yosys output.",
 )

--- a/apio/commands/raw.py
+++ b/apio/commands/raw.py
@@ -8,21 +8,46 @@
 """Main implementation of APIO RAW command"""
 
 import click
+from click.core import Context
 from apio import util
 
 
 # ---------------------------
 # -- COMMAND
 # ---------------------------
-@click.command("raw", context_settings=util.context_settings())
+HELP = """
+The raw command allows to bypass  apio and run underlying
+tools directly. This is an advanced command that requires familiarity
+with the underlying tools.
+
+\b
+Examples:
+  apio raw "yosys --version"                          # yosys version
+  apio raw "nextpnr-ice40 --version"                  # nextpnr version
+  apio raw "yosys -p 'read_verilog leds.v; show' -q"  # Graph a module
+  apio raw "verilator --lint-only  leds.v"            # lint a module
+
+[Note] If you find a raw command that would benefit other apio users
+consider suggesting it as an apio feature request.
+"""
+
+
+@click.command(
+    "raw",
+    short_help="Execute commands directly from the Apio packages.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
 @click.argument("cmd")
 def cli(
-    ctx,
+    ctx: Context,
     # Arguments
     cmd: str,
 ):
-    """Execute commands directly from the Apio packages"""
+    """Implements the apio raw command which executes user
+    specified commands from apio installed tools.
+    """
 
     exit_code = util.call(cmd)
     ctx.exit(exit_code)

--- a/apio/commands/sim.py
+++ b/apio/commands/sim.py
@@ -18,19 +18,22 @@ from apio.commands import options
 # ---------------------------
 
 HELP = """
-The apio sim command simulates a given testbench file and shows
-the simulation results a GTKWave graphical window. A typical invocation
-is done in the PFGA project directory where the apio.ini file and the verilog
-source files resides. The command accepts the testbench file name as
-an argument. For example:
+The sim command simulates a testbench file and shows
+the simulation results a GTKWave graphical window.
+The commands is typically used in the root directory
+of the project that that contains the apio.ini file and it
+accepts the testbench file name as an argument. For example:
 
+\b
+Example:
   apio sim my_module_tb.v
 
-The apio sim command defines the verilog macro INTERACTIVE_SIM. The
-presernce of this macro allows testbenches to continue and display the
-simulation signals instead of aborting the simulation.
+The sim command defines the macros VCD_OUTPUT and INTERACTIVE_SIM
+that can be used by the testbench. For a sample testbench that
+uses those macro see the example at
+https://github.com/FPGAwars/apio-examples/tree/master/upduino31/testbench
 
-Hint: when you configure the signals in GTKWave, you can save the
+[Hint] when you configure the signals in GTKWave, you can save the
 configuration for future invocations.
 """
 
@@ -42,7 +45,7 @@ configuration for future invocations.
     context_settings=util.context_settings(),
 )
 @click.pass_context
-@click.argument("testbench", nargs=1)
+@click.argument("testbench", nargs=1, required=True)
 @options.project_dir_option
 def cli(
     ctx,

--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio import util
 from apio.util import get_systype
 from apio.managers.system import System
@@ -44,16 +45,34 @@ info_option = click.option(
     "-i",
     "--info",
     is_flag=True,
-    help="Show system information.",
+    help="Show platform id.",
 )
 
 
 # ---------------------------
 # -- COMMAND
 # ---------------------------
+HELP = """
+The system command provides system info that help diagnosing apio
+installation and connectivity issue.
+
+\b
+Examples:
+  apio system --lsftdi    # List FTDI devices
+  apio system --lsusb     # List USB devices
+  apio system --lsserial  # List serial devices
+  apio system --info      # Show platform id
+"""
+
+
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
-@click.command("system", context_settings=util.context_settings())
+@click.command(
+    "system",
+    short_help="Provides system info.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
 @options.project_dir_option
 @lsftdi_option
@@ -61,7 +80,7 @@ info_option = click.option(
 @lsserial_option
 @info_option
 def cli(
-    ctx,
+    ctx: Context,
     # Options
     project_dir: Path,
     lsftdi: bool,
@@ -69,7 +88,8 @@ def cli(
     lsserial: bool,
     info: bool,
 ):
-    """System tools."""
+    """Implements the system command. This command executes assorted
+    system tools"""
 
     # Load the various resource files.
     resources = Resources(project_dir=project_dir)

--- a/apio/commands/test.py
+++ b/apio/commands/test.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.scons import SCons
 from apio import util
 from apio.commands import options
@@ -17,21 +18,48 @@ from apio.commands import options
 # ---------------------------
 # -- COMMAND
 # ---------------------------
-@click.command("test", context_settings=util.context_settings())
+HELP = """
+The sim command simulates one or all the testbenches in the project
+and is useful for automatic unit testing of the code. Testbenches
+are expected to exist with the $fatal directive if any error is
+detected. The commands is typically used in the root directory
+of the project that that contains the apio.ini.
+
+\b
+Examples
+  apio test my_module_tb.v  # Run a single testbench
+  apio test                 # Run all *_tb.v testbenches.
+
+For a sample testbench that is compatible with apio see the
+example at
+https://github.com/FPGAwars/apio-examples/tree/master/upduino31/testbench
+
+[Hint] To simulate the testbench with a graphical visualizaiton of the
+signals see the apio sim command.
+"""
+
+
+@click.command(
+    "test",
+    short_help="Test all or a single verilog testbench module.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
+@click.argument("testbench_file", nargs=1, required=False)
 @options.project_dir_option
-@options.testbench
+# @options.testbench
 def cli(
-    ctx,
+    ctx: Context,
+    # Arguments
+    testbench_file: str,
     # Options
     project_dir: Path,
-    testbench: str,
 ):
-    # def cli(ctx, project_dir, testbench):
-    """Test all or a single verilog testbench module."""
+    """Implements the test command."""
 
     # -- Create the scons object
     scons = SCons(project_dir)
 
-    exit_code = scons.test({"testbench": testbench})
+    exit_code = scons.test({"testbench": testbench_file})
     ctx.exit(exit_code)

--- a/apio/commands/time.py
+++ b/apio/commands/time.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.scons import SCons
 from apio import util
 from apio.commands import options
@@ -17,33 +18,60 @@ from apio.commands import options
 # ---------------------------
 # -- COMMAND
 # ---------------------------
+HELP = """
+The time command analyzes
+and reports the timing of the design. It is useful to determine the
+maximal clock rate that the FPGA can handle with this design. For more
+detailed timing information, inspect the file 'hardware.rpt' that the
+command generates.
+The commands is typically used in the root directory
+of the project that that contains the apio.ini file.
+
+\b
+Examples:
+  apio time
+
+[Note] The flags marked with (deprecated) are not recomanded.
+Instead, use an apio.ini project config file and if neaded, add
+to the project custom boards.json and fpga.json files.
+"""
+
+
 # R0801: Similar lines in 2 files
 # pylint: disable=R0801
 # R0913: Too many arguments (10/5)
 # pylint: disable=R0913
-@click.command("time", context_settings=util.context_settings())
+@click.command(
+    "time",
+    short_help="Report design timing.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
+@options.project_dir_option
+@options.verbose_option
+@options.verbose_yosys_option
+@options.verbose_pnr_option
+@options.top_module_option_gen()
 @options.board_option_gen()
 @options.fpga_option
 @options.size_option
 @options.type_option
 @options.pack_option
-@options.project_dir_option
-@options.verbose_option
-@options.verbose_yosys_option
-@options.verbose_pnr_option
 def cli(
-    ctx,
+    ctx: Context,
     # Options
+    project_dir: Path,
+    verbose: bool,
+    verbose_yosys: bool,
+    verbose_pnr: bool,
+    # Deprecated options
+    top_module: str,
     board: str,
     fpga: str,
     size: str,
     type_: str,
     pack: str,
-    project_dir: Path,
-    verbose: bool,
-    verbose_yosys: bool,
-    verbose_pnr: bool,
 ):
     """Analyze the design and report timing."""
 
@@ -63,6 +91,7 @@ def cli(
                 "yosys": verbose_yosys,
                 "pnr": verbose_pnr,
             },
+            "top-module": top_module,
         }
     )
 

--- a/apio/commands/uninstall.py
+++ b/apio/commands/uninstall.py
@@ -8,7 +8,9 @@
 """Main implementation of APIO UNINSTALL command"""
 
 from pathlib import Path
+from typing import Tuple
 import click
+from click.core import Context
 from apio.managers.installer import Installer, list_packages
 from apio.profile import Profile
 from apio import util
@@ -40,26 +42,44 @@ def _uninstall(packages: list, platform: str, resources: Resources):
 # ---------------------------
 # -- COMMAND
 # ---------------------------
+HELP = """
+The uninstall command lists and installs apio packages.
+
+\b
+Examples:
+  apio uninstall --list    # List packages
+  apio uninstall --all     # Uninstall all packages
+  apio uninstall examples  # Uninstall the examples package
+
+For packages installation see the apio install command.
+"""
+
+
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
-@click.command("uninstall", context_settings=util.context_settings())
+@click.command(
+    "uninstall",
+    short_help="Uninstall apio packages.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
-@click.argument("packages", nargs=-1)
-@options.project_dir_option
-@options.all_option_gen(help="Uninstall all packages.")
+@click.argument("packages", nargs=-1, required=False)
 @options.list_option_gen(help="List all installed packages.")
+@options.all_option_gen(help="Uninstall all packages.")
+@options.project_dir_option
 @options.platform_option
 def cli(
-    ctx,
+    ctx: Context,
     # Arguments
-    packages,
+    packages: Tuple[str],
     # Options
-    project_dir: Path,
-    all_: bool,
     list_: bool,
+    all_: bool,
+    project_dir: Path,
     platform: str,
 ):
-    """Uninstall packages."""
+    """Implements the uninstall command."""
 
     # -- Load the resources.
     resources = Resources(platform=platform, project_dir=project_dir)

--- a/apio/commands/upgrade.py
+++ b/apio/commands/upgrade.py
@@ -9,6 +9,7 @@
 
 import importlib.metadata
 import click
+from click.core import Context
 from packaging import version
 from apio.util import get_pypi_latest_version
 from apio import util
@@ -17,9 +18,24 @@ from apio import util
 # ---------------------------
 # -- COMMAND
 # ---------------------------
-@click.command("upgrade", context_settings=util.context_settings())
+HELP = """
+The upgrade command checks the version of the latest apio release
+and provide upgrade directions if needed.
+
+\b
+Examples:
+  apio upgrade
+"""
+
+
+@click.command(
+    "upgrade",
+    short_help="Check the latest Apio version.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
-def cli(ctx):
+def cli(ctx: Context):
     """Check the latest Apio version."""
 
     # -- Get the current apio version from the python package installed

--- a/apio/commands/upload.py
+++ b/apio/commands/upload.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.scons import SCons
 from apio.managers.drivers import Drivers
 from apio import util
@@ -35,37 +36,63 @@ flash_option = click.option(
 )
 
 
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+
+HELP = """
+The uploade command builds the bitstream file (similar to the
+build command) and uploaded it to the FPGA board.
+The commands is typically used in the root directory
+of the project that that contains the apio.ini file.
+
+\b
+Examples:
+  apio upload
+
+[Note] The flags marked with (deprecated) are not recomanded.
+Instead, use an apio.ini project config file and if neaded, add
+to the project custom boards.json and fpga.json files.
+"""
+
+
 # R0913: Too many arguments (6/5)
 # pylint: disable=R0913
 # R0914: Too many local variables (16/15) (too-many-locals)
 # pylint: disable=R0914
-@click.command("upload", context_settings=util.context_settings())
+@click.command(
+    "upload",
+    short_help="Upload the bitstream to the FPGA.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
-@options.board_option_gen()
+@options.project_dir_option
 @options.serial_port_option
 @options.ftdi_id
 @sram_option
 @flash_option
-@options.project_dir_option
 @options.verbose_option
 @options.verbose_yosys_option
 @options.verbose_pnr_option
 @options.top_module_option_gen()
+@options.board_option_gen()
 def cli(
-    ctx,
+    ctx: Context,
     # Options
-    board: str,
+    project_dir: Path,
     serial_port: str,
     ftdi_id: str,
     sram: bool,
     flash: bool,
-    project_dir: Path,
     verbose: bool,
     verbose_yosys: bool,
     verbose_pnr: bool,
+    # Deprecated options
     top_module: str,
+    board: str,
 ):
-    """Upload the bitstream to the FPGA."""
+    """Implements the upload command."""
 
     # -- Create a drivers object
     drivers = Drivers()

--- a/apio/commands/verify.py
+++ b/apio/commands/verify.py
@@ -9,6 +9,7 @@
 
 from pathlib import Path
 import click
+from click.core import Context
 from apio.managers.scons import SCons
 from apio import util
 from apio.commands import options
@@ -17,19 +18,41 @@ from apio.commands import options
 # ---------------------------
 # -- COMMAND
 # ---------------------------
-@click.command("verify", context_settings=util.context_settings())
+
+HELP = """
+The verify command performs a shallow verification of the verilog code
+it finds without requiring a top module or a constraint file.
+Is useful mainly in early stages of the project, before the
+strictier build and lint commands can be used.
+The verify commands is typically used in the root directory
+of the project that that contains the apio.ini file.
+
+\b
+Examples:
+  apio verify
+
+"""
+
+
+@click.command(
+    "verify",
+    short_help="Verify project's verilog code.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
 @click.pass_context
 @options.project_dir_option
-@options.board_option_gen()
 @options.verbose_option
+@options.board_option_gen()
 def cli(
-    ctx,
+    ctx: Context,
     # Options
     project_dir: Path,
-    board: str,
     verbose: bool,
+    # Deprecated options
+    board: str,
 ):
-    """Verify project's verilog code."""
+    """Implements the verify command."""
 
     # -- Crete the scons object
     scons = SCons(project_dir)

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -231,7 +231,7 @@ class Examples:
             return 1
 
         # -- Copy the example files!!
-        # -- TODO: fix an error...
+        # -- TODO: fix an error.
         exit_code = self._copy_files(
             example, src_example_path, dst_example_path, sayno
         )

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -6,7 +6,6 @@
       "type": "pi-sicle_loader"}
   },
 
-{
   "icezum": {
     "name": "IceZUM Alhambra",
     "fpga": "iCE40-HX1K-TQ144",


### PR DESCRIPTION
Each command has now both short and long click help texts,  and the long
text should be sufficient to understand how to user the command. Having the command
documentation near the code will help keeping it current.

Also:
1. The sim and test commands now accepts the testbench as an argument instead
   of a --testbench option.
2. Some options where marked in the help text as "(deprecated)"
   though there is not change in their functionality.
3. Fixed a broken boards.json format.

Here is an example of the help text of the build command.
```
$ apio build -h
Usage: apio build [OPTIONS]

  The build command reads the project source files and generates a bitstream
  file that you can uploaded to your FPGA. The commands is typically used in
  the root directory of the project that that contains the apio.ini file.

  Examples:
    apio build
    apio build -v

  [Note] The flags marked with (deprecated) are not recomanded. Instead, use
  an apio.ini project config file and if neaded, add to the project custom
  boards.json and fpga.json files.

Options:
  -p, --project-dir path  Set the root directory for the project.
  -v, --verbose           Show the entire output of the command.
  --verbose-yosys         Show the yosys output.
  --verbose-pnr           Show the pnr output.
  -t, --top-module name   (deprecated) Set the top level module name.
  -b, --board str         (deprecated) Set the board.
  --fpga str              (deprecated) Set the FPGA.
  --size str              (deprecated) Set the FPGA type (1k/8k).
  --type str              (deprecated) Set the FPGA type (hx/lp).
  --pack str              (deprecated) Set the FPGA package.
  -h, --help              Show this message and exit.
```