### PR TITLE
Added a flag exclusivity check to the apio system command.

### DIFF
--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -104,7 +104,10 @@ def cli(
     flags_count = int(lsftdi) + int(lsusb) + int(lsserial) + int(info)
     if flags_count > 1:
         click.secho(
-            "Error: --lsftdi, --lsusb, --lsserial, and --info are mutually exclusive.",
+            (
+                "Error: --lsftdi, --lsusb, --lsserial, and --info"
+                " are mutually exclusive."
+            ),
             fg="red",
         )
         ctx.exit(1)

--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -62,6 +62,9 @@ Examples:
   apio system --lsusb     # List USB devices
   apio system --lsserial  # List serial devices
   apio system --info      # Show platform id
+
+The flags --lstdi, --lsusb, --lsserial, and --info are exclusive and
+cannot be mixed in the same command.
 """
 
 
@@ -97,28 +100,36 @@ def cli(
     # -- Create the system object
     system = System(resources)
 
+    # -- Verify exlusive flags.
+    flags_count = int(lsftdi) + int(lsusb) + int(lsserial) + int(info)
+    if flags_count > 1:
+        click.secho(
+            "Error: --lsftdi, --lsusb, --lsserial, and --info are mutually exclusive.",
+            fg="red",
+        )
+        ctx.exit(1)
+
     # -- List all connected ftdi devices
     if lsftdi:
         exit_code = system.lsftdi()
+        ctx.exit(exit_code)
 
     # -- List all connected USB devices
-    elif lsusb:
+    if lsusb:
         exit_code = system.lsusb()
+        ctx.exit(exit_code)
 
     # -- List all connected serial devices
-    elif lsserial:
+    if lsserial:
         exit_code = system.lsserial()
+        ctx.exit(exit_code)
 
     # -- Show system information
-    elif info:
+    if info:
         click.secho("Platform: ", nl=False)
         click.secho(get_systype(), fg="yellow")
-        exit_code = 0
+        ctx.exit(0)
 
     # -- Invalid option. Just show the help
-    else:
-        click.secho(ctx.get_help())
-        exit_code = 0
-
-    # -- Done!
-    ctx.exit(exit_code)
+    click.secho(ctx.get_help())
+    ctx.exit(0)

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -85,13 +85,13 @@ class SCons:
         """Executes scons for verifying"""
 
         # -- Split the arguments
-        __, __, arch = process_arguments(args, self.resources, self.project)
+        var, __, arch = process_arguments(args, self.resources, self.project)
 
         # -- Execute scons!!!
         # -- The packages to check are passed
         return self.run(
             "verify",
-            variables=[],
+            variables=var,
             arch=arch,
             packages=["oss-cad-suite"],
         )

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -190,6 +190,7 @@ def iverilog_generator(source, target, env, for_signature):
         f'-D VCD_OUTPUT=dummy_vcd_output'  if is_verify 
         else  f'-D VCD_OUTPUT={target_name}' if is_testbench 
         else  "")
+    verbose_flag = '-v' if VERBOSE_ALL else ''
     # If running a testbench with the sim command, we define the macro INTERACTIVE_SIM that
     # allows the testbench to supress assertions so we can examine the waves in gtkwave. 
     # For example, with an assertion macro like this one that fails when running apio test.
@@ -202,8 +203,8 @@ def iverilog_generator(source, target, env, for_signature):
     #     end
     is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
     interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
-    result = 'iverilog {0} -o $TARGET {1} {2} -D NO_INCLUDES "{3}/ecp5/cells_bb.v" "{3}/ecp5/cells_sim.v" $SOURCES'.format(
-        IVER_PATH, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
+    result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_INCLUDES "{3}/ecp5/cells_bb.v" "{4}/ecp5/cells_sim.v" $SOURCES'.format(
+        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
     return result
 
 iverilog_builder = Builder(

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -198,6 +198,7 @@ def iverilog_generator(source, target, env, for_signature):
         f'-D VCD_OUTPUT=dummy_vcd_output'  if is_verify 
         else  f'-D VCD_OUTPUT={target_name}' if is_testbench 
         else  "")
+    verbose_flag = '-v' if VERBOSE_ALL else ''
     # If running a testbench with the sim command, we define the macro INTERACTIVE_SIM that
     # allows the testbench to supress assertions so we can examine the waves in gtkwave. 
     # For example, with an assertion macro like this one that fails when running apio test.
@@ -210,8 +211,8 @@ def iverilog_generator(source, target, env, for_signature):
     #     end
     is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
     interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
-    result = 'iverilog {0} -o $TARGET {1} {2} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{3}/ice40/cells_sim.v" $SOURCES'.format(
-        IVER_PATH, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
+    result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{4}/ice40/cells_sim.v" $SOURCES'.format(
+        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
     return result
 
 iverilog_builder = Builder(

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -196,6 +196,7 @@ def iverilog_generator(source, target, env, for_signature):
         f'-D VCD_OUTPUT=dummy_vcd_output'  if is_verify 
         else  f'-D VCD_OUTPUT={target_name}' if is_testbench 
         else  "")
+    verbose_flag = '-v' if VERBOSE_ALL else ''
     # If running a testbench with the sim command, we define the macro INTERACTIVE_SIM that
     # allows the testbench to supress assertions so we can examine the waves in gtkwave. 
     # For example, with an assertion macro like this one that fails when running apio test.
@@ -208,8 +209,8 @@ def iverilog_generator(source, target, env, for_signature):
     #     end
     is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
     interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
-    result = 'iverilog {0} -o $TARGET {1} {2} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{3}/ice40/cells_sim.v" $SOURCES'.format(
-        IVER_PATH, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
+    result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{4}/ice40/cells_sim.v" $SOURCES'.format(
+        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
     return result
 
 iverilog_builder = Builder(


### PR DESCRIPTION
The apio system command now exits with an error code if more than one flag is specified. Before this change, it processed one flag, not necessarily the first specified, and silently ignored the rest.

Edit: I created another commit and it was added automatically to this pull request. It makes the existing --verbose flag fo the apio verify command functional.