### PR TITLE
Made the lint command working with primitive cells + 2 minor tweaks.

### DIFF
--- a/apio/commands/boards.py
+++ b/apio/commands/boards.py
@@ -33,7 +33,7 @@ HELP = """
 The boards commands lists the FPGA boards and chips that are
 supported by apio.
 The commands is typically used in the root directory
-of the project that that contains the apio.ini file.
+of the project that contains the apio.ini file.
 
 \b
 Examples:

--- a/apio/commands/build.py
+++ b/apio/commands/build.py
@@ -23,7 +23,7 @@ HELP = """
 The build command reads the project source files
 and generates a bitstream file that you can uploaded to your FPGA.
 The commands is typically used in the root directory
-of the project that that contains the apio.ini file.
+of the project that contains the apio.ini file.
 
 \b
 Examples:

--- a/apio/commands/clean.py
+++ b/apio/commands/clean.py
@@ -22,7 +22,7 @@ HELP = """
 The clean command deletes the temporary files that were generated
 in the project directory by previous apio commands.
 The commands is typically used in the root directory
-of the project that that contains the apio.ini file.
+of the project that contains the apio.ini file.
 
 \b
 Example:

--- a/apio/commands/graph.py
+++ b/apio/commands/graph.py
@@ -22,7 +22,7 @@ HELP = """
 The graph command generates a graphical representation of the
 verilog code in the project.
 The commands is typically used in the root directory
-of the project that that contains the apio.ini file.
+of the project that contains the apio.ini file.
 
 \b
 Examples:

--- a/apio/commands/lint.py
+++ b/apio/commands/lint.py
@@ -52,7 +52,7 @@ verilog code and flags errors, inconsistencies, and style violations,
 and is a useful tool for improving the code quality. The command uses
 the verilator tool which is installed as park of the apio installation.
 The commands is typically used in the root directory
-of the project that that contains the apio.ini file.
+of the project that contains the apio.ini file.
 
 \b
 Examples:

--- a/apio/commands/sim.py
+++ b/apio/commands/sim.py
@@ -21,7 +21,7 @@ HELP = """
 The sim command simulates a testbench file and shows
 the simulation results a GTKWave graphical window.
 The commands is typically used in the root directory
-of the project that that contains the apio.ini file and it
+of the project that contains the apio.ini file and it
 accepts the testbench file name as an argument. For example:
 
 \b

--- a/apio/commands/test.py
+++ b/apio/commands/test.py
@@ -23,7 +23,7 @@ The sim command simulates one or all the testbenches in the project
 and is useful for automatic unit testing of the code. Testbenches
 are expected to exist with the $fatal directive if any error is
 detected. The commands is typically used in the root directory
-of the project that that contains the apio.ini.
+of the project that contains the apio.ini.
 
 \b
 Examples

--- a/apio/commands/time.py
+++ b/apio/commands/time.py
@@ -25,7 +25,7 @@ maximal clock rate that the FPGA can handle with this design. For more
 detailed timing information, inspect the file 'hardware.rpt' that the
 command generates.
 The commands is typically used in the root directory
-of the project that that contains the apio.ini file.
+of the project that contains the apio.ini file.
 
 \b
 Examples:

--- a/apio/commands/upload.py
+++ b/apio/commands/upload.py
@@ -44,7 +44,7 @@ HELP = """
 The uploade command builds the bitstream file (similar to the
 build command) and uploaded it to the FPGA board.
 The commands is typically used in the root directory
-of the project that that contains the apio.ini file.
+of the project that contains the apio.ini file.
 
 \b
 Examples:

--- a/apio/commands/verify.py
+++ b/apio/commands/verify.py
@@ -25,7 +25,7 @@ it finds without requiring a top module or a constraint file.
 Is useful mainly in early stages of the project, before the
 strictier build and lint commands can be used.
 The verify commands is typically used in the root directory
-of the project that that contains the apio.ini file.
+of the project that contains the apio.ini file.
 
 \b
 Examples:

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -85,13 +85,15 @@ class SCons:
         """Executes scons for verifying"""
 
         # -- Split the arguments
-        var, __, arch = process_arguments(args, self.resources, self.project)
+        variables, __, arch = process_arguments(
+            args, self.resources, self.project
+        )
 
         # -- Execute scons!!!
         # -- The packages to check are passed
         return self.run(
             "verify",
-            variables=var,
+            variables=variables,
             arch=arch,
             packages=["oss-cad-suite"],
         )
@@ -101,13 +103,15 @@ class SCons:
         """Executes scons for visual graph generation"""
 
         # -- Split the arguments
-        var, _, arch = process_arguments(args, self.resources, self.project)
+        variables, _, arch = process_arguments(
+            args, self.resources, self.project
+        )
 
         # -- Execute scons!!!
         # -- The packages to check are passed
         return self.run(
             "graph",
-            variables=var,
+            variables=variables,
             arch=arch,
             packages=["oss-cad-suite"],
         )
@@ -118,7 +122,7 @@ class SCons:
 
         config = {}
         __, __, arch = process_arguments(config, self.resources, self.project)
-        var = serialize_scons_flags(
+        variables = serialize_scons_flags(
             {
                 "all": args.get("all"),
                 "top": args.get("top"),
@@ -129,7 +133,7 @@ class SCons:
         )
         return self.run(
             "lint",
-            variables=var,
+            variables=variables,
             arch=arch,
             packages=["oss-cad-suite"],
         )
@@ -139,11 +143,13 @@ class SCons:
         """Simulates a testbench and shows the result in a gtkwave window."""
 
         # -- Split the arguments
-        var, _, arch = process_arguments(args, self.resources, self.project)
+        variables, _, arch = process_arguments(
+            args, self.resources, self.project
+        )
 
         return self.run(
             "sim",
-            variables=var,
+            variables=variables,
             arch=arch,
             packages=["oss-cad-suite", "gtkwave"],
         )
@@ -153,11 +159,13 @@ class SCons:
         """Tests all or a single testbench by simulating."""
 
         # -- Split the arguments
-        var, _, arch = process_arguments(args, self.resources, self.project)
+        variables, _, arch = process_arguments(
+            args, self.resources, self.project
+        )
 
         return self.run(
             "test",
-            variables=var,
+            variables=variables,
             arch=arch,
             packages=["oss-cad-suite"],
         )
@@ -167,7 +175,7 @@ class SCons:
         """Build the circuit"""
 
         # -- Split the arguments
-        var, board, arch = process_arguments(
+        variables, board, arch = process_arguments(
             args, self.resources, self.project
         )
 
@@ -175,7 +183,7 @@ class SCons:
         # -- The packages to check are passed
         return self.run(
             "build",
-            variables=var,
+            variables=variables,
             board=board,
             arch=arch,
             packages=["oss-cad-suite"],
@@ -187,12 +195,12 @@ class SCons:
     def time(self, args):
         """DOC: TODO"""
 
-        var, board, arch = process_arguments(
+        variables, board, arch = process_arguments(
             args, self.resources, self.project
         )
         return self.run(
             "time",
-            variables=var,
+            variables=variables,
             board=board,
             arch=arch,
             packages=["oss-cad-suite"],

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -11,7 +11,7 @@ import os
 import re
 from platform import system
 
-from SCons.Script import (Builder, DefaultEnvironment, Default, AlwaysBuild,
+from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 
@@ -70,12 +70,14 @@ if 'build' in COMMAND_LINE_TARGETS or \
             Exit(1)
         assert "${SOURCE}" in PROG, f"{PROG = }"
 
+
 # -- Resources paths
 IVL_PATH = os.environ['IVL'] if 'IVL' in os.environ else ''
 TRELLIS_PATH = os.environ['TRELLIS'] if 'TRELLIS' in os.environ else ''
 DATABASE_PATH = os.path.join(TRELLIS_PATH, 'database')
 CHIPDB_PATH = os.path.join(TRELLIS_PATH, 'chipdb-{0}.txt'.format(FPGA_SIZE))
 YOSYS_PATH = os.environ['YOSYS_LIB'] if 'YOSYS_LIB' in os.environ else ''
+YOSYS_CELLS_PATH = f"{YOSYS_PATH}/ecp5/cells_sim.v"
 
 isWindows = 'Windows' == system()
 VVP_PATH = '' if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
@@ -203,8 +205,8 @@ def iverilog_generator(source, target, env, for_signature):
     #     end
     is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
     interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
-    result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_INCLUDES "{3}/ecp5/cells_bb.v" "{4}/ecp5/cells_sim.v" $SOURCES'.format(
-        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
+    result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_INCLUDES "{3}/ecp5/cells_bb.v" "{4}" $SOURCES'.format(
+        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_CELLS_PATH)
     return result
 
 iverilog_builder = Builder(
@@ -325,22 +327,37 @@ if 'test' in COMMAND_LINE_TARGETS:
     tests_target = env.Alias('test', tests)
     AlwaysBuild(tests_target)
 
+# -- Verilator config file builder
+def verilator_config_func(target, source, env):
+        with open(target[0].get_path(), 'w') as target_file:
+            # NOTE: This config was copied from ICE40. Adjust as needed.
+            target_file.write('`verilator_config\n'
+                f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
+                f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n')
+        return 0
+
+verilator_config_builder = Builder(
+    action=Action(verilator_config_func, "Creating verilator config file."),
+    suffix='.vlt',
+    source_scanner=list_scanner)
+env.Append(BUILDERS={'VerilatorConfig': verilator_config_builder})
+
 # -- Verilator builder
 verilator_builder = Builder(
-    action='verilator --lint-only --timing -Wno-TIMESCALEMOD -Wno-MULTITOP -v {0}/ecp5/cells_sim.v {1} {2} {3} {4} $SOURCES'.format(
-        YOSYS_PATH,
+    action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES "{4}"'.format(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
         VERILATOR_PARAM_STR if VERILATOR_PARAM_STR else '',
-        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else ''),
+        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
+        YOSYS_CELLS_PATH),
     src_suffix='.v',
     source_scanner=list_scanner)
 env.Append(BUILDERS={'Verilator': verilator_builder})
 
 # --- Lint
-lout_target = env.Verilator(TARGET, src_synth + list_tb)
-
-lint_target = env.Alias('lint', lout_target)
+lint_config_target = env.VerilatorConfig(TARGET, [])
+lint_out_target = env.Verilator(TARGET, [TARGET + ".vlt"] + src_synth + list_tb)
+lint_target = env.Alias('lint', lint_out_target)
 AlwaysBuild(lint_target)
 
 Default(bitstream_target)
@@ -355,4 +372,4 @@ if GetOption('clean'):
         for node in Glob(glob_pattern):
             env.Clean(time_target, str(node))
 
-    env.Default([time_target, build_target, json_out_target, config_out_target, graph_target])
+    env.Default([time_target, build_target, json_out_target, config_out_target, graph_target, lint_target])

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -11,7 +11,7 @@ import os
 import re
 from platform import system
 
-from SCons.Script import (Builder, DefaultEnvironment, Default, AlwaysBuild,
+from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 
@@ -82,6 +82,7 @@ IVL_PATH = os.environ['IVL'] if 'IVL' in os.environ else ''
 ICEBOX_PATH = os.environ['ICEBOX'] if 'ICEBOX' in os.environ else ''
 CHIPDB_PATH = os.path.join(ICEBOX_PATH, 'chipdb-{0}.txt'.format(FPGA_SIZE))
 YOSYS_PATH = os.environ['YOSYS_LIB'] if 'YOSYS_LIB' in os.environ else ''
+YOSYS_CELLS_PATH = f"{YOSYS_PATH}/gowin/cells_sim.v"
 
 isWindows = 'Windows' == system()
 VVP_PATH = '' if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
@@ -211,8 +212,8 @@ def iverilog_generator(source, target, env, for_signature):
     #     end
     is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
     interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
-    result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{4}/ice40/cells_sim.v" $SOURCES'.format(
-        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
+    result = 'iverilog {0} {1} -o $TARGET {2} {3} "{4}" $SOURCES'.format(
+        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_CELLS_PATH)
     return result
 
 iverilog_builder = Builder(
@@ -333,20 +334,36 @@ if 'test' in COMMAND_LINE_TARGETS:
     tests_target = env.Alias('test', tests)
     AlwaysBuild(tests_target)
 
+# -- Verilator config file builder
+def verilator_config_func(target, source, env):
+        with open(target[0].get_path(), 'w') as target_file:
+            # NOTE: This config was copied from ICE40. Adjust as needed.
+            target_file.write('`verilator_config\n'
+                f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
+                f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n')
+        return 0
+
+verilator_config_builder = Builder(
+    action=Action(verilator_config_func, "Creating verilator config file."),
+    suffix='.vlt',
+    source_scanner=list_scanner)
+env.Append(BUILDERS={'VerilatorConfig': verilator_config_builder})
+
 # -- Verilator builder
 verilator_builder = Builder(
-    action='verilator --lint-only --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES'.format(
+    action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES "{4}"'.format(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
         VERILATOR_PARAM_STR if VERILATOR_PARAM_STR else '',
-        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else ''),
+        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
+        YOSYS_CELLS_PATH),
     src_suffix='.v',
     source_scanner=list_scanner)
 env.Append(BUILDERS={'Verilator': verilator_builder})
 
 # --- Lint
-lint_out_target = env.Verilator(TARGET, src_synth + list_tb)
-
+lint_config_target = env.VerilatorConfig(TARGET, [])
+lint_out_target = env.Verilator(TARGET, [TARGET + ".vlt"] + src_synth + list_tb)
 lint_target = env.Alias('lint', lint_out_target)
 AlwaysBuild(lint_target)
 
@@ -362,5 +379,5 @@ if GetOption('clean'):
         for node in Glob(glob_pattern):
             env.Clean(time_target, str(node))
 
-    env.Default([time_target, build_target, vout_target, graph_target])
+    env.Default([time_target, build_target, vout_target, graph_target, lint_target])
 

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -11,7 +11,7 @@ import os
 import re
 from platform import system
 
-from SCons.Script import (Builder, DefaultEnvironment, Default, AlwaysBuild,
+from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 
@@ -79,6 +79,7 @@ IVL_PATH = os.environ['IVL'] if 'IVL' in os.environ else ''
 ICEBOX_PATH = os.environ['ICEBOX'] if 'ICEBOX' in os.environ else ''
 CHIPDB_PATH = os.path.join(ICEBOX_PATH, 'chipdb-{0}.txt'.format(FPGA_SIZE))
 YOSYS_PATH = os.environ['YOSYS_LIB'] if 'YOSYS_LIB' in os.environ else ''
+YOSYS_CELLS_PATH = f"{YOSYS_PATH}/ice40/cells_sim.v"
 
 isWindows = 'Windows' == system()
 VVP_PATH = '' if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
@@ -209,8 +210,8 @@ def iverilog_generator(source, target, env, for_signature):
     #     end
     is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
     interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
-    result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{4}/ice40/cells_sim.v" $SOURCES'.format(
-        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_PATH)
+    result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{4}" $SOURCES'.format(
+        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_CELLS_PATH)
     return result
 
 iverilog_builder = Builder(
@@ -331,20 +332,35 @@ if 'test' in COMMAND_LINE_TARGETS:
     tests_target = env.Alias('test', tests)
     AlwaysBuild(tests_target)
 
+# -- Verilator config file builder
+def verilator_config_func(target, source, env):
+        with open(target[0].get_path(), 'w') as target_file:
+            target_file.write('`verilator_config\n'
+                f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
+                f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n')
+        return 0
+
+verilator_config_builder = Builder(
+    action=Action(verilator_config_func, "Creating verilator config file."),
+    suffix='.vlt',
+    source_scanner=list_scanner)
+env.Append(BUILDERS={'VerilatorConfig': verilator_config_builder})
+
 # -- Verilator builder
 verilator_builder = Builder(
-    action='verilator --lint-only --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES'.format(
+    action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP -DNO_ICE40_DEFAULT_ASSIGNMENTS {0} {1} {2} {3} $SOURCES "{4}"'.format(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
         VERILATOR_PARAM_STR if VERILATOR_PARAM_STR else '',
-        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else ''),
+        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
+        YOSYS_CELLS_PATH),
     src_suffix='.v',
     source_scanner=list_scanner)
 env.Append(BUILDERS={'Verilator': verilator_builder})
 
 # --- Lint
-lint_out_target = env.Verilator(TARGET, src_synth + list_tb)
-
+lint_config_target = env.VerilatorConfig(TARGET, [])
+lint_out_target = env.Verilator(TARGET, [TARGET + ".vlt"] + src_synth + list_tb)
 lint_target = env.Alias('lint', lint_out_target)
 AlwaysBuild(lint_target)
 
@@ -360,5 +376,5 @@ if GetOption('clean'):
         for node in Glob(glob_pattern):
             env.Clean(time_target, str(node))
 
-    env.Default([time_target, build_target, vout_target, graph_target])
+    env.Default([time_target, build_target, vout_target, graph_target, lint_target])
 


### PR DESCRIPTION

1. Made the lint command working with yosys library primitive cells. This require creating the target hardware.vlt with averilator's config.

2. (minor) Removed an extra 'that' from the commands' help text.

3. (Minor) Rename variable 'var' to 'variables' to convey plurality.