### PR TITLE
Added two commands for future replacement of 'apio init'.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -43,3 +43,10 @@ To return back to the release package run this (in any directory):
 pip uninstall apio
 pip install apio
 ```
+The command ``apio system -i`` (not released yet as of Sep 2024) shows the source directory of the apio package used. For example:
+
+```
+$ apio system -i
+Platform: darwin_arm64
+Source:   /Users/user/projects/apio_dev/repo/apio
+```

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -30,20 +30,19 @@ python apio_run.py build --project_dir ~/projects/fpga/repo/hdl
 
 ## Using the dev repository for apio commands.
 
-While developement it's handy to run apio commands that will use the dev repo being worked on rather than the released apio version installed by pip. One way to achive that is to symlink the dev repo instead of the pip installed apio package as outlined below. 
-Adjust the example as needed to match your system.
+You can tell pip to youse your apio dev repository for apio commands instead of the standard
+apio release. This allows quick edit/test cycles where you the modify code in your apio dev 
+repository and  immediately test it by running ``apio`` commands in the console..
 
+Note: Replace the path with the actual path of your apio dev repo (that is, 
+the path of the directory that contains the file ``pyproject.toml``.)
 ```
+pip uninstall apio
+pip install -e ~/projects/apio_dev/repo
+```
+
+To return back to the release package run
+```
+pip uninstall apio
 pip install apio
-pip show apio
-# Replace the path below with the 'Location' path provided by 'pip show apio'.
-cd /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages
-mv apio apio.original
-# Replace the path below with to the 'apio' directory in your apio dev directory.
-ln -s ~/projects/apio_dev/repo/apio apio
 ```
-
-With this symbolic link, the python, resources, and SConstruct files will be loaded
-from the dev repo you are developing on. Note that binaries such as yosys are not 
-part of the dev repository and will be loaded from ~/.apio. 
-

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -34,14 +34,13 @@ You can tell pip to youse your apio dev repository for apio commands instead of 
 apio release. This allows quick edit/test cycles where you the modify code in your apio dev 
 repository and  immediately test it by running ``apio`` commands in the console..
 
-Note: Replace the path with the actual path of your apio dev repo (that is, 
-the path of the directory that contains the file ``pyproject.toml``.)
+To use the local repo run this in the repo's root directory:
 ```
 pip uninstall apio
-pip install -e ~/projects/apio_dev/repo
+pip install -e .
 ```
 
-To return back to the release package run
+To return back to the release package run this (in any directory):
 ```
 pip uninstall apio
 pip install apio

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,4 +1,4 @@
-# APIO Developers Hints
+# Apio Developers Hints
 
 This file is not intended for APIO users.
 
@@ -19,7 +19,7 @@ pytest test/code_commands/test_build.py
 ```
 
 
-## Running APIO in a debugger
+## Running apio in a debugger
 
 Set the debugger to run the ``apio_run.py`` main with the regular ``apio`` arguments. Set the project directory ot the project file or use the ``--project_dir`` apio argument to point to the project directory.
 
@@ -28,18 +28,22 @@ Example of an equivalent manual command:
 python apio_run.py build --project_dir ~/projects/fpga/repo/hdl
 ```
 
-## Running APIO commands using a dev repo
+## Using the dev repository for apio commands.
 
-One way is to link the pip package to the dev repository. Something along these lines. Adjust patches to match your system. The ``pip show`` command shows the directory where the stock pip package is installed.
-
-NOTE: This make the command ``apio init --scons`` opsolete since the scons files can be edited in the dev repository.
+While developement it's handy to run apio commands that will use the dev repo being worked on rather than the released apio version installed by pip. One way to achive that is to symlink the dev repo instead of the pip installed apio package as outlined below. 
+Adjust the example as needed to match your system.
 
 ```
 pip install apio
 pip show apio
+# Replace the path below with the 'Location' path provided by 'pip show apio'.
 cd /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages
 mv apio apio.original
-ln -s ~/projects/apio_dev/repo/apio
+# Replace the path below with to the 'apio' directory in your apio dev directory.
+ln -s ~/projects/apio_dev/repo/apio apio
 ```
 
+With this symbolic link, the python, resources, and SConstruct files will be loaded
+from the dev repo you are developing on. Note that binaries such as yosys are not 
+part of the dev repository and will be loaded from ~/.apio. 
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -30,9 +30,7 @@ python apio_run.py build --project_dir ~/projects/fpga/repo/hdl
 
 ## Using the dev repository for apio commands.
 
-You can tell pip to youse your apio dev repository for apio commands instead of the standard
-apio release. This allows quick edit/test cycles where you the modify code in your apio dev 
-repository and  immediately test it by running ``apio`` commands in the console..
+You can tell pip to youse your apio dev repository for apio commands instead of the standard apio release. This allows quick edit/test cycles where you the modify code in your apio dev repository and  immediately test it by running ``apio`` commands in the console..
 
 To use the local repo run this in the repo's root directory:
 ```

--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -167,7 +167,8 @@ def cli(ctx):
         )
         # -- Select setup commands
         setup_help = select_commands_help(
-            command_lines, ["drivers", "init", "install", "uninstall"]
+            command_lines,
+            ["create", "modify", "drivers", "init", "install", "uninstall"],
         )
 
         # -- Select utility commands

--- a/apio/commands/create.py
+++ b/apio/commands/create.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# -- This file is part of the Apio project
+# -- (C) 2016-2024 FPGAwars
+# -- Authors
+# --  * Jesús Arroyo (2016-2019)
+# --  * Juan Gonzalez (obijuan) (2019-2024)
+# -- Licence GPLv2
+"""Main implementation of APIO CREATE command"""
+
+from pathlib import Path
+import click
+from click.core import Context
+from apio.managers.project import Project, DEFAULT_TOP_MODULE
+from apio import util
+from apio.commands import options
+
+
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+HELP = f"""
+The create command creates the project file apio.ini from scratch.
+The commands is typically used in the root directory
+of the project where the apio.ini file is created.
+
+\b
+Examples:
+  apio create --board icezum
+  apio create --board icezum --top-module MyModule
+  apio create --board icezum --sayyes
+
+The flag --board is required. The flag --top-module is optional and has
+the default '{DEFAULT_TOP_MODULE}'. If the file apio.ini already exists
+the command asks for permision to delete it. If --sayyes is specified,
+the file is deleted automatically.
+
+[Hint] Use the command 'apio examples -l' to see a list of
+the supported boards.
+"""
+
+
+# R0913: Too many arguments (6/5)
+# pylint: disable=R0913
+@click.command(
+    "create",
+    short_help="Create an apio.ini project file.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
+@click.pass_context
+@options.board_option_gen(help="Set the board.", required=True)
+@options.top_module_option_gen(help="Set the top level module name.")
+@options.project_dir_option
+@options.sayyes
+def cli(
+    ctx: Context,
+    # Options
+    board: str,
+    top_module: str,
+    project_dir: Path,
+    sayyes: bool,
+):
+    """Create a project file."""
+
+    # Board is annotated above as required so must exist.
+    assert board is not None
+
+    if not top_module:
+        top_module = DEFAULT_TOP_MODULE
+
+    # pylint: disable=fixme
+    # TODO: Make the default Path(".") in get_project_dir and delete this.
+    # It preserves the user provided relative path and is more friendly.
+    if not project_dir:
+        project_dir = Path(".")
+
+    project_dir = util.get_project_dir(project_dir)
+
+    # Create the apio.ini file
+    ok = Project.create_ini(project_dir, board, top_module, sayyes)
+
+    exit_code = 0 if ok else 1
+    ctx.exit(exit_code)

--- a/apio/commands/create.py
+++ b/apio/commands/create.py
@@ -10,7 +10,7 @@
 from pathlib import Path
 import click
 from click.core import Context
-from apio.managers.project import Project, DEFAULT_TOP_MODULE
+from apio.managers.project import Project, DEFAULT_TOP_MODULE, PROJECT_FILENAME
 from apio import util
 from apio.commands import options
 
@@ -33,6 +33,11 @@ The flag --board is required. The flag --top-module is optional and has
 the default '{DEFAULT_TOP_MODULE}'. If the file apio.ini already exists
 the command asks for permision to delete it. If --sayyes is specified,
 the file is deleted automatically.
+
+[Note] this command creates just the '{PROJECT_FILENAME}' file
+rather than a full buildable project.
+Some users use instead the examples command to copy a working
+project for their board, and then modify it with with their design.
 
 [Hint] Use the command 'apio examples -l' to see a list of
 the supported boards.

--- a/apio/commands/examples.py
+++ b/apio/commands/examples.py
@@ -96,7 +96,6 @@ def cli(
     # -- no options: Show help!
     else:
         click.secho(ctx.get_help())
-        click.secho(examples.examples_of_use_cad())
         exit_code = 0
 
     ctx.exit(exit_code)

--- a/apio/commands/init.py
+++ b/apio/commands/init.py
@@ -7,10 +7,14 @@
 # -- Licence GPLv2
 """Main implementation of APIO INIT command"""
 
+# pylint: disable=fixme
+# TODO: After migrating IceStudio to the create/modify commands, delete
+# this command and the *_deprecated methods it call.
+
 from pathlib import Path
 import click
 from click.core import Context
-from apio.managers.project import Project
+from apio.managers.project import Project, DEFAULT_TOP_MODULE
 from apio import util
 from apio.commands import options
 
@@ -31,19 +35,8 @@ scons_option = click.option(
 # -- COMMAND
 # ---------------------------
 HELP = """
-[Note] This command is DEPRECATED. To create a new project use the
-examples command and fetch an example of your FPGA board.
-To modify the configuration of an existing project, edit its
-apio.ini file manually.
-
-[Developers] To develope an SConstruct file either symlink the
-pip apio package to the apio directory of your dev directory
-(recommanded), or copy SConstruct to the project dir and it will
-be fetched from there (make sure copy the correct SConstruct file for
-your FPGA board)
-
-The command is preserved for now to backward compatibility and
-may be eliminated in a future release.
+The init command is DEPRECATED and will be deleted in the
+future. Use instead the commands 'apio create' and 'apio modify'.
 """
 
 
@@ -78,22 +71,22 @@ def cli(
 
     # -- scons option: Create default SConstruct file
     if scons:
-        project.create_sconstruct("ice40", sayyes)
+        project.create_sconstruct_deprecated("ice40", sayyes)
 
     # -- Create the project file apio.ini
     elif board:
         # -- Set the default top_module when creating the ini file
         if not top_module:
-            top_module = "main"
+            top_module = DEFAULT_TOP_MODULE
 
         # -- Create the apio.ini file
-        project.create_ini(board, top_module, sayyes)
+        project.create_ini_deprecated(board, top_module, sayyes)
 
     # -- Add the top_module to the apio.ini file
     elif top_module:
 
         # -- Update the apio.ini file
-        project.update_ini(top_module)
+        project.update_ini_deprecated(top_module)
 
     # -- No options: show help
     else:

--- a/apio/commands/modify.py
+++ b/apio/commands/modify.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# -- This file is part of the Apio project
+# -- (C) 2016-2024 FPGAwars
+# -- Authors
+# --  * Jesús Arroyo (2016-2019)
+# --  * Juan Gonzalez (obijuan) (2019-2024)
+# -- Licence GPLv2
+"""Main implementation of APIO MODIFY command"""
+
+from pathlib import Path
+import click
+from click.core import Context
+from apio.managers.project import Project
+from apio import util
+from apio.commands import options
+
+
+# ---------------------------
+# -- COMMAND
+# ---------------------------
+HELP = """
+The modify command modifies selected fields in an existing
+apio.ini project file. The commands is typically used in
+the root directory of the project that contains the apio.ini file.
+
+\b
+Examples:
+  apio modify --board icezum
+  apio modify --board icezum --top-module MyModule
+  apio create --top-module MyModule
+
+At least one of the flags --board and --top-module must be specified.
+
+[Hint] Use the command 'apio examples -l' to see a list of
+the supported boards.
+"""
+
+
+# R0913: Too many arguments (6/5)
+# pylint: disable=R0913
+@click.command(
+    "modify",
+    short_help="Modify the apio.ini project file.",
+    help=HELP,
+    context_settings=util.context_settings(),
+)
+@click.pass_context
+@options.board_option_gen(help="Set the board.")
+@options.top_module_option_gen(help="Set the top level module name.")
+@options.project_dir_option
+def cli(
+    ctx: Context,
+    # Options
+    board: str,
+    top_module: str,
+    project_dir: Path,
+):
+    """Modify the project file."""
+
+    if not (board or top_module):
+        click.secho(
+            "Error: at least one of --board or --top-module must be "
+            "specified.\n"
+            "Type 'apio modify -h' for help.",
+            fg="red",
+        )
+        ctx.exit(0)
+
+    # pylint: disable=fixme
+    # TODO: Make the default Path(".") in get_project_dir and delete this.
+    # It preserves the user provided relative path and is more friendly.
+    if not project_dir:
+        project_dir = Path(".")
+
+    project_dir = util.get_project_dir(project_dir)
+
+    # Create the apio.ini file
+    ok = Project.modify_ini_file(project_dir, board, top_module)
+
+    exit_code = 0 if ok else 1
+    ctx.exit(exit_code)

--- a/apio/commands/options.py
+++ b/apio/commands/options.py
@@ -66,13 +66,16 @@ def list_option_gen(*, help: str):
 
 # W0622: Redefining built-in 'help'
 # pylint: disable=W0622
-def board_option_gen(*, help: str = "(deprecated) Set the board."):
+def board_option_gen(
+    *, help: str = "(deprecated) Set the board.", required=False
+):
     """Generate a --board option with given help text."""
     return click.option(
         "board",  # Var name.
         "-b",
         "--board",
         type=str,
+        required=required,
         metavar="str",
         help=help,
     )

--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -8,6 +8,7 @@
 """Main implementation of APIO SYSTEM command"""
 
 from pathlib import Path
+import inspect
 import click
 from click.core import Context
 from apio import util
@@ -45,7 +46,7 @@ info_option = click.option(
     "-i",
     "--info",
     is_flag=True,
-    help="Show platform id.",
+    help="Show platform id and other info.",
 )
 
 
@@ -129,8 +130,15 @@ def cli(
 
     # -- Show system information
     if info:
+        # -- Print platform id.
         click.secho("Platform: ", nl=False)
         click.secho(get_systype(), fg="yellow")
+
+        # -- Print apio package source directory.
+        this_file_path = inspect.getfile(lambda: None)
+        apio_source_path = Path(this_file_path).parent.parent
+        click.secho("Source:   ", nl=False)
+        click.secho(apio_source_path, fg="yellow")
         ctx.exit(0)
 
     # -- Invalid option. Just show the help

--- a/apio/managers/arguments.py
+++ b/apio/managers/arguments.py
@@ -8,7 +8,7 @@
 from functools import wraps
 
 import click
-from apio.managers.project import Project
+from apio.managers.project import Project, DEFAULT_TOP_MODULE
 
 # -- Class for accesing api resources (boards, fpgas...)
 from apio.resources import Resources
@@ -228,8 +228,8 @@ def process_arguments(
                 fg="yellow",
             )
 
-            # -- "main" is used as a default top-level
-            config[TOP_MODULE] = "main"
+            # -- Use the default top-level
+            config[TOP_MODULE] = DEFAULT_TOP_MODULE
 
             click.secho("Using the default top-module: `main`", fg="blue")
 

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -326,9 +326,3 @@ class Examples:
             "Example '" + example + "' has been successfully created!",
             fg="green",
         )
-
-    @staticmethod
-    def examples_of_use_cad():
-        """Return the example of use help string"""
-
-        return EXAMPLE_OF_USE_CAD

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -136,7 +136,7 @@ class Project:
                 )
 
                 # -- Ask for confirmation
-                replace = click.confirm("Ok to delete it?")
+                replace = click.confirm("Do you want to replace it?")
 
                 # -- User say: NO! --> Abort
                 if not replace:
@@ -234,7 +234,7 @@ class Project:
         config.write()
 
         click.secho(
-            f"File '{ini_path}' has been modified successfully.\n"
+            f"File '{ini_path}' was modified successfully.\n"
             f"Run the apio clean command for project consistency.",
             fg="green",
         )

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -153,7 +153,7 @@ class Project:
         config.write()
         click.secho(
             f"The file '{ini_path}' was created successfully.\n"
-            "Run apio clean for project consistency.",
+            "Run the apio clean command for project consistency.",
             fg="green",
         )
         return True
@@ -235,7 +235,7 @@ class Project:
 
         click.secho(
             f"File '{ini_path}' has been modified successfully.\n"
-            f"Run apio clean for project consistency.",
+            f"Run the apio clean command for project consistency.",
             fg="green",
         )
         return True

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -7,19 +7,13 @@
 # -- Licence GPLv2
 """Utilities for accesing the apio.ini projects"""
 
-# TODO(zapta): Deprecate the mutations of existing api.ini file.
-
-# TODO(zapta): Deprecate the copying of the sconstruct file.
-# This is a developer only feature and developers can copy
-# it manually as needed.
-
 import sys
 from os.path import isfile
 from pathlib import Path
 
-# -- Config Parser: Use INI config files with easy
-# https://docs.python.org/3/library/configparser.html
 from configparser import ConfigParser
+from typing import Optional
+from configobj import ConfigObj
 import click
 from apio import util
 from apio.resources import Resources
@@ -27,18 +21,26 @@ from apio.resources import Resources
 # -- Apio projecto filename
 PROJECT_FILENAME = "apio.ini"
 
+DEFAULT_TOP_MODULE = "main"
+
+TOP_COMMENT = """\
+APIO project configuration file. For details see
+https://github.com/FPGAwars/apio/wiki/Project-configuration-file
+"""
+
 
 class Project:
     """Class for managing apio projects"""
 
     def __init__(self, project_dir: Path):
-        # TODO(zapta): Make these __private and provide getter methods.
+        # pylint: disable=fixme
+        # TODO: Make these __private and provide getter methods.
         self.project_dir = util.get_project_dir(project_dir)
         self.board: str = None
         self.top_module: str = None
         self.native_exe_mode: bool = None
 
-    def create_sconstruct(self, arch=None, sayyes=False):
+    def create_sconstruct_deprecated(self, arch=None, sayyes=False):
         """Creates a default SConstruct file"""
 
         sconstruct_name = "SConstruct"
@@ -50,7 +52,7 @@ class Project:
         if sconstruct_path.exists():
             # -- If sayyes, skip the question
             if sayyes:
-                self._copy_sconstruct_file(
+                self._copy_sconstruct_file_deprecated(
                     sconstruct_name,
                     sconstruct_path,
                     local_sconstruct_path,
@@ -62,7 +64,7 @@ class Project:
                 )
 
                 if click.confirm("Do you want to replace it?"):
-                    self._copy_sconstruct_file(
+                    self._copy_sconstruct_file_deprecated(
                         sconstruct_name,
                         sconstruct_path,
                         local_sconstruct_path,
@@ -71,11 +73,11 @@ class Project:
                     click.secho("Abort!", fg="red")
 
         else:
-            self._copy_sconstruct_file(
+            self._copy_sconstruct_file_deprecated(
                 sconstruct_name, sconstruct_path, local_sconstruct_path
             )
 
-    def create_ini(self, board, top_module, sayyes=False):
+    def create_ini_deprecated(self, board, top_module, sayyes=False):
         """Creates a new apio project file"""
 
         # -- Build the filename
@@ -106,10 +108,57 @@ class Project:
                     return
 
         # -- Create the apio.ini from scratch
-        self._create_ini_file(board, top_module, ini_path, PROJECT_FILENAME)
+        self._create_ini_file_deprecated(
+            board, top_module, ini_path, PROJECT_FILENAME
+        )
 
-    # TODO- Deprecate prgramatic mutations of apio.ini
-    def update_ini(self, top_module):
+    @staticmethod
+    def create_ini(project_dir, board, top_module, sayyes=False) -> bool:
+        """Creates a new apio project file. Returns True if ok."""
+
+        # -- Construct the path
+        ini_path = project_dir / PROJECT_FILENAME
+
+        # -- Verify that the board id is valid.
+        boards = Resources().boards
+        if board not in boards.keys():
+            click.secho(f"Error: no such board '{board}'", fg="red")
+            return False
+
+        # -- If the ini file already exists, ask if it's ok to delete.
+        if ini_path.is_file():
+
+            # -- Warn the user, unless the flag sayyes is active
+            if not sayyes:
+                click.secho(
+                    f"Warning: {PROJECT_FILENAME} file already exists",
+                    fg="yellow",
+                )
+
+                # -- Ask for confirmation
+                replace = click.confirm("Ok to delete it?")
+
+                # -- User say: NO! --> Abort
+                if not replace:
+                    click.secho("Abort!", fg="red")
+                    return False
+
+        # -- Create the apio.ini from scratch.
+        click.secho(f"Creating {ini_path} file ...")
+        config = ConfigObj(str(ini_path))
+        config.initial_comment = TOP_COMMENT.split("\n")
+        config["env"] = {}
+        config["env"]["board"] = board
+        config["env"]["top-module"] = top_module
+        config.write()
+        click.secho(
+            f"The file '{ini_path}' was created successfully.\n"
+            "Run apio clean for project consistency.",
+            fg="green",
+        )
+        return True
+
+    def update_ini_deprecated(self, top_module):
         """Update the current init file with the given top-module"""
 
         # -- Build the filename
@@ -142,7 +191,57 @@ class Project:
         )
 
     @staticmethod
-    def _create_ini_file(board, top_module, ini_path, ini_name):
+    def modify_ini_file(
+        project_dir: Path, board: Optional[str], top_module: Optional[str]
+    ) -> bool:
+        """Update the current ini file with the given optional parameters.
+        Returns True if ok."""
+
+        # -- construct the file path.
+        ini_path = project_dir / PROJECT_FILENAME
+
+        # -- Verify that the board id is valid.
+        if board:
+            boards = Resources().boards
+            if board not in boards.keys():
+                click.secho(
+                    f"Error: no such board '{board}'.\n"
+                    "Use 'apio boards -l' to list supported boards.",
+                    fg="red",
+                )
+                return False
+
+        # -- Check if the apio.ini file exists
+        if not ini_path.is_file():
+            click.secho(
+                f"Error: '{ini_path}' not found. You should create it first.\n"
+                "see 'apio create -h' for more details.",
+                fg="red",
+            )
+            return False
+
+        # -- Read the current apio.ini file
+        config = ConfigObj(str(ini_path))
+
+        # -- Set specified fields.
+        if board:
+            config["env"]["board"] = board
+
+        if top_module:
+            config["env"]["top-module"] = top_module
+
+        # -- Write the apio ini file
+        config.write()
+
+        click.secho(
+            f"File '{ini_path}' has been modified successfully.\n"
+            f"Run apio clean for project consistency.",
+            fg="green",
+        )
+        return True
+
+    @staticmethod
+    def _create_ini_file_deprecated(board, top_module, ini_path, ini_name):
         click.secho(f"Creating {ini_name} file ...")
         with open(ini_path, "w", encoding="utf8") as file:
             config = ConfigParser()
@@ -160,7 +259,7 @@ class Project:
             )
 
     @staticmethod
-    def _copy_sconstruct_file(
+    def _copy_sconstruct_file_deprecated(
         sconstruct_name, sconstruct_path, local_sconstruct_path
     ):
         click.secho(f"Creating {sconstruct_name} file ...")
@@ -188,6 +287,9 @@ class Project:
         if not isfile(project_file):
             print(f"Info: No {PROJECT_FILENAME} file")
             return
+
+        # pylint: disable=fixme
+        # TODO: Can we replace ConfigParser with ConfigObj for consistency?
 
         # Load the project file.
         config_parser = ConfigParser()
@@ -267,7 +369,7 @@ class Project:
                 fg="yellow",
             )
             click.secho("No 'top-module' in [env] section. Assuming 'main'.")
-            return "main"
+            return DEFAULT_TOP_MODULE
         return top_module
 
     @staticmethod

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -916,7 +916,9 @@ class SCons:
             click.secho("Info: use custom SConstruct file")
 
         # -- Verify necessary packages if needed.
-        # TODO(zapta): Can we drop the 'native' mode for simplicity?
+        # pylint: disable=fixme
+        # TODO: Drop the 'native' mode for simplicity? It is broken anyway.
+        # E.g. when referencing yosys libraries in Sconstruct.
         if self.project.native_exe_mode:
             # Assuming blindly that the binaries we need are on the path.
             click.secho(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ requires = [
     'colorama==0.4.6',
     'pyserial==3.5',
     'wheel>=0.35.0,<1',
+    'configobj==5.0.8',
     'scons==4.2.0'
 ]
 

--- a/test/env_commands/test_create.py
+++ b/test/env_commands/test_create.py
@@ -1,0 +1,106 @@
+"""
+  Test for the "apio create" command
+"""
+
+from pathlib import Path
+from os.path import isfile, exists
+from configobj import ConfigObj
+from typing import Dict
+
+# -- apio create entry point
+from apio.commands.create import cli as cmd_create
+
+
+def check_ini_file(apio_ini: Path, expected_vars: Dict[str, str]) -> None:
+    # Read the ini file.
+    assert isfile(apio_ini)
+    conf = ConfigObj(str(apio_ini))
+    # Check the expected comment at the top.
+    assert "# APIO project configuration file" in conf.initial_comment[0]
+    # Check the expected vars.
+    assert conf.dict() == {"env": expected_vars}
+
+
+def test_create(clirunner, configenv, validate_cliresult):
+    """Test "apio create" with different parameters"""
+
+    with clirunner.isolated_filesystem():
+
+        # -- Config the environment (conftest.configenv())
+        configenv()
+
+        apio_ini = Path("apio.ini")
+        assert not exists(apio_ini)
+
+        # -- Execute "apio create"
+        result = clirunner.invoke(cmd_create)
+        assert result.exit_code != 0
+        assert "Error: Missing option" in result.output
+        assert not exists(apio_ini)
+
+        # -- Execute "apio create --board missed_board"
+        result = clirunner.invoke(cmd_create, ["--board", "missed_board"])
+        assert result.exit_code == 1
+        assert "Error: no such board" in result.output
+        assert not exists(apio_ini)
+
+        # -- Execute "apio create --board icezum"
+        result = clirunner.invoke(cmd_create, ["--board", "icezum"])
+        validate_cliresult(result)
+        assert "Creating apio.ini file ..." in result.output
+        assert "was created successfully." in result.output
+        check_ini_file(apio_ini, {"board": "icezum", "top-module": "main"})
+
+        # -- Execute "apio create --board alhambra-ii --top-module my_module" with 'y' input
+        result = clirunner.invoke(
+            cmd_create,
+            ["--board", "alhambra-ii", "--top-module", "my_module"],
+            input="y",
+        )
+        validate_cliresult(result)
+        assert "Warning" in result.output
+        assert "file already exists" in result.output
+        assert "Do you want to replace it?" in result.output
+        assert "was created successfully." in result.output
+        check_ini_file(
+            apio_ini, {"board": "alhambra-ii", "top-module": "my_module"}
+        )
+
+        # -- Add to the ini file an additional var. It should disappear after the next wrire.
+        conf = ConfigObj(str(apio_ini))
+        conf["env"]["exe-mode"] = "native"
+        conf.write()
+        check_ini_file(
+            apio_ini,
+            {
+                "board": "alhambra-ii",
+                "top-module": "my_module",
+                "exe-mode": "native",
+            },
+        )
+
+        # -- Execute "apio create --board icezum --top-module my_module --sayyse" with 'y' input
+        result = clirunner.invoke(
+            cmd_create,
+            ["--board", "icezum", "--top-module", "my_module", "--sayyes"],
+        )
+        validate_cliresult(result)
+        assert "was created successfully." in result.output
+        check_ini_file(
+            apio_ini, {"board": "icezum", "top-module": "my_module"}
+        )
+
+        # -- Execute "apio create --board alhambra-ii --top-module my_module" with 'n' input
+        result = clirunner.invoke(
+            cmd_create,
+            ["--board", "alhambra-ii", "--top-module", "my_module"],
+            input="n",
+        )
+        assert result.exit_code != 0
+        assert "Warning" in result.output
+        assert "file already exists" in result.output
+        assert "Do you want to replace it?" in result.output
+        assert "Abort!" in result.output
+        check_ini_file(
+            apio_ini, {"board": "icezum", "top-module": "my_module"}
+        )

--- a/test/env_commands/test_modify.py
+++ b/test/env_commands/test_modify.py
@@ -1,0 +1,108 @@
+"""
+  Test for the "apio modify" command
+"""
+
+from pathlib import Path
+from os.path import isfile, exists
+from configobj import ConfigObj
+from typing import Dict
+
+# -- apio modify entry point
+from apio.commands.modify import cli as cmd_modify
+
+
+def check_ini_file(apio_ini: Path, expected_vars: Dict[str, str]) -> None:
+    # Read the ini file.
+    assert isfile(apio_ini)
+    conf = ConfigObj(str(apio_ini))
+    # Check the expected comment at the top.
+    assert "# My initial comment." in conf.initial_comment[0]
+    # Check the expected vars.
+    assert conf.dict() == {"env": expected_vars}
+
+
+def test_modify(clirunner, configenv, validate_cliresult):
+    """Test "apio modify" with different parameters"""
+
+    with clirunner.isolated_filesystem():
+
+        # -- Config the environment (conftest.configenv())
+        configenv()
+
+        apio_ini = Path("apio.ini")
+        assert not exists(apio_ini)
+
+        # -- Execute "apio modify --top-module my_module"
+        result = clirunner.invoke(cmd_modify, ["--top-module", "my_module"])
+        print(f"{result.output = }")
+        assert result.exit_code != 0
+        assert "Error: 'apio.ini' not found" in result.output
+        assert not exists(apio_ini)
+
+        # -- Create initial apio.ini file.
+        conf = ConfigObj(str(apio_ini))
+        conf.initial_comment = ["# My initial comment.", ""]
+        conf["env"] = {
+            "board": "icezum",
+            "top-module": "my_module",
+            "extra_var": "dummy",
+        }
+        conf.write()
+        check_ini_file(
+            apio_ini,
+            {
+                "board": "icezum",
+                "top-module": "my_module",
+                "extra_var": "dummy",
+            },
+        )
+
+        # -- Execute "apio modify --board missed_board"
+        result = clirunner.invoke(cmd_modify, ["--board", "missed_board"])
+        assert result.exit_code == 1
+        assert "Error: no such board" in result.output
+        check_ini_file(
+            apio_ini,
+            {
+                "board": "icezum",
+                "top-module": "my_module",
+                "extra_var": "dummy",
+            },
+        )
+
+        # -- Execute "apio modify --board alhambra-ii"
+        result = clirunner.invoke(cmd_modify, ["--board", "alhambra-ii"])
+        validate_cliresult(result)
+        assert "was modified successfully." in result.output
+        check_ini_file(
+            apio_ini,
+            {
+                "board": "alhambra-ii",
+                "top-module": "my_module",
+                "extra_var": "dummy",
+            },
+        )
+
+        # -- Execute "apio modify --top-module my_main"
+        result = clirunner.invoke(cmd_modify, ["--top-module", "my_main"])
+        validate_cliresult(result)
+        assert "was modified successfully." in result.output
+        check_ini_file(
+            apio_ini,
+            {
+                "board": "alhambra-ii",
+                "top-module": "my_main",
+                "extra_var": "dummy",
+            },
+        )
+
+        # -- Execute "apio modify --board icezum --top-module my_top"
+        result = clirunner.invoke(
+            cmd_modify, ["--board", "icezum", "--top-module", "my_top"]
+        )
+        validate_cliresult(result)
+        assert "was modified successfully." in result.output
+        check_ini_file(
+            apio_ini,
+            {"board": "icezum", "top-module": "my_top", "extra_var": "dummy"},
+        )


### PR DESCRIPTION
This PR adds two commands with the intention to replace the existing ``apio init`` command. They are ``apio create'``to create an ``apio.ini`` from scratch and ``apio modify`` to modify selected vars while preserving the reset.

The apio init command was left unchanged case it's may used by IceStudio (need to verify). If IceStudio does use ``apio init``, it can be easily be migrated to the new commands (once the new apio is released).

Motivation:
1. ``apio init`` selects the create-from-scratch vs modify-and-preseve-the-rest modes implicitly which is counter intuitive. 
2. ``apio init`` doesn't preserve well other vars in ``apio.in`` 
3. ``apio init`` doesn't preserve comments in the ``apio.ini``.