### PR TITLE
Fixed ecp5 scons not uploading target to board.

### DIFF
--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -171,7 +171,7 @@ AlwaysBuild(build_target)
 
 # -- Upload the bitstream into FPGA
 programmer = PROG.replace("${SOURCE}", "$SOURCE")
-upload_target = env.Alias('upload', bitstream_target)
+upload_target = env.Alias('upload', bitstream_target, programmer)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time


### PR DESCRIPTION
In #405 a bug was fixed with programmer argument ordering but unfortunately the refactored `programmer` string was left out from the `Alias` call. 