### PR TITLE
Assorted cleaned up and refactoring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ work/
 test-colorlight-v61.ice
 hardware.json
 hardware.out
+hardware.vlt
 *.out
 *.vcd
 hardware.bit

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -255,5 +255,27 @@
             "justMyCode": false,
             "cwd": "${workspaceFolder}/test-examples/Alhambra-II/02-jumping-LED"
         },
+        {
+            "name": "Scon (direct)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/scons_run.py",
+            "args": [
+                "-Q",  
+                "build", 
+                "fpga_model=iCE40-HX4K-TQ144",  
+                "fpga_arch=ice40",  
+                "fpga_size=4k",  
+                "fpga_type=hx",  
+                "fpga_pack=tq144", 
+                "top_module=main",
+                "-f",
+                "${workspaceFolder}/apio/resources/ice40/SConstruct",
+                "force_colors=True"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "cwd": "${workspaceFolder}/test-examples/Alhambra-II/02-jumping-LED"
+        },
     ]
 }

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -3,11 +3,11 @@
 This file is not intended for APIO users.
 
 ## Pre commit tests
-Before submitting a new commit, make sure the following commands runs successfuly (in the repository root):
+Before submitting a new commit, make sure to run successfuly the following command
+in the root directory of the repository.:
 
 ```shell
-make lint
-make tox
+make presubmit
 ```
 
 ## Running an individual APIO test

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -7,7 +7,7 @@ Before submitting a new commit, make sure to run successfuly the following comma
 in the root directory of the repository.:
 
 ```shell
-make presubmit
+make check
 ```
 
 ## Running an individual APIO test

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ lint:	## Run lint only
 test:	## Run tests only
 	python -m tox --skip-env lint
 
-presubmit: # Presubmit checks. Run full tox.
-	python -m tox
+check:	# Presubmit checks. Run full tox.
+	python -m tox --skip-missing-interpreters false
 
 publish_test:  ## Publish to testPypi
 	flit publish --repository testpypi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-.PHONY: deps cenv env lint tox publish publish_test
+.PHONY: deps cenv env lint test presubmit publish_test publish install
 
+# TODO: Force specific packages versions to have consistency across deevelopment
+# environments. Also make sure to sync with the versions in tox.ini
 deps:  ## Install dependencies for apio development
 	python -m pip install --upgrade pip
 	pip install flit black flake8 pylint tox pytest semantic-version pyserial importlib-metadata
@@ -13,15 +15,13 @@ env:
 	@echo "For entering the virtual-environment just type:"
 	@echo ". venv/bin/activate"
 
-# Keep this list the same as in tox.ini.
-lint_dirs = apio test test-boards
-
-lint:  ## Lint the apio app code
-	python -m black  $(lint_dirs)
-	python -m flake8 $(lint_dirs)
-	python -m pylint $(lint_dirs)
+lint:	## Run lint only
+	python -m tox -e lint
 	
-tox:   ## Run tox
+test:	## Run tests only
+	python -m tox --skip-env lint
+
+presubmit: # Presubmit checks. Run full tox.
 	python -m tox
 
 publish_test:  ## Publish to testPypi
@@ -34,5 +34,3 @@ install:  ## Install the tool locally
 	flit build
 	flit install
 
-tests: ## Execute ALL the tests
-	pytest apio test

--- a/Makefile
+++ b/Makefile
@@ -17,19 +17,24 @@ env:
 	@echo ". venv/bin/activate"
 
 
-# Lints the apio code base and tests.
+# Lint only, no tests. 
 lint:
 	python -m tox -e lint
 
 
-# Developers this target to test before submitting a commit.
-# It performs lint and test and requires a single python interpreter.
-check:	
+# Tests only, no lint, single python version.
+test:	
 	python -m tox --skip-missing-interpreters false -e py312
 
 
-# Similar to 'check' but test with  multiple Python versions
-# that need to be pre installed..
+# Tests and lint, single python version.
+# Run this before submitting code.
+ check:	
+	python -m tox --skip-missing-interpreters false -e lint,py312
+
+
+# Tests and lint, multiple python versions.
+# Should be be run automatically on github.
 check_all:
 	python -m tox --skip-missing-interpreters false
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ check:
 
 # Similar to 'check' but test with  multiple Python versions
 # that need to be pre installed..
-full_check:
+check_all:
 	python -m tox --skip-missing-interpreters false
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,50 @@
 .PHONY: deps cenv env lint test presubmit publish_test publish install
 
-# TODO: Force specific packages versions to have consistency across deevelopment
-# environments. Also make sure to sync with the versions in tox.ini
-deps:  ## Install dependencies for apio development
+# Install dependencies for apio development
+deps:
 	python -m pip install --upgrade pip
 	pip install flit black flake8 pylint tox pytest semantic-version pyserial importlib-metadata
 	
 
-cenv:  ## Create the virtual-environment and update dependencies
+# Create the virtual-environment and update dependencies
+cenv:  
 	python3 -m venv venv
 	python3 -m venv venv --upgrade
+
 
 env:
 	@echo "For entering the virtual-environment just type:"
 	@echo ". venv/bin/activate"
 
-lint:	## Run lint only
-	python -m tox -e lint
-	
-test:	## Run tests only
-	python -m tox --skip-env lint
 
-check:	# Presubmit checks. Run full tox.
+# Lints the apio code base and tests.
+lint:
+	python -m tox -e lint
+
+
+# Developers this target to test before submitting a commit.
+# It performs lint and test and requires a single python interpreter.
+check:	
+	python -m tox --skip-missing-interpreters false -e py312
+
+
+# Similar to 'check' but test with  multiple Python versions
+# that need to be pre installed..
+full_check:
 	python -m tox --skip-missing-interpreters false
 
-publish_test:  ## Publish to testPypi
+
+# Publish to testPypi
+publish_test:
 	flit publish --repository testpypi
 
-publish:  ## Publish to PyPi
+
+# Publish to PyPi
+publish:
 	python -m flit publish
 
-install:  ## Install the tool locally
+## Install the tool locally
+install:
 	flit build
 	flit install
 

--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -12,6 +12,7 @@
 
 import string
 import re
+from typing import override
 from typing import List
 from click.core import Context
 import click
@@ -142,7 +143,7 @@ class ApioCLI(click.MultiCommand):
         super().__init__(*args, **kwargs)
 
     # -- Return  a list of all the available commands
-    # @override
+    @override
     def list_commands(self, ctx):
         # -- All the python files inside the apio/commands folder are commands,
         # -- except __init__.py
@@ -165,7 +166,7 @@ class ApioCLI(click.MultiCommand):
     # -- is issued
     # -- INPUT:
     # --   * cmd_name: Apio command name
-    # @override
+    @override
     def get_command(self, ctx, cmd_name: string):
         nnss = {}
 
@@ -187,7 +188,7 @@ class ApioCLI(click.MultiCommand):
         # -- Return the function needed for executing the command
         return nnss.get("cli")
 
-    # @override
+    @override
     def get_help(self, ctx: Context) -> str:
         """Formats the help into a string and returns it.
 

--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -12,7 +12,6 @@
 
 import string
 import re
-from typing import override
 from typing import List
 from click.core import Context
 import click
@@ -143,7 +142,7 @@ class ApioCLI(click.MultiCommand):
         super().__init__(*args, **kwargs)
 
     # -- Return  a list of all the available commands
-    @override
+    # @override
     def list_commands(self, ctx):
         # -- All the python files inside the apio/commands folder are commands,
         # -- except __init__.py
@@ -166,7 +165,7 @@ class ApioCLI(click.MultiCommand):
     # -- is issued
     # -- INPUT:
     # --   * cmd_name: Apio command name
-    @override
+    # @override
     def get_command(self, ctx, cmd_name: string):
         nnss = {}
 
@@ -188,7 +187,7 @@ class ApioCLI(click.MultiCommand):
         # -- Return the function needed for executing the command
         return nnss.get("cli")
 
-    @override
+    # @override
     def get_help(self, ctx: Context) -> str:
         """Formats the help into a string and returns it.
 

--- a/apio/cmd_util.py
+++ b/apio/cmd_util.py
@@ -10,7 +10,7 @@
 """Utility functionality for apio click commands. """
 
 
-from typing import Mapping, List, Tuple, Any, Dict, Union
+from typing import Mapping, List, Tuple, Any, Dict, Union, override
 import click
 
 
@@ -174,7 +174,7 @@ class ApioOption(click.Option):
             )
         super().__init__(*args, **kwargs)
 
-    # @override
+    @override
     def handle_parse_result(
         self, ctx: click.Context, opts: Mapping[str, Any], args: List[str]
     ) -> Tuple[Any, List[str]]:
@@ -205,7 +205,7 @@ class ApioCommand(click.Command):
                 deprecated_options += 1
         return deprecated_options
 
-    # @override
+    @override
     def format_help_text(
         self, ctx: click.Context, formatter: click.HelpFormatter
     ) -> None:

--- a/apio/cmd_util.py
+++ b/apio/cmd_util.py
@@ -10,7 +10,7 @@
 """Utility functionality for apio click commands. """
 
 
-from typing import Mapping, List, Tuple, Any, Dict, Union, override
+from typing import Mapping, List, Tuple, Any, Dict, Union
 import click
 
 
@@ -174,7 +174,7 @@ class ApioOption(click.Option):
             )
         super().__init__(*args, **kwargs)
 
-    @override
+    # @override
     def handle_parse_result(
         self, ctx: click.Context, opts: Mapping[str, Any], args: List[str]
     ) -> Tuple[Any, List[str]]:
@@ -205,7 +205,7 @@ class ApioCommand(click.Command):
                 deprecated_options += 1
         return deprecated_options
 
-    @override
+    # @override
     def format_help_text(
         self, ctx: click.Context, formatter: click.HelpFormatter
     ) -> None:

--- a/apio/commands/build.py
+++ b/apio/commands/build.py
@@ -32,8 +32,8 @@ Examples:
 """
 
 
-# R0913: Too many arguments (11/5)
-# pylint: disable=R0913
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @click.command(
     "build",
     short_help="Synthesize the bitstream.",

--- a/apio/commands/drivers.py
+++ b/apio/commands/drivers.py
@@ -60,10 +60,10 @@ and affects all the projects on the local host.
 
 \b
 Examples:
-  apio drivers --ftdi_enable     # Install FTDI driver
-  apio drivers --ftdi_disable    # Uninstall FTDI driver
-  apio drivers --serial_enable   # Install serial driver
-  apio drivers --serial_disable  # Uninstall serial driver
+  apio drivers --ftdi-enable     # Install FTDI driver
+  apio drivers --ftdi-disable    # Uninstall FTDI driver
+  apio drivers --serial-enable   # Install serial driver
+  apio drivers --serial-disable  # Uninstall serial driver
 
   Do not specify more than flag per command invocation.
 """

--- a/apio/commands/examples.py
+++ b/apio/commands/examples.py
@@ -56,8 +56,8 @@ Examples:
 """
 
 
-# R0913: Too many arguments (6/5)
-# pylint: disable=R0913
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @click.command(
     "examples",
     short_help="List and fetch apio examples.",

--- a/apio/commands/install.py
+++ b/apio/commands/install.py
@@ -55,10 +55,9 @@ For packages uninstallation see the apio uninstall command.
 """
 
 
-# R0801: Similar lines in 2 files
-# pylint: disable=R0801
-# R0913: Too many arguments (7/5)
-# pylint: disable=R0913
+# pylint: disable=duplicate-code
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @click.command(
     "install",
     short_help="Install apio packages.",

--- a/apio/commands/lint.py
+++ b/apio/commands/lint.py
@@ -72,6 +72,9 @@ Examples:
     cls=cmd_util.ApioCommand,
 )
 @click.pass_context
+@options.top_module_option_gen(
+    help="Restrict linting to this module and its depedencies."
+)
 @options.all_option_gen(
     help="Enable all warnings, including code style warnings."
 )
@@ -79,12 +82,11 @@ Examples:
 @nowarn_option
 @warn_option
 @options.project_dir_option
-@options.top_module_option_gen(deprecated=True)
 def cli(
     ctx: Context,
     # Options
-    all_: bool,
     top_module: str,
+    all_: bool,
     nostyle: bool,
     nowarn: str,
     warn: str,
@@ -99,7 +101,7 @@ def cli(
     exit_code = scons.lint(
         {
             "all": all_,
-            "top": top_module,
+            "top_module": top_module,
             "nostyle": nostyle,
             "nowarn": nowarn,
             "warn": warn,

--- a/apio/commands/lint.py
+++ b/apio/commands/lint.py
@@ -63,8 +63,8 @@ Examples:
 """
 
 
-# R0913: Too many arguments (7/5)
-# pylint: disable=R0913
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @click.command(
     "lint",
     short_help="Lint the verilog code.",

--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -74,8 +74,8 @@ cannot be mixed in the same command.
 """
 
 
-# R0913: Too many arguments (6/5)
-# pylint: disable=R0913
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @click.command(
     "system",
     short_help="Provides system info.",

--- a/apio/commands/time.py
+++ b/apio/commands/time.py
@@ -33,10 +33,9 @@ Examples:
 """
 
 
-# R0801: Similar lines in 2 files
-# pylint: disable=R0801
-# R0913: Too many arguments (10/5)
-# pylint: disable=R0913
+# pylint: disable=duplicate-code
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @click.command(
     "time",
     short_help="Report design timing.",

--- a/apio/commands/uninstall.py
+++ b/apio/commands/uninstall.py
@@ -56,10 +56,9 @@ For packages installation see the apio install command.
 """
 
 
-# R0801: Similar lines in 2 files
-# pylint: disable=R0801
-# R0913: Too many arguments (6/5)
-# pylint: disable=R0913
+# pylint: disable=duplicate-code
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 @click.command(
     "uninstall",
     short_help="Uninstall apio packages.",

--- a/apio/commands/upgrade.py
+++ b/apio/commands/upgrade.py
@@ -53,23 +53,27 @@ def cli(ctx: Context):
     print(f"Local Apio version: {current_version}")
     print(f"Lastest Apio stable version (Pypi): {latest_version}")
 
-    # -- Compare versions and inform the user
-    # -- No real action are taken!
+    # -- Case 1: Using an old version.
     if version.parse(current_version) < version.parse(latest_version):
         click.secho(
             "You're not updated\nPlease execute "
             "`pip install -U apio` to upgrade.",
             fg="yellow",
         )
-    elif version.parse(current_version) > version.parse(latest_version):
+        return
+
+    # -- Case 2: Using a dev version.
+    if version.parse(current_version) > version.parse(latest_version):
         click.secho(
             "You are using a development version! (Not stable)\n"
             "Use it at your own risk",
             fg="yellow",
         )
-    else:
-        click.secho(
-            f"You're up-to-date!\nApio {latest_version} is currently the "
-            "latest stable version available.",
-            fg="green",
-        )
+        return
+
+    # -- Case 3: Using the latest version.
+    click.secho(
+        f"You're up-to-date!\nApio {latest_version} is currently the "
+        "latest stable version available.",
+        fg="green",
+    )

--- a/apio/commands/upload.py
+++ b/apio/commands/upload.py
@@ -54,10 +54,9 @@ Examples:
 """
 
 
-# R0913: Too many arguments (6/5)
-# pylint: disable=R0913
-# R0914: Too many local variables (16/15) (too-many-locals)
-# pylint: disable=R0914
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-locals
 @click.command(
     "upload",
     short_help="Upload the bitstream to the FPGA.",

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -892,8 +892,8 @@ class SCons:
         # -- No FTDI board found
         return None
 
-    # R0913: Too many arguments (6/5)
-    # pylint: disable=R0913
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
     def run(self, command, variables, packages, board=None, arch=None):
         """Executes scons"""
 

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -982,6 +982,9 @@ class SCons:
             ["scons"] + ["-Q", command] + variables + ["force_colors=True"]
         )
 
+        # -- For debugging.
+        print(f"scons_command = {' '.join(scons_command)}")
+
         # -- Execute the scons builder!
         result = util.exec_command(
             scons_command,

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -897,23 +897,12 @@ class SCons:
     def run(self, command, variables, packages, board=None, arch=None):
         """Executes scons"""
 
-        # -- Check if in the current project a custom SConstruct file
-        # is being used. We fist build the full name (with the full path)
-        scon_file = Path.cwd() / "SConstruct"
+        # -- Construct the path to the SConstruct file.
+        resources = util.get_path_in_apio_package("resources")
+        scons_file_path = resources / arch / "SConstruct"
 
-        # -- If the SConstruct file does NOT exist, we use the one provided by
-        # -- apio, which is located in the resources/arch/ folder
-        if not scon_file.exists():
-            # -- This is the default SConstruct file
-            resources = util.get_path_in_apio_package("resources")
-            default_scons_file = resources / arch / "SConstruct"
-
-            # -- It is passed to scons using the flag -f default_scons_file
-            variables += ["-f", f"{default_scons_file}"]
-
-        else:
-            # -- We are using our custom SConstruct file
-            click.secho("Info: use custom SConstruct file")
+        # -- It is passed to scons using the flag -f default_scons_file
+        variables += ["-f", f"{scons_file_path}"]
 
         # -- Verify necessary packages if needed.
         # pylint: disable=fixme

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -125,7 +125,7 @@ class SCons:
         variables = serialize_scons_flags(
             {
                 "all": args.get("all"),
-                "top": args.get("top"),
+                "top_module": args.get("top_module"),
                 "nowarn": args.get("nowarn"),
                 "warn": args.get("warn"),
                 "nostyle": args.get("nostyle"),

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -983,7 +983,7 @@ class SCons:
         )
 
         # -- For debugging.
-        print(f"scons_command = {' '.join(scons_command)}")
+        # print(f"scons_command = {' '.join(scons_command)}")
 
         # -- Execute the scons builder!
         result = util.exec_command(

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -976,7 +976,11 @@ class SCons:
             click.secho("-" * terminal_width, bold=True)
 
         # -- Command to execute: scons -Q apio_cmd flags
-        scons_command = ["scons"] + ["-Q", command] + variables
+        # -- Without force_colors=True, click.secho() colors from the scons
+        # -- child process will be stripped out becaused they are piped out.
+        scons_command = (
+            ["scons"] + ["-Q", command] + variables + ["force_colors=True"]
+        )
 
         # -- Execute the scons builder!
         result = util.exec_command(

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -15,7 +15,11 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 from SCons.Script.SConscript import SConsEnvironment
-from apio.scons_util import get_constraint_file, error, fatal_error, update_env_force_colors
+from apio.scons_util import get_constraint_file, error, fatal_error, create_construction_env
+
+# -- Create the environment
+env = create_construction_env(ARGUMENTS)
+
 
 # -- Load arguments
 PROG = ARGUMENTS.get('prog', '')
@@ -42,27 +46,6 @@ for warn in VERILATOR_WARN:
     if warn != '':
         VERILATOR_PARAM_STR += ' -Wwarn-' + warn
 
-# -- Add the FPGA flags as variables to be shown with the -h scons option
-vars = Variables()
-vars.Add('fpga_size', 'Set the ECP5 FPGA size', FPGA_SIZE)
-vars.Add('fpga_type', 'Set the ECP5 FPGA type', FPGA_TYPE)
-vars.Add('fpga_pack', 'Set the ECP5 FPGA packages', FPGA_PACK)
-vars.Add('fpga_idcode', 'Set the ECP5 FPGA idcode override', FPGA_IDCODE)
-
-# -- Create environment
-env:SConsEnvironment = DefaultEnvironment(
-        ENV=os.environ,
-        tools=[],
-        variables=vars)
-
-update_env_force_colors(env, ARGUMENTS)
-
-# For debugging.
-# from apio.scons_util import dump_env_vars
-# dump_env_vars(env)
-
-# -- Show all the flags defined, when scons is invoked with -h
-Help(vars.GenerateHelpText(env))
 
 # -- Just for debugging
 if 'build' in COMMAND_LINE_TARGETS or \
@@ -120,7 +103,7 @@ src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
 # -- Get the LPF file name.
-LPF = scons_util.get_constraint_file(env, ".lpf", TOP_MODULE)
+LPF = get_constraint_file(env, ".lpf", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -16,13 +16,14 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           Variables, Help, Glob)
 from SCons.Script.SConscript import SConsEnvironment
 from apio.scons_util import (get_constraint_file, error, fatal_error, 
-                             create_construction_env, arg_bool, arg_str)
+                             create_construction_env, arg_bool, arg_str,
+                             get_verilator_param_str)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 
-# -- Load arguments
+# -- Get arguments.
 PROG = arg_str(env, 'prog', '')
 FPGA_SIZE = arg_str(env, 'fpga_size', '')
 FPGA_TYPE = arg_str(env, 'fpga_type', '')
@@ -35,19 +36,10 @@ VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
 TESTBENCH = arg_str(env, 'testbench', '')
 VERILATOR_ALL = arg_bool(env, 'all', False)
 VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
-VERILATOR_NO_WARN = arg_str(env, 'nowarn', '').split(',')
-VERILATOR_WARN = arg_str(env, 'warn', '').split(',')
 VERILATOR_TOP = arg_str(env, 'top', '')
 
-VERILATOR_PARAM_STR = ''
-for warn in VERILATOR_NO_WARN:
-    if warn != '':
-        VERILATOR_PARAM_STR += ' -Wno-' + warn
-
-for warn in VERILATOR_WARN:
-    if warn != '':
-        VERILATOR_PARAM_STR += ' -Wwarn-' + warn
-
+# Derived from args "nowarn" and "warn".
+VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
 # -- Just for debugging
 if 'build' in COMMAND_LINE_TARGETS or \
@@ -325,7 +317,7 @@ verilator_builder = Builder(
     action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES "{4}"'.format(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
-        VERILATOR_PARAM_STR if VERILATOR_PARAM_STR else '',
+        VERILATOR_PARAM_STR,
         '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
         YOSYS_CELLS_PATH),
     src_suffix='.v',

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -143,7 +143,7 @@ env.Append(BUILDERS={'Bin': bitstream_builder})
 
 #-- No time analysis report implemented for the ECP5 family
 time_rpt_builder = Builder(
-    action='echo No time analysis report implemented for the ECP5 family $TARGET $SOURCE  > $TARGET',
+    action='echo "Time analysis report is not impelemnted for the ECP5 family." > $TARGET',
     suffix='.rpt',
     src_suffix='.config')
 env.Append(BUILDERS={'Time': time_rpt_builder})

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -20,7 +20,7 @@ PROG = ARGUMENTS.get('prog', '')
 FPGA_SIZE = ARGUMENTS.get('fpga_size', '')
 FPGA_TYPE = ARGUMENTS.get('fpga_type', '')
 FPGA_PACK = ARGUMENTS.get('fpga_pack', '')
-YOSYS_TOP = ARGUMENTS.get('top_module', '')
+TOP_MODULE = ARGUMENTS.get('top_module', '')
 FPGA_IDCODE = ARGUMENTS.get('fpga_idcode', '')
 VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
 VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
@@ -111,13 +111,13 @@ v_files = [str(f) for f in v_nodes]
 src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-# -- Get the LPF file
-LPF = scons_util.get_constraint_file(".lpf", Glob)
+# -- Get the LPF file name.
+LPF = scons_util.get_constraint_file(env, ".lpf", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(
     action='yosys -p \"synth_ecp5 {0} -json $TARGET\" {1} $SOURCES'.format(
-        ('-top '+YOSYS_TOP) if YOSYS_TOP else '',
+        ('-top '+TOP_MODULE) if TOP_MODULE else '',
         '' if VERBOSE_ALL or VERBOSE_YOSYS else '-q'
     ),
     suffix='.json',
@@ -127,8 +127,8 @@ env.Append(BUILDERS={'Synth': synth_builder})
 
 # -- Place and route Builder.
 pnr_builder = Builder(
-    action='nextpnr-ecp5 --{0} --package {2} --json $SOURCE --textcfg $TARGET {3} {4} --timing-allow-fail --force'.format(
-        FPGA_TYPE_PARAM, FPGA_SIZE, FPGA_PACK, '--lpf ' + str(LPF) if LPF else '',
+    action='nextpnr-ecp5 --{0} --package {2} --json $SOURCE --textcfg $TARGET --lpf {3} {4} --timing-allow-fail --force'.format(
+        FPGA_TYPE_PARAM, FPGA_SIZE, FPGA_PACK, LPF,
         '' if VERBOSE_ALL or VERBOSE_PNR else '-q'),
     suffix='.config',
     src_suffix='.json')
@@ -206,7 +206,7 @@ env.Append(BUILDERS={'IVerilog': iverilog_builder})
 
 dot_builder = Builder(
     action='yosys -f verilog -p \"show -format dot -colors 1 -prefix hardware {0}\" {1} $SOURCES'.format(
-        YOSYS_TOP if YOSYS_TOP else 'unknown_top',
+        TOP_MODULE if TOP_MODULE else 'unknown_top',
         '' if VERBOSE_ALL else '-q'
     ),
     suffix='.dot',

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -17,14 +17,13 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
 from SCons.Script.SConscript import SConsEnvironment
 from apio.scons_util import (get_constraint_file, error, fatal_error, 
                              create_construction_env, arg_bool, arg_str,
-                             get_verilator_param_str)
+                             get_verilator_param_str, get_programmer_cmd)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 
 # -- Get arguments.
-PROG = arg_str(env, 'prog', '')
 FPGA_SIZE = arg_str(env, 'fpga_size', '')
 FPGA_TYPE = arg_str(env, 'fpga_type', '')
 FPGA_PACK = arg_str(env, 'fpga_pack', '')
@@ -40,20 +39,6 @@ VERILATOR_TOP = arg_str(env, 'top', '')
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
-
-# -- Just for debugging
-if 'build' in COMMAND_LINE_TARGETS or \
-   'upload' in COMMAND_LINE_TARGETS or \
-   'time' in COMMAND_LINE_TARGETS:
-
-    # print('FPGA_SIZE: {}'.format(FPGA_SIZE))
-    # print('FPGA_TYPE: {}'.format(FPGA_TYPE))
-    # print('FPGA_PACK: {}'.format(FPGA_PACK))
-
-    if 'upload' in COMMAND_LINE_TARGETS:
-        if PROG == '':
-            fatal_error(env, 'No programmer command found.')
-        assert "${SOURCE}" in PROG, f"{PROG = }"
 
 
 # -- Resources paths
@@ -142,8 +127,8 @@ build_target = env.Alias('build', bitstream_target)
 AlwaysBuild(build_target)
 
 # -- Upload the bitstream into FPGA
-programmer = PROG.replace("${SOURCE}", "$SOURCE")
-upload_target = env.Alias('upload', bitstream_target, programmer)
+programmer_cmd = get_programmer_cmd(env)
+upload_target = env.Alias('upload', bitstream_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -111,10 +111,6 @@ v_files = [str(f) for f in v_nodes]
 src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-if len(src_synth) == 0:
-    print('Error: no verilog module files found (.v)')
-    Exit(1)
-
 # -- Get the LPF file
 LPF = ''
 LPF_list = Glob('*.lpf')

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -14,6 +14,8 @@ from apio import scons_util
 from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
+from SCons.Script.SConscript import SConsEnvironment
+from apio.scons_util import get_constraint_file, error, fatal_error, update_env_force_colors
 
 # -- Load arguments
 PROG = ARGUMENTS.get('prog', '')
@@ -48,9 +50,16 @@ vars.Add('fpga_pack', 'Set the ECP5 FPGA packages', FPGA_PACK)
 vars.Add('fpga_idcode', 'Set the ECP5 FPGA idcode override', FPGA_IDCODE)
 
 # -- Create environment
-env = DefaultEnvironment(ENV=os.environ,
-                         tools=[],
-                         variables=vars)
+env:SConsEnvironment = DefaultEnvironment(
+        ENV=os.environ,
+        tools=[],
+        variables=vars)
+
+update_env_force_colors(env, ARGUMENTS)
+
+# For debugging.
+# from apio.scons_util import dump_env_vars
+# dump_env_vars(env)
 
 # -- Show all the flags defined, when scons is invoked with -h
 Help(vars.GenerateHelpText(env))
@@ -66,8 +75,7 @@ if 'build' in COMMAND_LINE_TARGETS or \
 
     if 'upload' in COMMAND_LINE_TARGETS:
         if PROG == '':
-            print('Error: no programmer command found')
-            Exit(1)
+            fatal_error(env, 'No programmer command found.')
         assert "${SOURCE}" in PROG, f"{PROG = }"
 
 
@@ -255,11 +263,10 @@ if 'sim' in COMMAND_LINE_TARGETS:
         # No --testbench flag was specified. If there is exactly one testbench then pick
         # it, otherwise fail. 
         if len(list_tb) == 0:
-            print('Error: no testbench found for simulation.')
-            Exit(1)
+            fatal_error(env, 'No testbench found for simulation.')
         if len(list_tb) > 1:
             # TODO: consider to allow specifying the default testbench in apio.ini.
-            print('Error: found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
+            error(env, 'Found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
             for tb in list_tb:
                 print('- {}'.format(tb))
             Exit(1)
@@ -291,8 +298,7 @@ if 'test' in COMMAND_LINE_TARGETS:
     else:
         # No --testbench flag specified. We will test all them.
         if len(list_tb) == 0:
-            print('Error: no testbenchs found for simulation.')
-            Exit(1)
+            fatal_error(env, 'No testbenchs found for simulation.')
         test_tbs= list_tb  # All testbenches.
     tests = [] # Targets of all tests
     for test_tb in test_tbs:

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -35,7 +35,6 @@ VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
 TESTBENCH = arg_str(env, 'testbench', '')
 VERILATOR_ALL = arg_bool(env, 'all', False)
 VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
-VERILATOR_TOP = arg_str(env, 'top', '')
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
@@ -303,7 +302,7 @@ verilator_builder = Builder(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
         VERILATOR_PARAM_STR,
-        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
+        '--top-module ' + TOP_MODULE if TOP_MODULE else '',
         YOSYS_CELLS_PATH),
     src_suffix='.v',
     source_scanner=list_scanner)

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -11,56 +11,74 @@ import os
 import re
 from platform import system
 from apio import scons_util
-from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
-                          GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
-                          Variables, Help, Glob)
+from SCons.Script import (
+    Builder,
+    Action,
+    DefaultEnvironment,
+    Default,
+    AlwaysBuild,
+    GetOption,
+    Exit,
+    COMMAND_LINE_TARGETS,
+    ARGUMENTS,
+    Variables,
+    Help,
+    Glob,
+)
 from SCons.Script.SConscript import SConsEnvironment
-from apio.scons_util import (get_constraint_file, error, fatal_error, 
-                             create_construction_env, arg_bool, arg_str,
-                             get_verilator_param_str, get_programmer_cmd)
+from apio.scons_util import (
+    get_constraint_file,
+    error,
+    fatal_error,
+    create_construction_env,
+    arg_bool,
+    arg_str,
+    get_verilator_param_str,
+    get_programmer_cmd,
+)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 
 # -- Get arguments.
-FPGA_SIZE = arg_str(env, 'fpga_size', '')
-FPGA_TYPE = arg_str(env, 'fpga_type', '')
-FPGA_PACK = arg_str(env, 'fpga_pack', '')
-TOP_MODULE = arg_str(env, 'top_module', '')
-FPGA_IDCODE = arg_str(env, 'fpga_idcode', '')
-VERBOSE_ALL = arg_bool(env, 'verbose_all', False)
-VERBOSE_YOSYS = arg_bool(env, 'verbose_yosys', False)
-VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
-TESTBENCH = arg_str(env, 'testbench', '')
-VERILATOR_ALL = arg_bool(env, 'all', False)
-VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
+FPGA_SIZE = arg_str(env, "fpga_size", "")
+FPGA_TYPE = arg_str(env, "fpga_type", "")
+FPGA_PACK = arg_str(env, "fpga_pack", "")
+TOP_MODULE = arg_str(env, "top_module", "")
+FPGA_IDCODE = arg_str(env, "fpga_idcode", "")
+VERBOSE_ALL = arg_bool(env, "verbose_all", False)
+VERBOSE_YOSYS = arg_bool(env, "verbose_yosys", False)
+VERBOSE_PNR = arg_bool(env, "verbose_pnr", False)
+TESTBENCH = arg_str(env, "testbench", "")
+VERILATOR_ALL = arg_bool(env, "all", False)
+VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
 
 # -- Resources paths
-IVL_PATH = os.environ['IVL'] if 'IVL' in os.environ else ''
-TRELLIS_PATH = os.environ['TRELLIS'] if 'TRELLIS' in os.environ else ''
-DATABASE_PATH = os.path.join(TRELLIS_PATH, 'database')
-CHIPDB_PATH = os.path.join(TRELLIS_PATH, 'chipdb-{0}.txt'.format(FPGA_SIZE))
-YOSYS_PATH = os.environ['YOSYS_LIB'] if 'YOSYS_LIB' in os.environ else ''
+IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
+TRELLIS_PATH = os.environ["TRELLIS"] if "TRELLIS" in os.environ else ""
+DATABASE_PATH = os.path.join(TRELLIS_PATH, "database")
+CHIPDB_PATH = os.path.join(TRELLIS_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
+YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
 YOSYS_CELLS_PATH = f"{YOSYS_PATH}/ecp5/cells_sim.v"
 
-isWindows = 'Windows' == system()
-VVP_PATH = '' if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
-IVER_PATH = '' if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
+isWindows = "Windows" == system()
+VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
+IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 
-IDCODE_PARAM = '' if not FPGA_IDCODE else '--idcode {0}'.format(FPGA_IDCODE)
+IDCODE_PARAM = "" if not FPGA_IDCODE else "--idcode {0}".format(FPGA_IDCODE)
 
-FPGA_TYPE_PARAM = '25k' if (FPGA_TYPE=="12k") else '{0}'.format(FPGA_TYPE)
+FPGA_TYPE_PARAM = "25k" if (FPGA_TYPE == "12k") else "{0}".format(FPGA_TYPE)
 
 # -- Target name
-TARGET = 'hardware'
+TARGET = "hardware"
 
 # -- Scan required .list files
-list_files_re = re.compile(r'[\n|\s][^\/]?\"(.*\.list?)\"', re.M)
+list_files_re = re.compile(r"[\n|\s][^\/]?\"(.*\.list?)\"", re.M)
 
 
 def list_files_scan(node, env, path):
@@ -73,84 +91,98 @@ list_scanner = env.Scanner(function=list_files_scan)
 
 # -- Get a list of all the verilog files in the src folfer, in ASCII, with
 # -- the full path. All these files are used for the simulation
-v_nodes = Glob('*.v')
+v_nodes = Glob("*.v")
 v_files = [str(f) for f in v_nodes]
 
 # Construct disjoint lists of .v module and testbench files.
-src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
-list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
+src_synth = [f for f in v_files if f[-5:].upper() != "_TB.V"]
+list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
 
 # -- Get the LPF file name.
 LPF = get_constraint_file(env, ".lpf", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(
-    action='yosys -p \"synth_ecp5 {0} -json $TARGET\" {1} $SOURCES'.format(
-        ('-top '+TOP_MODULE) if TOP_MODULE else '',
-        '' if VERBOSE_ALL or VERBOSE_YOSYS else '-q'
+    action='yosys -p "synth_ecp5 {0} -json $TARGET" {1} $SOURCES'.format(
+        ("-top " + TOP_MODULE) if TOP_MODULE else "",
+        "" if VERBOSE_ALL or VERBOSE_YOSYS else "-q",
     ),
-    suffix='.json',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'Synth': synth_builder})
+    suffix=".json",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"Synth": synth_builder})
 
 # -- Place and route Builder.
 pnr_builder = Builder(
-    action='nextpnr-ecp5 --{0} --package {2} --json $SOURCE --textcfg $TARGET --lpf {3} {4} --timing-allow-fail --force'.format(
-        FPGA_TYPE_PARAM, FPGA_SIZE, FPGA_PACK, LPF,
-        '' if VERBOSE_ALL or VERBOSE_PNR else '-q'),
-    suffix='.config',
-    src_suffix='.json')
-env.Append(BUILDERS={'PnR': pnr_builder})
+    action="nextpnr-ecp5 --{0} --package {2} --json $SOURCE --textcfg $TARGET --lpf {3} {4} --timing-allow-fail --force".format(
+        FPGA_TYPE_PARAM,
+        FPGA_SIZE,
+        FPGA_PACK,
+        LPF,
+        "" if VERBOSE_ALL or VERBOSE_PNR else "-q",
+    ),
+    suffix=".config",
+    src_suffix=".json",
+)
+env.Append(BUILDERS={"PnR": pnr_builder})
 
 # -- Bitstream Builder.
 bitstream_builder = Builder(
-    action='ecppack --compress --db {0} {1} $SOURCE hardware.bit'.format(DATABASE_PATH, IDCODE_PARAM),
-    suffix='.bit',
-    src_suffix='.config')
-env.Append(BUILDERS={'Bin': bitstream_builder})
+    action="ecppack --compress --db {0} {1} $SOURCE hardware.bit".format(
+        DATABASE_PATH, IDCODE_PARAM
+    ),
+    suffix=".bit",
+    src_suffix=".config",
+)
+env.Append(BUILDERS={"Bin": bitstream_builder})
 
-#-- No time analysis report implemented for the ECP5 family
+# -- No time analysis report implemented for the ECP5 family
 time_rpt_builder = Builder(
     action='echo "Time analysis report is not impelemnted for the ECP5 family." > $TARGET',
-    suffix='.rpt',
-    src_suffix='.config')
-env.Append(BUILDERS={'Time': time_rpt_builder})
+    suffix=".rpt",
+    src_suffix=".config",
+)
+env.Append(BUILDERS={"Time": time_rpt_builder})
 
 # -- Generate the bitstream
 json_out_target = env.Synth(TARGET, [src_synth])
 config_out_target = env.PnR(TARGET, [json_out_target, LPF])
 bitstream_target = env.Bin(TARGET, config_out_target)
 
-build_target = env.Alias('build', bitstream_target)
+build_target = env.Alias("build", bitstream_target)
 AlwaysBuild(build_target)
 
 # -- Upload the bitstream into FPGA
 programmer_cmd = get_programmer_cmd(env)
-upload_target = env.Alias('upload', bitstream_target, programmer_cmd)
+upload_target = env.Alias("upload", bitstream_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time
 time_rpt_target = env.Time(config_out_target)
 AlwaysBuild(time_rpt_target)
-time_target = env.Alias('time', time_rpt_target)
+time_target = env.Alias("time", time_rpt_target)
 
 # -- Icarus Verilog builders
 
+
 def iverilog_generator(source, target, env, for_signature):
-    """Constructs dynamically a commands for iverlog targets builders. """
-    target_name, _  = os.path.splitext(str(target[0]))  # E.g. "my_module" or"my_module_tb"
+    """Constructs dynamically a commands for iverlog targets builders."""
+    target_name, _ = os.path.splitext(
+        str(target[0])
+    )  # E.g. "my_module" or"my_module_tb"
     # Testbenches use the value macro VCD_OUTPUT to know the name of the waves output file.
-    # We also pass a dummy when the verify command to avoid a warning about the undefined macro. 
+    # We also pass a dummy when the verify command to avoid a warning about the undefined macro.
     is_testbench = target_name.upper().endswith("_TB")
-    is_verify = 'verify' in COMMAND_LINE_TARGETS
+    is_verify = "verify" in COMMAND_LINE_TARGETS
     vcd_output_flag = (
-        f'-D VCD_OUTPUT=dummy_vcd_output'  if is_verify 
-        else  f'-D VCD_OUTPUT={target_name}' if is_testbench 
-        else  "")
-    verbose_flag = '-v' if VERBOSE_ALL else ''
+        f"-D VCD_OUTPUT=dummy_vcd_output"
+        if is_verify
+        else f"-D VCD_OUTPUT={target_name}" if is_testbench else ""
+    )
+    verbose_flag = "-v" if VERBOSE_ALL else ""
     # If running a testbench with the sim command, we define the macro INTERACTIVE_SIM that
-    # allows the testbench to supress assertions so we can examine the waves in gtkwave. 
+    # allows the testbench to supress assertions so we can examine the waves in gtkwave.
     # For example, with an assertion macro like this one that fails when running apio test.
     # `define EXPECT(signal, value) \
     #     if (signal !== value) begin \
@@ -159,50 +191,57 @@ def iverilog_generator(source, target, env, for_signature):
     #             $fatal; \
     #         `endif \
     #     end
-    is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
-    interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
+    is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
+    interactive_sim_flag = f"-D INTERACTIVE_SIM" if is_interactive_sim else ""
     result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_INCLUDES "{3}/ecp5/cells_bb.v" "{4}" $SOURCES'.format(
-        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_CELLS_PATH)
+        IVER_PATH,
+        verbose_flag,
+        vcd_output_flag,
+        interactive_sim_flag,
+        YOSYS_CELLS_PATH,
+    )
     return result
+
 
 iverilog_builder = Builder(
     # Action string is computed automatically by the generator.
-    generator = iverilog_generator,
-    suffix='.out',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'IVerilog': iverilog_builder})
+    generator=iverilog_generator,
+    suffix=".out",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"IVerilog": iverilog_builder})
 
 dot_builder = Builder(
-    action='yosys -f verilog -p \"show -format dot -colors 1 -prefix hardware {0}\" {1} $SOURCES'.format(
-        TOP_MODULE if TOP_MODULE else 'unknown_top',
-        '' if VERBOSE_ALL else '-q'
+    action='yosys -f verilog -p "show -format dot -colors 1 -prefix hardware {0}" {1} $SOURCES'.format(
+        TOP_MODULE if TOP_MODULE else "unknown_top",
+        "" if VERBOSE_ALL else "-q",
     ),
-    suffix='.dot',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'DOT': dot_builder})
+    suffix=".dot",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"DOT": dot_builder})
 
 svg_builder = Builder(
     # Expecting graphviz dot to be installed and in the path.
-    action='dot -Tsvg $SOURCES -o $TARGET',
-    suffix='.svg',
-    src_suffix='.dot',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'SVG': svg_builder})
+    action="dot -Tsvg $SOURCES -o $TARGET",
+    suffix=".svg",
+    src_suffix=".dot",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"SVG": svg_builder})
 
 # NOTE: output file name is defined in the iverilog call using VCD_OUTPUT macro
 vcd_builder = Builder(
-    action='vvp {0} $SOURCE'.format(
-        VVP_PATH),
-    suffix='.vcd',
-    src_suffix='.out')
-env.Append(BUILDERS={'VCD': vcd_builder})
+    action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
+)
+env.Append(BUILDERS={"VCD": vcd_builder})
 
 # --- Verify
 vout_target = env.IVerilog(TARGET, src_synth + list_tb)
 AlwaysBuild(vout_target)
-verify_target = env.Alias('verify', vout_target)
+verify_target = env.Alias("verify", vout_target)
 
 # --- Graph
 # TODO: Launch some portable SVG (or differentn format) viewer.
@@ -210,26 +249,31 @@ dot_target = env.DOT(TARGET, src_synth)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
-graph_target = env.Alias('graph', svg_target)
+graph_target = env.Alias("graph", svg_target)
 
 # --- Simulation
-# Since the simulation targets are dynamic due to the testbench selection, we 
+# Since the simulation targets are dynamic due to the testbench selection, we
 # create them only when running simulation.
-if 'sim' in COMMAND_LINE_TARGETS: 
-    assert 'test' not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
+if "sim" in COMMAND_LINE_TARGETS:
+    assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench.
         sim_testbench = TESTBENCH
     else:
         # No --testbench flag was specified. If there is exactly one testbench then pick
-        # it, otherwise fail. 
+        # it, otherwise fail.
         if len(list_tb) == 0:
-            fatal_error(env, 'No testbench found for simulation.')
+            fatal_error(env, "No testbench found for simulation.")
         if len(list_tb) > 1:
             # TODO: consider to allow specifying the default testbench in apio.ini.
-            error(env, 'Found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
+            error(
+                env,
+                "Found {} testbranches, please use the --testbench flag.".format(
+                    len(list_tb)
+                ),
+            )
             for tb in list_tb:
-                print('- {}'.format(tb))
+                print("- {}".format(tb))
             Exit(1)
         sim_testbench = list_tb[0]  # Pick the only available testbench.
     # Here sim_testbench contains the testbench, e.g. my_module_tb.v.
@@ -238,30 +282,36 @@ if 'sim' in COMMAND_LINE_TARGETS:
     src_sim.extend(src_synth)  # All the .v files.
     src_sim.append(sim_testbench)
     # Create targets sim target and its dependent.
-    sim_name, _ = os.path.splitext(sim_testbench)  #e.g. my_module_tb
+    sim_name, _ = os.path.splitext(sim_testbench)  # e.g. my_module_tb
     sout_target = env.IVerilog(sim_name, src_sim)
     vcd_file_target = env.VCD(sout_target)
     # 'do_initial_zoom_fit' does max zoom only if .gtkw file not found.
-    waves_target = env.Alias('sim', vcd_file_target, 'gtkwave {0} {1} {2}.gtkw'.format(
-        '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
-        vcd_file_target[0], sim_name))
+    waves_target = env.Alias(
+        "sim",
+        vcd_file_target,
+        "gtkwave {0} {1} {2}.gtkw".format(
+            '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
+            vcd_file_target[0],
+            sim_name,
+        ),
+    )
     AlwaysBuild(waves_target)
 
 
 # --- Testing
-# Since the simulation targets are dynamic due to the testbench selection, we 
+# Since the simulation targets are dynamic due to the testbench selection, we
 # create them only when running simulation.
-if 'test' in COMMAND_LINE_TARGETS: 
-    assert 'sim' not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
+if "test" in COMMAND_LINE_TARGETS:
+    assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench. We test just that one.
-        test_tbs= [ TESTBENCH ]
+        test_tbs = [TESTBENCH]
     else:
         # No --testbench flag specified. We will test all them.
         if len(list_tb) == 0:
-            fatal_error(env, 'No testbenchs found for simulation.')
-        test_tbs= list_tb  # All testbenches.
-    tests = [] # Targets of all tests
+            fatal_error(env, "No testbenchs found for simulation.")
+        test_tbs = list_tb  # All testbenches.
+    tests = []  # Targets of all tests
     for test_tb in test_tbs:
         # Create a list of source files. All the modules + the current testbench.
         src_test = []
@@ -269,8 +319,8 @@ if 'test' in COMMAND_LINE_TARGETS:
         src_test.append(test_tb)
         # Create the targets for the 'out' and 'vcd' files of the testbench.
         # NOTE: Remove the two AlwaysBuild() calls below for an incremental test. Fast, correct,
-        # but may confuse the user seeing nothing happens. 
-        test_name, _ = os.path.splitext(test_tb)  #e.g. my_module_tb
+        # but may confuse the user seeing nothing happens.
+        test_name, _ = os.path.splitext(test_tb)  # e.g. my_module_tb
         test_out_target = env.IVerilog(test_name, src_test)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
@@ -278,52 +328,70 @@ if 'test' in COMMAND_LINE_TARGETS:
         test_target = env.Alias(test_name, [test_out_target, test_vcd_target])
         tests.append(test_target)
     # Create a target for the test command that depends on all the test targets.
-    tests_target = env.Alias('test', tests)
+    tests_target = env.Alias("test", tests)
     AlwaysBuild(tests_target)
+
 
 # -- Verilator config file builder
 def verilator_config_func(target, source, env):
-        with open(target[0].get_path(), 'w') as target_file:
-            # NOTE: This config was copied from ICE40. Adjust as needed.
-            target_file.write('`verilator_config\n'
-                f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
-                f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n')
-        return 0
+    with open(target[0].get_path(), "w") as target_file:
+        # NOTE: This config was copied from ICE40. Adjust as needed.
+        target_file.write(
+            "`verilator_config\n"
+            f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
+            f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n'
+        )
+    return 0
+
 
 verilator_config_builder = Builder(
     action=Action(verilator_config_func, "Creating verilator config file."),
-    suffix='.vlt',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'VerilatorConfig': verilator_config_builder})
+    suffix=".vlt",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
 # -- Verilator builder
 verilator_builder = Builder(
     action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES "{4}"'.format(
-        '-Wall' if VERILATOR_ALL else '',
-        '-Wno-style' if VERILATOR_NO_STYLE else '',
+        "-Wall" if VERILATOR_ALL else "",
+        "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
-        '--top-module ' + TOP_MODULE if TOP_MODULE else '',
-        YOSYS_CELLS_PATH),
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'Verilator': verilator_builder})
+        "--top-module " + TOP_MODULE if TOP_MODULE else "",
+        YOSYS_CELLS_PATH,
+    ),
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"Verilator": verilator_builder})
 
 # --- Lint
 lint_config_target = env.VerilatorConfig(TARGET, [])
-lint_out_target = env.Verilator(TARGET, [TARGET + ".vlt"] + src_synth + list_tb)
-lint_target = env.Alias('lint', lint_out_target)
+lint_out_target = env.Verilator(
+    TARGET, [TARGET + ".vlt"] + src_synth + list_tb
+)
+lint_target = env.Alias("lint", lint_out_target)
 AlwaysBuild(lint_target)
 
 Default(bitstream_target)
 
 # -- These is for cleaning the artifact files.
-if GetOption('clean'):
+if GetOption("clean"):
     # Identify additional files that may not be associated with targets and
     # associate them with a target such that they will be cleaned up as well.
     # This cleans for example artifacts of past simulation since the testbench
     # target are dynamic and changes with the selected testbench.
-    for glob_pattern in ['*.out', '*.vcd']:
+    for glob_pattern in ["*.out", "*.vcd"]:
         for node in Glob(glob_pattern):
             env.Clean(time_target, str(node))
 
-    env.Default([time_target, build_target, json_out_target, config_out_target, graph_target, lint_target])
+    env.Default(
+        [
+            time_target,
+            build_target,
+            json_out_target,
+            config_out_target,
+            graph_target,
+            lint_target,
+        ]
+    )

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -15,28 +15,30 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 from SCons.Script.SConscript import SConsEnvironment
-from apio.scons_util import get_constraint_file, error, fatal_error, create_construction_env
+from apio.scons_util import (get_constraint_file, error, fatal_error, 
+                             create_construction_env, arg_bool, arg_str)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 
 # -- Load arguments
-PROG = ARGUMENTS.get('prog', '')
-FPGA_SIZE = ARGUMENTS.get('fpga_size', '')
-FPGA_TYPE = ARGUMENTS.get('fpga_type', '')
-FPGA_PACK = ARGUMENTS.get('fpga_pack', '')
-TOP_MODULE = ARGUMENTS.get('top_module', '')
-FPGA_IDCODE = ARGUMENTS.get('fpga_idcode', '')
-VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
-VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
-VERBOSE_PNR = ARGUMENTS.get('verbose_pnr', False)
-TESTBENCH = ARGUMENTS.get('testbench', '')
-VERILATOR_ALL = ARGUMENTS.get('all', False)
-VERILATOR_NO_STYLE = ARGUMENTS.get('nostyle', False)
-VERILATOR_NO_WARN = ARGUMENTS.get('nowarn', '').split(',')
-VERILATOR_WARN = ARGUMENTS.get('warn', '').split(',')
-VERILATOR_TOP = ARGUMENTS.get('top', '')
+PROG = arg_str(env, 'prog', '')
+FPGA_SIZE = arg_str(env, 'fpga_size', '')
+FPGA_TYPE = arg_str(env, 'fpga_type', '')
+FPGA_PACK = arg_str(env, 'fpga_pack', '')
+TOP_MODULE = arg_str(env, 'top_module', '')
+FPGA_IDCODE = arg_str(env, 'fpga_idcode', '')
+VERBOSE_ALL = arg_bool(env, 'verbose_all', False)
+VERBOSE_YOSYS = arg_bool(env, 'verbose_yosys', False)
+VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
+TESTBENCH = arg_str(env, 'testbench', '')
+VERILATOR_ALL = arg_bool(env, 'all', False)
+VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
+VERILATOR_NO_WARN = arg_str(env, 'nowarn', '').split(',')
+VERILATOR_WARN = arg_str(env, 'warn', '').split(',')
+VERILATOR_TOP = arg_str(env, 'top', '')
+
 VERILATOR_PARAM_STR = ''
 for warn in VERILATOR_NO_WARN:
     if warn != '':

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -10,7 +10,7 @@
 import os
 import re
 from platform import system
-
+from apio import scons_util
 from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
@@ -112,16 +112,7 @@ src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
 # -- Get the LPF file
-LPF = ''
-LPF_list = Glob('*.lpf')
-
-try:
-    LPF = LPF_list[0]
-except IndexError:
-    print('\n---> WARNING: no LPF file found (.lpf)\n')
-
-# -- Debug
-# print('LPF Found: {}'.format(LPF))
+LPF = scons_util.get_constraint_file(".lpf", Glob)
 
 # -- Synthesizing Builder
 synth_builder = Builder(

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -16,13 +16,14 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           Variables, Help, Glob)
 from SCons.Script.SConscript import SConsEnvironment
 from apio.scons_util import (get_constraint_file, error, fatal_error, 
-                             create_construction_env, arg_bool, arg_str)
+                             create_construction_env, arg_bool, arg_str,
+                             get_verilator_param_str)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 
-# -- Load arguments
+# -- Get arguments
 PROG = arg_str(env, 'prog', '')
 FPGA_MODEL = arg_str(env, 'fpga_model', '')
 FPGA_SIZE = arg_str(env, 'fpga_size', '')
@@ -35,19 +36,10 @@ VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
 TESTBENCH = arg_str(env, 'testbench', '')
 VERILATOR_ALL = arg_bool(env, 'all', False)
 VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
-VERILATOR_NO_WARN = arg_str(env, 'nowarn', '').split(',')
-VERILATOR_WARN = arg_str(env, 'warn', '').split(',')
 VERILATOR_TOP = arg_str(env, 'top', '')
 
-VERILATOR_PARAM_STR = ''
-for warn in VERILATOR_NO_WARN:
-    if warn != '':
-        VERILATOR_PARAM_STR += ' -Wno-' + warn
-
-for warn in VERILATOR_WARN:
-    if warn != '':
-        VERILATOR_PARAM_STR += ' -Wwarn-' + warn
-
+# Derived from args "nowarn" and "warn".
+VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
 # -- Just for debugging
 if 'build' in COMMAND_LINE_TARGETS or \
@@ -325,7 +317,7 @@ verilator_builder = Builder(
     action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES "{4}"'.format(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
-        VERILATOR_PARAM_STR if VERILATOR_PARAM_STR else '',
+        VERILATOR_PARAM_STR,
         '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
         YOSYS_CELLS_PATH),
     src_suffix='.v',

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -15,7 +15,11 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 from SCons.Script.SConscript import SConsEnvironment
-from apio.scons_util import get_constraint_file, error, fatal_error, update_env_force_colors
+from apio.scons_util import get_constraint_file, error, fatal_error, create_construction_env
+
+# -- Create the environment
+env = create_construction_env(ARGUMENTS)
+
 
 # -- Load arguments
 PROG = ARGUMENTS.get('prog', '')
@@ -42,34 +46,6 @@ for warn in VERILATOR_WARN:
     if warn != '':
         VERILATOR_PARAM_STR += ' -Wwarn-' + warn
 
-
-
-# -- Size. Possible values: 1k, 4k, 9k, 20k
-# -- Type. Possible values: gw1nz-1, gw1ns-4, gw1n-9c, gw2a-18c
-# -- Package. Unused.
-
-
-# -- Add the FPGA flags as variables to be shown with the -h scons option
-vars = Variables()
-vars.Add('fpga_size', 'Set the Gowin FPGA size (20k)', FPGA_SIZE)
-vars.Add('fpga_type', 'Set the Gowin FPGA type (gw2a-18c)', FPGA_TYPE)
-vars.Add('fpga_pack', 'Set the Gowin FPGA packages', FPGA_PACK)
-vars.Add('fpga_model', 'Set a specific Gowin FPGA model', FPGA_MODEL)
-
-# -- Create environment
-env:SConsEnvironment = DefaultEnvironment(
-        ENV=os.environ,
-        tools=[],
-        variables=vars)
-
-update_env_force_colors(env, ARGUMENTS)
-
-# For debugging.
-# from apio.scons_util import dump_env_vars
-# dump_env_vars(env)
-
-# -- Show all the flags defined, when scons is invoked with -h
-Help(vars.GenerateHelpText(env))
 
 # -- Just for debugging
 if 'build' in COMMAND_LINE_TARGETS or \
@@ -121,7 +97,7 @@ src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
 # -- Get the CST file name.
-CST = scons_util.get_constraint_file(env, ".cst", TOP_MODULE)
+CST = get_constraint_file(env, ".cst", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -14,6 +14,8 @@ from apio import scons_util
 from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
+from SCons.Script.SConscript import SConsEnvironment
+from apio.scons_util import get_constraint_file, error, fatal_error, update_env_force_colors
 
 # -- Load arguments
 PROG = ARGUMENTS.get('prog', '')
@@ -55,9 +57,16 @@ vars.Add('fpga_pack', 'Set the Gowin FPGA packages', FPGA_PACK)
 vars.Add('fpga_model', 'Set a specific Gowin FPGA model', FPGA_MODEL)
 
 # -- Create environment
-env = DefaultEnvironment(ENV=os.environ,
-                         tools=[],
-                         variables=vars)
+env:SConsEnvironment = DefaultEnvironment(
+        ENV=os.environ,
+        tools=[],
+        variables=vars)
+
+update_env_force_colors(env, ARGUMENTS)
+
+# For debugging.
+# from apio.scons_util import dump_env_vars
+# dump_env_vars(env)
 
 # -- Show all the flags defined, when scons is invoked with -h
 Help(vars.GenerateHelpText(env))
@@ -73,8 +82,7 @@ if 'build' in COMMAND_LINE_TARGETS or \
 
     if 'upload' in COMMAND_LINE_TARGETS:
         if PROG == '':
-            print('Error: no programmer command found')
-            Exit(1)
+            fatal_error(env, 'No programmer command found.')
         assert "${SOURCE}" in PROG, f"{PROG = }"
    
 # -- Resources paths
@@ -262,11 +270,10 @@ if 'sim' in COMMAND_LINE_TARGETS:
         # No --testbench flag specified. If there is exactly one testbench then pick
         # it, otherwise fail. 
         if len(list_tb) == 0:
-            print('Error: no testbench found for simulation.')
-            Exit(1)
+            fatal_error(env, 'No testbench found for simulation.')
         if len(list_tb) > 1:
             # TODO: consider to allow specifying the default testbench in apio.ini.
-            print('Error: found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
+            error('Found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
             for tb in list_tb:
                 print('- {}'.format(tb))
             Exit(1)
@@ -298,8 +305,7 @@ if 'test' in COMMAND_LINE_TARGETS:
     else:
         # No --testbench flag specified. We will test all them.
         if len(list_tb) == 0:
-            print('Error: no testbenchs found for simulation.')
-            Exit(1)
+            fatal_error(env, 'No testbenchs found for simulation.')
         test_tbs= list_tb  # All testbenches.
     tests = [] # Targets of all tests
     for test_tb in test_tbs:

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -35,7 +35,6 @@ VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
 TESTBENCH = arg_str(env, 'testbench', '')
 VERILATOR_ALL = arg_bool(env, 'all', False)
 VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
-VERILATOR_TOP = arg_str(env, 'top', '')
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
@@ -304,7 +303,7 @@ verilator_builder = Builder(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
         VERILATOR_PARAM_STR,
-        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
+        '--top-module ' + TOP_MODULE if TOP_MODULE else '',
         YOSYS_CELLS_PATH),
     src_suffix='.v',
     source_scanner=list_scanner)

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -10,7 +10,7 @@
 import os
 import re
 from platform import system
-
+from apio import scons_util
 from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
@@ -112,17 +112,8 @@ v_files = [str(f) for f in v_nodes]
 src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-# -- Get the CST file
-CST = ''
-CST_list = Glob('*.cst')
-
-try:
-    CST = CST_list[0]
-except IndexError:
-    print('\n---> WARNING: no CST file found (.cst)\n')
-
-# -- Debug
-# print('CST Found: {}'.format(CST))
+# -- Get the CST file. 
+CST = scons_util.get_constraint_file(".cst", Glob)
 
 # -- Synthesizing Builder
 synth_builder = Builder(

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -21,7 +21,7 @@ FPGA_MODEL = ARGUMENTS.get('fpga_model', '')
 FPGA_SIZE = ARGUMENTS.get('fpga_size', '')
 FPGA_TYPE = ARGUMENTS.get('fpga_type', '')
 FPGA_PACK = ARGUMENTS.get('fpga_pack', '')
-YOSYS_TOP = ARGUMENTS.get('top_module', '')
+TOP_MODULE = ARGUMENTS.get('top_module', '')
 VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
 VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
 VERBOSE_PNR = ARGUMENTS.get('verbose_pnr', False)
@@ -112,13 +112,13 @@ v_files = [str(f) for f in v_nodes]
 src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-# -- Get the CST file. 
-CST = scons_util.get_constraint_file(".cst", Glob)
+# -- Get the CST file name.
+CST = scons_util.get_constraint_file(env, ".cst", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(
     action='yosys -D LEDS_NR=6 -p \"synth_gowin {0} -json $TARGET\" {1} $SOURCES'.format(
-        ('-top '+YOSYS_TOP) if YOSYS_TOP else '',
+        ('-top '+TOP_MODULE) if TOP_MODULE else '',
         '' if VERBOSE_ALL or VERBOSE_YOSYS else '-q'
     ),
     suffix='.json',
@@ -213,7 +213,7 @@ env.Append(BUILDERS={'IVerilog': iverilog_builder})
 
 dot_builder = Builder(
     action='yosys -f verilog -p \"show -format dot -colors 1 -prefix hardware {0}\" {1} $SOURCES'.format(
-        YOSYS_TOP if YOSYS_TOP else 'unknown_top',
+        TOP_MODULE if TOP_MODULE else 'unknown_top',
         '' if VERBOSE_ALL else '-q'
     ),
     suffix='.dot',

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -112,10 +112,6 @@ v_files = [str(f) for f in v_nodes]
 src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-if len(src_synth) == 0:
-    print('Error: no verilog module files found (.v)')
-    Exit(1)
-
 # -- Get the CST file
 CST = ''
 CST_list = Glob('*.cst')

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -17,14 +17,13 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
 from SCons.Script.SConscript import SConsEnvironment
 from apio.scons_util import (get_constraint_file, error, fatal_error, 
                              create_construction_env, arg_bool, arg_str,
-                             get_verilator_param_str)
+                             get_verilator_param_str, get_programmer_cmd)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 
 # -- Get arguments
-PROG = arg_str(env, 'prog', '')
 FPGA_MODEL = arg_str(env, 'fpga_model', '')
 FPGA_SIZE = arg_str(env, 'fpga_size', '')
 FPGA_TYPE = arg_str(env, 'fpga_type', '')
@@ -41,19 +40,6 @@ VERILATOR_TOP = arg_str(env, 'top', '')
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
-# -- Just for debugging
-if 'build' in COMMAND_LINE_TARGETS or \
-   'upload' in COMMAND_LINE_TARGETS or \
-   'time' in COMMAND_LINE_TARGETS:
-
-    # print('FPGA_SIZE: {}'.format(FPGA_SIZE))
-    # print('FPGA_TYPE: {}'.format(FPGA_TYPE))
-    # print('FPGA_PACK: {}'.format(FPGA_PACK))
-
-    if 'upload' in COMMAND_LINE_TARGETS:
-        if PROG == '':
-            fatal_error(env, 'No programmer command found.')
-        assert "${SOURCE}" in PROG, f"{PROG = }"
    
 # -- Resources paths
 IVL_PATH = os.environ['IVL'] if 'IVL' in os.environ else ''
@@ -142,8 +128,8 @@ if(VERBOSE_ALL or VERBOSE_PNR):
     AlwaysBuild(asc_target)
 
 # -- Upload the bitstream into FPGA
-programmer = PROG.replace("${SOURCE}", "$SOURCE")
-upload_target = env.Alias('upload', bitstream_target, programmer)
+programmer_cmd = get_programmer_cmd(env)
+upload_target = env.Alias('upload', bitstream_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -145,7 +145,7 @@ env.Append(BUILDERS={'Bin': bitstream_builder})
 # -- Time report builder
 # https://github.com/cliffordwolf/icestorm/issues/57
 time_rpt_builder = Builder(
-    action='echo No timme analysis report implemented for Gowin devices $TARGET $SOURCE > $TARGET',
+    action='echo "Time analysis report is not impelemnted for the Gowin family." > $TARGET',
     suffix='.rpt',
     src_suffix='.pnr.json')
 env.Append(BUILDERS={'Time': time_rpt_builder})

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -11,51 +11,69 @@ import os
 import re
 from platform import system
 from apio import scons_util
-from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
-                          GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
-                          Variables, Help, Glob)
+from SCons.Script import (
+    Builder,
+    Action,
+    DefaultEnvironment,
+    Default,
+    AlwaysBuild,
+    GetOption,
+    Exit,
+    COMMAND_LINE_TARGETS,
+    ARGUMENTS,
+    Variables,
+    Help,
+    Glob,
+)
 from SCons.Script.SConscript import SConsEnvironment
-from apio.scons_util import (get_constraint_file, error, fatal_error, 
-                             create_construction_env, arg_bool, arg_str,
-                             get_verilator_param_str, get_programmer_cmd)
+from apio.scons_util import (
+    get_constraint_file,
+    error,
+    fatal_error,
+    create_construction_env,
+    arg_bool,
+    arg_str,
+    get_verilator_param_str,
+    get_programmer_cmd,
+)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 
 # -- Get arguments
-FPGA_MODEL = arg_str(env, 'fpga_model', '')
-FPGA_SIZE = arg_str(env, 'fpga_size', '')
-FPGA_TYPE = arg_str(env, 'fpga_type', '')
-FPGA_PACK = arg_str(env, 'fpga_pack', '')
-TOP_MODULE = arg_str(env, 'top_module', '')
-VERBOSE_ALL = arg_bool(env, 'verbose_all', False)
-VERBOSE_YOSYS = arg_bool(env, 'verbose_yosys', False)
-VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
-TESTBENCH = arg_str(env, 'testbench', '')
-VERILATOR_ALL = arg_bool(env, 'all', False)
-VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
+FPGA_MODEL = arg_str(env, "fpga_model", "")
+FPGA_SIZE = arg_str(env, "fpga_size", "")
+FPGA_TYPE = arg_str(env, "fpga_type", "")
+FPGA_PACK = arg_str(env, "fpga_pack", "")
+TOP_MODULE = arg_str(env, "top_module", "")
+VERBOSE_ALL = arg_bool(env, "verbose_all", False)
+VERBOSE_YOSYS = arg_bool(env, "verbose_yosys", False)
+VERBOSE_PNR = arg_bool(env, "verbose_pnr", False)
+TESTBENCH = arg_str(env, "testbench", "")
+VERILATOR_ALL = arg_bool(env, "all", False)
+VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
-   
+
 # -- Resources paths
-IVL_PATH = os.environ['IVL'] if 'IVL' in os.environ else ''
-ICEBOX_PATH = os.environ['ICEBOX'] if 'ICEBOX' in os.environ else ''
-CHIPDB_PATH = os.path.join(ICEBOX_PATH, 'chipdb-{0}.txt'.format(FPGA_SIZE))
-YOSYS_PATH = os.environ['YOSYS_LIB'] if 'YOSYS_LIB' in os.environ else ''
+IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
+ICEBOX_PATH = os.environ["ICEBOX"] if "ICEBOX" in os.environ else ""
+CHIPDB_PATH = os.path.join(ICEBOX_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
+YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
 YOSYS_CELLS_PATH = f"{YOSYS_PATH}/gowin/cells_sim.v"
 
-isWindows = 'Windows' == system()
-VVP_PATH = '' if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
-IVER_PATH = '' if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
+isWindows = "Windows" == system()
+VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
+IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 
 # -- Target name
-TARGET = 'hardware'
+TARGET = "hardware"
 
 # -- Scan required .list files
-list_files_re = re.compile(r'[\n|\s][^\/]?\"(.*\.list?)\"', re.M)
+list_files_re = re.compile(r"[\n|\s][^\/]?\"(.*\.list?)\"", re.M)
 
 
 def list_files_scan(node, env, path):
@@ -68,90 +86,103 @@ list_scanner = env.Scanner(function=list_files_scan)
 
 # -- Get a list of all the verilog files in the src folfer, in ASCII, with
 # -- the full path. All these files are used for the simulation
-v_nodes = Glob('*.v')
+v_nodes = Glob("*.v")
 v_files = [str(f) for f in v_nodes]
 
 # Construct disjoint lists of .v module and testbench files.
-src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
-list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
+src_synth = [f for f in v_files if f[-5:].upper() != "_TB.V"]
+list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
 
 # -- Get the CST file name.
 CST = get_constraint_file(env, ".cst", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(
-    action='yosys -D LEDS_NR=6 -p \"synth_gowin {0} -json $TARGET\" {1} $SOURCES'.format(
-        ('-top '+TOP_MODULE) if TOP_MODULE else '',
-        '' if VERBOSE_ALL or VERBOSE_YOSYS else '-q'
+    action='yosys -D LEDS_NR=6 -p "synth_gowin {0} -json $TARGET" {1} $SOURCES'.format(
+        ("-top " + TOP_MODULE) if TOP_MODULE else "",
+        "" if VERBOSE_ALL or VERBOSE_YOSYS else "-q",
     ),
-    suffix='.json',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'Synth': synth_builder})
+    suffix=".json",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"Synth": synth_builder})
 
 # -- Place and route Builder.
 pnr_builder = Builder(
-    action='nextpnr-himbaechel --device {0} --json $SOURCE --write $TARGET --vopt family={5} --vopt cst={3} {4}'.format(
-        FPGA_MODEL, FPGA_SIZE, FPGA_PACK, CST,
-        '' if VERBOSE_ALL or VERBOSE_PNR else '-q', FPGA_TYPE),
-    suffix='.pnr.json',
-    src_suffix='.json')
-env.Append(BUILDERS={'PnR': pnr_builder})
+    action="nextpnr-himbaechel --device {0} --json $SOURCE --write $TARGET --vopt family={5} --vopt cst={3} {4}".format(
+        FPGA_MODEL,
+        FPGA_SIZE,
+        FPGA_PACK,
+        CST,
+        "" if VERBOSE_ALL or VERBOSE_PNR else "-q",
+        FPGA_TYPE,
+    ),
+    suffix=".pnr.json",
+    src_suffix=".json",
+)
+env.Append(BUILDERS={"PnR": pnr_builder})
 
 # -- Bitstream Builder.
 bitstream_builder = Builder(
-    action='gowin_pack -d {0} -o $TARGET $SOURCE'.format(FPGA_TYPE.upper()),
-    suffix='.fs',
-    src_suffix='.pnr.json')
-env.Append(BUILDERS={'Bin': bitstream_builder})
+    action="gowin_pack -d {0} -o $TARGET $SOURCE".format(FPGA_TYPE.upper()),
+    suffix=".fs",
+    src_suffix=".pnr.json",
+)
+env.Append(BUILDERS={"Bin": bitstream_builder})
 
 # -- Time report builder
 # https://github.com/cliffordwolf/icestorm/issues/57
 time_rpt_builder = Builder(
     action='echo "Time analysis report is not impelemnted for the Gowin family." > $TARGET',
-    suffix='.rpt',
-    src_suffix='.pnr.json')
-env.Append(BUILDERS={'Time': time_rpt_builder})
+    suffix=".rpt",
+    src_suffix=".pnr.json",
+)
+env.Append(BUILDERS={"Time": time_rpt_builder})
 
 # -- Generate the bitstream
 blif_target = env.Synth(TARGET, [src_synth])
 asc_target = env.PnR(TARGET, [blif_target, CST])
 bitstream_target = env.Bin(TARGET, asc_target)
 
-build_target = env.Alias('build', bitstream_target)
+build_target = env.Alias("build", bitstream_target)
 AlwaysBuild(build_target)
 
-if(VERBOSE_ALL or VERBOSE_YOSYS):
+if VERBOSE_ALL or VERBOSE_YOSYS:
     AlwaysBuild(blif_target)
-if(VERBOSE_ALL or VERBOSE_PNR):
+if VERBOSE_ALL or VERBOSE_PNR:
     AlwaysBuild(asc_target)
 
 # -- Upload the bitstream into FPGA
 programmer_cmd = get_programmer_cmd(env)
-upload_target = env.Alias('upload', bitstream_target, programmer_cmd)
+upload_target = env.Alias("upload", bitstream_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time
 rpt_target = env.Time(asc_target)
-AlwaysBuild(rpt_target) 
-time_target = env.Alias('time', rpt_target)
+AlwaysBuild(rpt_target)
+time_target = env.Alias("time", rpt_target)
 
 # -- Icarus Verilog builders
 
+
 def iverilog_generator(source, target, env, for_signature):
-    """Constructs dynamically a commands for iverlog targets builders. """
-    target_name, _  = os.path.splitext(str(target[0]))  # E.g. "my_module" or"my_module_tb"
+    """Constructs dynamically a commands for iverlog targets builders."""
+    target_name, _ = os.path.splitext(
+        str(target[0])
+    )  # E.g. "my_module" or"my_module_tb"
     # Testbenches use the value macro VCD_OUTPUT to know the name of the waves output file.
-    # We also pass a dummy when the verify command to avoid a warning about the undefined macro. 
+    # We also pass a dummy when the verify command to avoid a warning about the undefined macro.
     is_testbench = target_name.upper().endswith("_TB")
-    is_verify = 'verify' in COMMAND_LINE_TARGETS
+    is_verify = "verify" in COMMAND_LINE_TARGETS
     vcd_output_flag = (
-        f'-D VCD_OUTPUT=dummy_vcd_output'  if is_verify 
-        else  f'-D VCD_OUTPUT={target_name}' if is_testbench 
-        else  "")
-    verbose_flag = '-v' if VERBOSE_ALL else ''
+        f"-D VCD_OUTPUT=dummy_vcd_output"
+        if is_verify
+        else f"-D VCD_OUTPUT={target_name}" if is_testbench else ""
+    )
+    verbose_flag = "-v" if VERBOSE_ALL else ""
     # If running a testbench with the sim command, we define the macro INTERACTIVE_SIM that
-    # allows the testbench to supress assertions so we can examine the waves in gtkwave. 
+    # allows the testbench to supress assertions so we can examine the waves in gtkwave.
     # For example, with an assertion macro like this one that fails when running apio test.
     # `define EXPECT(signal, value) \
     #     if (signal !== value) begin \
@@ -160,50 +191,57 @@ def iverilog_generator(source, target, env, for_signature):
     #             $fatal; \
     #         `endif \
     #     end
-    is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
-    interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
+    is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
+    interactive_sim_flag = f"-D INTERACTIVE_SIM" if is_interactive_sim else ""
     result = 'iverilog {0} {1} -o $TARGET {2} {3} "{4}" $SOURCES'.format(
-        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_CELLS_PATH)
+        IVER_PATH,
+        verbose_flag,
+        vcd_output_flag,
+        interactive_sim_flag,
+        YOSYS_CELLS_PATH,
+    )
     return result
+
 
 iverilog_builder = Builder(
     # Action string is computed automatically by the generator.
-    generator = iverilog_generator,
-    suffix='.out',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'IVerilog': iverilog_builder})
+    generator=iverilog_generator,
+    suffix=".out",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"IVerilog": iverilog_builder})
 
 dot_builder = Builder(
-    action='yosys -f verilog -p \"show -format dot -colors 1 -prefix hardware {0}\" {1} $SOURCES'.format(
-        TOP_MODULE if TOP_MODULE else 'unknown_top',
-        '' if VERBOSE_ALL else '-q'
+    action='yosys -f verilog -p "show -format dot -colors 1 -prefix hardware {0}" {1} $SOURCES'.format(
+        TOP_MODULE if TOP_MODULE else "unknown_top",
+        "" if VERBOSE_ALL else "-q",
     ),
-    suffix='.dot',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'DOT': dot_builder})
+    suffix=".dot",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"DOT": dot_builder})
 
 svg_builder = Builder(
     # Expecting graphviz dot to be installed and in the path.
-    action='dot -Tsvg $SOURCES -o $TARGET',
-    suffix='.svg',
-    src_suffix='.dot',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'SVG': svg_builder})
+    action="dot -Tsvg $SOURCES -o $TARGET",
+    suffix=".svg",
+    src_suffix=".dot",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"SVG": svg_builder})
 
 # NOTE: output file name is defined in the iverilog call using VCD_OUTPUT macro
 vcd_builder = Builder(
-    action='vvp {0} $SOURCE'.format(
-        VVP_PATH),
-    suffix='.vcd',
-    src_suffix='.out')
-env.Append(BUILDERS={'VCD': vcd_builder})
+    action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
+)
+env.Append(BUILDERS={"VCD": vcd_builder})
 
 # --- Verify
 vout_target = env.IVerilog(TARGET, src_synth + list_tb)
 AlwaysBuild(vout_target)
-verify_target = env.Alias('verify', vout_target)
+verify_target = env.Alias("verify", vout_target)
 
 # --- Graph
 # TODO: Launch some portable SVG (or differentn format) viewer.
@@ -211,26 +249,30 @@ dot_target = env.DOT(TARGET, src_synth)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
-graph_target = env.Alias('graph', svg_target)
+graph_target = env.Alias("graph", svg_target)
 
 # --- Simulation
-# Since the simulation targets are dynamic due to the testbench selection, we 
+# Since the simulation targets are dynamic due to the testbench selection, we
 # create them only when running simulation.
-if 'sim' in COMMAND_LINE_TARGETS: 
-    assert 'test' not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
+if "sim" in COMMAND_LINE_TARGETS:
+    assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench.
         sim_testbench = TESTBENCH
     else:
         # No --testbench flag specified. If there is exactly one testbench then pick
-        # it, otherwise fail. 
+        # it, otherwise fail.
         if len(list_tb) == 0:
-            fatal_error(env, 'No testbench found for simulation.')
+            fatal_error(env, "No testbench found for simulation.")
         if len(list_tb) > 1:
             # TODO: consider to allow specifying the default testbench in apio.ini.
-            error('Found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
+            error(
+                "Found {} testbranches, please use the --testbench flag.".format(
+                    len(list_tb)
+                )
+            )
             for tb in list_tb:
-                print('- {}'.format(tb))
+                print("- {}".format(tb))
             Exit(1)
         sim_testbench = list_tb[0]  # Pick the only available testbench.
     # Here sim_testbench contains the testbench, e.g. my_module_tb.v.
@@ -239,30 +281,36 @@ if 'sim' in COMMAND_LINE_TARGETS:
     src_sim.extend(src_synth)  # All the .v files.
     src_sim.append(sim_testbench)
     # Create targets sim target and its dependent.
-    sim_name, _ = os.path.splitext(sim_testbench)  #e.g. my_module_tb
+    sim_name, _ = os.path.splitext(sim_testbench)  # e.g. my_module_tb
     sout_target = env.IVerilog(sim_name, src_sim)
     vcd_file_target = env.VCD(sout_target)
     # 'do_initial_zoom_fit' does max zoom only if .gtkw file not found.
-    waves_target = env.Alias('sim', vcd_file_target, 'gtkwave {0} {1} {2}.gtkw'.format(
-        '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
-        vcd_file_target[0], sim_name))
+    waves_target = env.Alias(
+        "sim",
+        vcd_file_target,
+        "gtkwave {0} {1} {2}.gtkw".format(
+            '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
+            vcd_file_target[0],
+            sim_name,
+        ),
+    )
     AlwaysBuild(waves_target)
 
 
 # --- Testing
-# Since the simulation targets are dynamic due to the testbench selection, we 
+# Since the simulation targets are dynamic due to the testbench selection, we
 # create them only when running simulation.
-if 'test' in COMMAND_LINE_TARGETS: 
-    assert 'sim' not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
+if "test" in COMMAND_LINE_TARGETS:
+    assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench. We test just that one.
-        test_tbs= [ TESTBENCH ]
+        test_tbs = [TESTBENCH]
     else:
         # No --testbench flag specified. We will test all them.
         if len(list_tb) == 0:
-            fatal_error(env, 'No testbenchs found for simulation.')
-        test_tbs= list_tb  # All testbenches.
-    tests = [] # Targets of all tests
+            fatal_error(env, "No testbenchs found for simulation.")
+        test_tbs = list_tb  # All testbenches.
+    tests = []  # Targets of all tests
     for test_tb in test_tbs:
         # Create a list of source files. All the modules + the current testbench.
         src_test = []
@@ -270,8 +318,8 @@ if 'test' in COMMAND_LINE_TARGETS:
         src_test.append(test_tb)
         # Create the targets for the 'out' and 'vcd' files of the testbench.
         # NOTE: Remove the two AlwaysBuild() calls below for an incremental test. Fast, correct,
-        # but may confuse the user seeing nothing happens. 
-        test_name, _ = os.path.splitext(test_tb)  #e.g. my_module_tb
+        # but may confuse the user seeing nothing happens.
+        test_name, _ = os.path.splitext(test_tb)  # e.g. my_module_tb
         test_out_target = env.IVerilog(test_name, src_test)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
@@ -279,53 +327,63 @@ if 'test' in COMMAND_LINE_TARGETS:
         test_target = env.Alias(test_name, [test_out_target, test_vcd_target])
         tests.append(test_target)
     # Create a target for the test command that depends on all the test targets.
-    tests_target = env.Alias('test', tests)
+    tests_target = env.Alias("test", tests)
     AlwaysBuild(tests_target)
+
 
 # -- Verilator config file builder
 def verilator_config_func(target, source, env):
-        with open(target[0].get_path(), 'w') as target_file:
-            # NOTE: This config was copied from ICE40. Adjust as needed.
-            target_file.write('`verilator_config\n'
-                f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
-                f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n')
-        return 0
+    with open(target[0].get_path(), "w") as target_file:
+        # NOTE: This config was copied from ICE40. Adjust as needed.
+        target_file.write(
+            "`verilator_config\n"
+            f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
+            f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n'
+        )
+    return 0
+
 
 verilator_config_builder = Builder(
     action=Action(verilator_config_func, "Creating verilator config file."),
-    suffix='.vlt',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'VerilatorConfig': verilator_config_builder})
+    suffix=".vlt",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
 # -- Verilator builder
 verilator_builder = Builder(
     action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP {0} {1} {2} {3} $SOURCES "{4}"'.format(
-        '-Wall' if VERILATOR_ALL else '',
-        '-Wno-style' if VERILATOR_NO_STYLE else '',
+        "-Wall" if VERILATOR_ALL else "",
+        "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
-        '--top-module ' + TOP_MODULE if TOP_MODULE else '',
-        YOSYS_CELLS_PATH),
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'Verilator': verilator_builder})
+        "--top-module " + TOP_MODULE if TOP_MODULE else "",
+        YOSYS_CELLS_PATH,
+    ),
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"Verilator": verilator_builder})
 
 # --- Lint
 lint_config_target = env.VerilatorConfig(TARGET, [])
-lint_out_target = env.Verilator(TARGET, [TARGET + ".vlt"] + src_synth + list_tb)
-lint_target = env.Alias('lint', lint_out_target)
+lint_out_target = env.Verilator(
+    TARGET, [TARGET + ".vlt"] + src_synth + list_tb
+)
+lint_target = env.Alias("lint", lint_out_target)
 AlwaysBuild(lint_target)
 
 Default(bitstream_target)
 
 # -- These is for cleaning the artifact files.
-if GetOption('clean'):
+if GetOption("clean"):
     # Identify additional files that may not be associated with targets and
     # associate them with a target such that they will be cleaned up as well.
     # This cleans for example artifacts of past simulation since the testbench
     # target are dynamic and changes with the selected testbench.
-    for glob_pattern in ['*.out', '*.vcd']:
+    for glob_pattern in ["*.out", "*.vcd"]:
         for node in Glob(glob_pattern):
             env.Clean(time_target, str(node))
 
-    env.Default([time_target, build_target, vout_target, graph_target, lint_target])
-
+    env.Default(
+        [time_target, build_target, vout_target, graph_target, lint_target]
+    )

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -15,28 +15,30 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 from SCons.Script.SConscript import SConsEnvironment
-from apio.scons_util import get_constraint_file, error, fatal_error, create_construction_env
+from apio.scons_util import (get_constraint_file, error, fatal_error, 
+                             create_construction_env, arg_bool, arg_str)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 
 # -- Load arguments
-PROG = ARGUMENTS.get('prog', '')
-FPGA_MODEL = ARGUMENTS.get('fpga_model', '')
-FPGA_SIZE = ARGUMENTS.get('fpga_size', '')
-FPGA_TYPE = ARGUMENTS.get('fpga_type', '')
-FPGA_PACK = ARGUMENTS.get('fpga_pack', '')
-TOP_MODULE = ARGUMENTS.get('top_module', '')
-VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
-VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
-VERBOSE_PNR = ARGUMENTS.get('verbose_pnr', False)
-TESTBENCH = ARGUMENTS.get('testbench', '')
-VERILATOR_ALL = ARGUMENTS.get('all', False)
-VERILATOR_NO_STYLE = ARGUMENTS.get('nostyle', False)
-VERILATOR_NO_WARN = ARGUMENTS.get('nowarn', '').split(',')
-VERILATOR_WARN = ARGUMENTS.get('warn', '').split(',')
-VERILATOR_TOP = ARGUMENTS.get('top', '')
+PROG = arg_str(env, 'prog', '')
+FPGA_MODEL = arg_str(env, 'fpga_model', '')
+FPGA_SIZE = arg_str(env, 'fpga_size', '')
+FPGA_TYPE = arg_str(env, 'fpga_type', '')
+FPGA_PACK = arg_str(env, 'fpga_pack', '')
+TOP_MODULE = arg_str(env, 'top_module', '')
+VERBOSE_ALL = arg_bool(env, 'verbose_all', False)
+VERBOSE_YOSYS = arg_bool(env, 'verbose_yosys', False)
+VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
+TESTBENCH = arg_str(env, 'testbench', '')
+VERILATOR_ALL = arg_bool(env, 'all', False)
+VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
+VERILATOR_NO_WARN = arg_str(env, 'nowarn', '').split(',')
+VERILATOR_WARN = arg_str(env, 'warn', '').split(',')
+VERILATOR_TOP = arg_str(env, 'top', '')
+
 VERILATOR_PARAM_STR = ''
 for warn in VERILATOR_NO_WARN:
     if warn != '':

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -13,27 +13,28 @@ from platform import system
 from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
-from SCons.Script.SConscript import SConsEnvironment
-from apio.scons_util import get_constraint_file, error, fatal_error, create_construction_env
+from apio.scons_util import (get_constraint_file, error, fatal_error, 
+                             create_construction_env, arg_bool, arg_str)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 # -- Load arguments
-PROG = ARGUMENTS.get('prog', '')
-FPGA_SIZE = ARGUMENTS.get('fpga_size', '')
-FPGA_TYPE = ARGUMENTS.get('fpga_type', '')
-FPGA_PACK = ARGUMENTS.get('fpga_pack', '')
-TOP_MODULE = ARGUMENTS.get('top_module', '')
-VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
-VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
-VERBOSE_PNR = ARGUMENTS.get('verbose_pnr', False)
-TESTBENCH = ARGUMENTS.get('testbench', '')
-VERILATOR_ALL = ARGUMENTS.get('all', False)
-VERILATOR_NO_STYLE = ARGUMENTS.get('nostyle', False)
-VERILATOR_NO_WARN = ARGUMENTS.get('nowarn', '').split(',')
-VERILATOR_WARN = ARGUMENTS.get('warn', '').split(',')
-VERILATOR_TOP = ARGUMENTS.get('top', '')
+PROG = arg_str(env, 'prog', '')
+FPGA_SIZE = arg_str(env, 'fpga_size', '')
+FPGA_TYPE = arg_str(env, 'fpga_type', '')
+FPGA_PACK = arg_str(env, 'fpga_pack', '')
+TOP_MODULE = arg_str(env, 'top_module', '')
+VERBOSE_ALL = arg_bool(env, 'verbose_all', False)
+VERBOSE_YOSYS = arg_bool(env, 'verbose_yosys', False)
+VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
+TESTBENCH = arg_str(env, 'testbench', '')
+VERILATOR_ALL = arg_bool(env, 'all', False)
+VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
+VERILATOR_NO_WARN = arg_str(env, 'nowarn', '').split(',')
+VERILATOR_WARN = arg_str(env, 'warn', '').split(',')
+VERILATOR_TOP = arg_str(env, 'top', '')
+
 VERILATOR_PARAM_STR = ''
 for warn in VERILATOR_NO_WARN:
     if warn != '':

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -20,7 +20,7 @@ PROG = ARGUMENTS.get('prog', '')
 FPGA_SIZE = ARGUMENTS.get('fpga_size', '')
 FPGA_TYPE = ARGUMENTS.get('fpga_type', '')
 FPGA_PACK = ARGUMENTS.get('fpga_pack', '')
-YOSYS_TOP = ARGUMENTS.get('top_module', '')
+TOP_MODULE = ARGUMENTS.get('top_module', '')
 VERBOSE_ALL = ARGUMENTS.get('verbose_all', False)
 VERBOSE_YOSYS = ARGUMENTS.get('verbose_yosys', False)
 VERBOSE_PNR = ARGUMENTS.get('verbose_pnr', False)
@@ -109,13 +109,13 @@ v_files = [str(f) for f in v_nodes]
 src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-# -- Get the PCF file. 
-PCF = scons_util.get_constraint_file(".pcf", Glob)
+# -- Get the PCF file name.
+PCF = scons_util.get_constraint_file(env, ".pcf", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(
     action='yosys -p \"synth_ice40 {0} -json $TARGET\" {1} $SOURCES'.format(
-        ('-top '+YOSYS_TOP) if YOSYS_TOP else '',
+        ('-top '+TOP_MODULE) if TOP_MODULE else '',
         '' if VERBOSE_ALL or VERBOSE_YOSYS else '-q'
     ),
     suffix='.json',
@@ -211,7 +211,7 @@ env.Append(BUILDERS={'IVerilog': iverilog_builder})
 
 dot_builder = Builder(
     action='yosys -f verilog -p \"show -format dot -colors 1 -prefix hardware {0}\" {1} $SOURCES'.format(
-        YOSYS_TOP if YOSYS_TOP else 'unknown_top',
+        TOP_MODULE if TOP_MODULE else 'unknown_top',
         '' if VERBOSE_ALL else '-q'
     ),
     suffix='.dot',

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -109,10 +109,6 @@ v_files = [str(f) for f in v_nodes]
 src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-if len(src_synth) == 0:
-    print('Error: no verilog module files found (.v)')
-    Exit(1)
-
 # -- Get the PCF file
 PCF = ''
 PCF_list = Glob('*.pcf')

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -10,48 +10,66 @@
 import os
 import re
 from platform import system
-from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
-                          GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
-                          Variables, Help, Glob)
-from apio.scons_util import (get_constraint_file, error, fatal_error, 
-                             create_construction_env, arg_bool, arg_str, 
-                             get_verilator_param_str, get_programmer_cmd)
+from SCons.Script import (
+    Builder,
+    Action,
+    DefaultEnvironment,
+    Default,
+    AlwaysBuild,
+    GetOption,
+    Exit,
+    COMMAND_LINE_TARGETS,
+    ARGUMENTS,
+    Variables,
+    Help,
+    Glob,
+)
+from apio.scons_util import (
+    get_constraint_file,
+    error,
+    fatal_error,
+    create_construction_env,
+    arg_bool,
+    arg_str,
+    get_verilator_param_str,
+    get_programmer_cmd,
+)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 # -- Get arguments
-FPGA_SIZE = arg_str(env, 'fpga_size', '')
-FPGA_TYPE = arg_str(env, 'fpga_type', '')
-FPGA_PACK = arg_str(env, 'fpga_pack', '')
-TOP_MODULE = arg_str(env, 'top_module', '')
-VERBOSE_ALL = arg_bool(env, 'verbose_all', False)
-VERBOSE_YOSYS = arg_bool(env, 'verbose_yosys', False)
-VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
-TESTBENCH = arg_str(env, 'testbench', '')
-VERILATOR_ALL = arg_bool(env, 'all', False)
-VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
+FPGA_SIZE = arg_str(env, "fpga_size", "")
+FPGA_TYPE = arg_str(env, "fpga_type", "")
+FPGA_PACK = arg_str(env, "fpga_pack", "")
+TOP_MODULE = arg_str(env, "top_module", "")
+VERBOSE_ALL = arg_bool(env, "verbose_all", False)
+VERBOSE_YOSYS = arg_bool(env, "verbose_yosys", False)
+VERBOSE_PNR = arg_bool(env, "verbose_pnr", False)
+TESTBENCH = arg_str(env, "testbench", "")
+VERILATOR_ALL = arg_bool(env, "all", False)
+VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
 # -- Resources paths
-IVL_PATH = os.environ['IVL'] if 'IVL' in os.environ else ''
-ICEBOX_PATH = os.environ['ICEBOX'] if 'ICEBOX' in os.environ else ''
-CHIPDB_PATH = os.path.join(ICEBOX_PATH, 'chipdb-{0}.txt'.format(FPGA_SIZE))
-YOSYS_PATH = os.environ['YOSYS_LIB'] if 'YOSYS_LIB' in os.environ else ''
+IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
+ICEBOX_PATH = os.environ["ICEBOX"] if "ICEBOX" in os.environ else ""
+CHIPDB_PATH = os.path.join(ICEBOX_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
+YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
 YOSYS_CELLS_PATH = f"{YOSYS_PATH}/ice40/cells_sim.v"
 
-isWindows = 'Windows' == system()
-VVP_PATH = '' if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
-IVER_PATH = '' if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
+isWindows = "Windows" == system()
+VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
+IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 
 # -- Target name
-TARGET = 'hardware'
+TARGET = "hardware"
 
 # -- Scan required .list files
-list_files_re = re.compile(r'[\n|\s][^\/]?\"(.*\.list?)\"', re.M)
+list_files_re = re.compile(r"[\n|\s][^\/]?\"(.*\.list?)\"", re.M)
 
 
 def list_files_scan(node, env, path):
@@ -64,91 +82,102 @@ list_scanner = env.Scanner(function=list_files_scan)
 
 # -- Get a list of all the verilog files in the src folfer, in ASCII, with
 # -- the full path. All these files are used for the simulation
-v_nodes = Glob('*.v')
+v_nodes = Glob("*.v")
 v_files = [str(f) for f in v_nodes]
 
 # Construct disjoint lists of .v module and testbench files.
-src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
-list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
+src_synth = [f for f in v_files if f[-5:].upper() != "_TB.V"]
+list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
 
 # -- Get the PCF file name.
 PCF = get_constraint_file(env, ".pcf", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(
-    action='yosys -p \"synth_ice40 {0} -json $TARGET\" {1} $SOURCES'.format(
-        ('-top '+TOP_MODULE) if TOP_MODULE else '',
-        '' if VERBOSE_ALL or VERBOSE_YOSYS else '-q'
+    action='yosys -p "synth_ice40 {0} -json $TARGET" {1} $SOURCES'.format(
+        ("-top " + TOP_MODULE) if TOP_MODULE else "",
+        "" if VERBOSE_ALL or VERBOSE_YOSYS else "-q",
     ),
-    suffix='.json',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'Synth': synth_builder})
+    suffix=".json",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"Synth": synth_builder})
 
 # -- Place and route Builder.
 pnr_builder = Builder(
-    action='nextpnr-ice40 --{0}{1} --package {2} --json $SOURCE --asc $TARGET --pcf {3} {4}'.format(
-        FPGA_TYPE, FPGA_SIZE, FPGA_PACK, PCF,
-        '' if VERBOSE_ALL or VERBOSE_PNR else '-q'),
-    suffix='.asc',
-    src_suffix='.json')
-env.Append(BUILDERS={'PnR': pnr_builder})
+    action="nextpnr-ice40 --{0}{1} --package {2} --json $SOURCE --asc $TARGET --pcf {3} {4}".format(
+        FPGA_TYPE,
+        FPGA_SIZE,
+        FPGA_PACK,
+        PCF,
+        "" if VERBOSE_ALL or VERBOSE_PNR else "-q",
+    ),
+    suffix=".asc",
+    src_suffix=".json",
+)
+env.Append(BUILDERS={"PnR": pnr_builder})
 
 # -- Bitstream Builder.
 bitstream_builder = Builder(
-    action='icepack $SOURCE $TARGET',
-    suffix='.bin',
-    src_suffix='.asc')
-env.Append(BUILDERS={'Bin': bitstream_builder})
+    action="icepack $SOURCE $TARGET", suffix=".bin", src_suffix=".asc"
+)
+env.Append(BUILDERS={"Bin": bitstream_builder})
 
 # -- Time report builder
 # https://github.com/cliffordwolf/icestorm/issues/57
 time_rpt_builder = Builder(
     action='icetime -d {0}{1} -P {2} -C "{3}" -mtr $TARGET $SOURCE'.format(
-        FPGA_TYPE, FPGA_SIZE, FPGA_PACK, CHIPDB_PATH),
-    suffix='.rpt',
-    src_suffix='.asc')
-env.Append(BUILDERS={'Time': time_rpt_builder})
+        FPGA_TYPE, FPGA_SIZE, FPGA_PACK, CHIPDB_PATH
+    ),
+    suffix=".rpt",
+    src_suffix=".asc",
+)
+env.Append(BUILDERS={"Time": time_rpt_builder})
 
 # -- Generate the bitstream
 blif_target = env.Synth(TARGET, [src_synth])
 asc_target = env.PnR(TARGET, [blif_target, PCF])
 bitstream_target = env.Bin(TARGET, asc_target)
 
-build_target = env.Alias('build', bitstream_target)
+build_target = env.Alias("build", bitstream_target)
 AlwaysBuild(build_target)
 
-if(VERBOSE_ALL or VERBOSE_YOSYS):
+if VERBOSE_ALL or VERBOSE_YOSYS:
     AlwaysBuild(blif_target)
-if(VERBOSE_ALL or VERBOSE_PNR):
+if VERBOSE_ALL or VERBOSE_PNR:
     AlwaysBuild(asc_target)
 
 # -- Upload the bitstream into FPGA
 programmer_cmd = get_programmer_cmd(env)
-upload_target = env.Alias('upload', bitstream_target, programmer_cmd)
+upload_target = env.Alias("upload", bitstream_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time
 rpt_target = env.Time(asc_target)
-AlwaysBuild(rpt_target) 
-time_target = env.Alias('time', rpt_target)
+AlwaysBuild(rpt_target)
+time_target = env.Alias("time", rpt_target)
 
 # -- Icarus Verilog builders
 
+
 def iverilog_generator(source, target, env, for_signature):
-    """Constructs dynamically a commands for iverlog targets builders. """
-    target_name, _  = os.path.splitext(str(target[0]))  # E.g. "my_module" or"my_module_tb"
+    """Constructs dynamically a commands for iverlog targets builders."""
+    target_name, _ = os.path.splitext(
+        str(target[0])
+    )  # E.g. "my_module" or"my_module_tb"
     # Testbenches use the value macro VCD_OUTPUT to know the name of the waves output file.
-    # We also pass a dummy when the verify command to avoid a warning about the undefined macro. 
+    # We also pass a dummy when the verify command to avoid a warning about the undefined macro.
     is_testbench = target_name.upper().endswith("_TB")
-    is_verify = 'verify' in COMMAND_LINE_TARGETS
+    is_verify = "verify" in COMMAND_LINE_TARGETS
     vcd_output_flag = (
-        f'-D VCD_OUTPUT=dummy_vcd_output'  if is_verify 
-        else  f'-D VCD_OUTPUT={target_name}' if is_testbench 
-        else  "")
-    verbose_flag = '-v' if VERBOSE_ALL else ''
+        f"-D VCD_OUTPUT=dummy_vcd_output"
+        if is_verify
+        else f"-D VCD_OUTPUT={target_name}" if is_testbench else ""
+    )
+    verbose_flag = "-v" if VERBOSE_ALL else ""
     # If running a testbench with the sim command, we define the macro INTERACTIVE_SIM that
-    # allows the testbench to supress assertions so we can examine the waves in gtkwave. 
+    # allows the testbench to supress assertions so we can examine the waves in gtkwave.
     # For example, with an assertion macro like this one that fails when running apio test.
     # `define EXPECT(signal, value) \
     #     if (signal !== value) begin \
@@ -157,50 +186,57 @@ def iverilog_generator(source, target, env, for_signature):
     #             $fatal; \
     #         `endif \
     #     end
-    is_interactive_sim = is_testbench and 'sim' in COMMAND_LINE_TARGETS
-    interactive_sim_flag = f'-D INTERACTIVE_SIM' if is_interactive_sim else ""
+    is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
+    interactive_sim_flag = f"-D INTERACTIVE_SIM" if is_interactive_sim else ""
     result = 'iverilog {0} {1} -o $TARGET {2} {3} -D NO_ICE40_DEFAULT_ASSIGNMENTS "{4}" $SOURCES'.format(
-        IVER_PATH, verbose_flag, vcd_output_flag, interactive_sim_flag, YOSYS_CELLS_PATH)
+        IVER_PATH,
+        verbose_flag,
+        vcd_output_flag,
+        interactive_sim_flag,
+        YOSYS_CELLS_PATH,
+    )
     return result
+
 
 iverilog_builder = Builder(
     # Action string is computed automatically by the generator.
-    generator = iverilog_generator,
-    suffix='.out',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'IVerilog': iverilog_builder})
+    generator=iverilog_generator,
+    suffix=".out",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"IVerilog": iverilog_builder})
 
 dot_builder = Builder(
-    action='yosys -f verilog -p \"show -format dot -colors 1 -prefix hardware {0}\" {1} $SOURCES'.format(
-        TOP_MODULE if TOP_MODULE else 'unknown_top',
-        '' if VERBOSE_ALL else '-q'
+    action='yosys -f verilog -p "show -format dot -colors 1 -prefix hardware {0}" {1} $SOURCES'.format(
+        TOP_MODULE if TOP_MODULE else "unknown_top",
+        "" if VERBOSE_ALL else "-q",
     ),
-    suffix='.dot',
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'DOT': dot_builder})
+    suffix=".dot",
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"DOT": dot_builder})
 
 svg_builder = Builder(
     # Expecting graphviz dot to be installed and in the path.
-    action='dot -Tsvg $SOURCES -o $TARGET',
-    suffix='.svg',
-    src_suffix='.dot',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'SVG': svg_builder})
+    action="dot -Tsvg $SOURCES -o $TARGET",
+    suffix=".svg",
+    src_suffix=".dot",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"SVG": svg_builder})
 
 # NOTE: output file name is defined in the iverilog call using VCD_OUTPUT macro
 vcd_builder = Builder(
-    action='vvp {0} $SOURCE'.format(
-        VVP_PATH),
-    suffix='.vcd',
-    src_suffix='.out')
-env.Append(BUILDERS={'VCD': vcd_builder})
+    action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
+)
+env.Append(BUILDERS={"VCD": vcd_builder})
 
 # --- Verify
 vout_target = env.IVerilog(TARGET, src_synth + list_tb)
 AlwaysBuild(vout_target)
-verify_target = env.Alias('verify', vout_target)
+verify_target = env.Alias("verify", vout_target)
 
 # --- Graph
 # TODO: Launch some portable SVG (or differentn format) viewer.
@@ -208,26 +244,31 @@ dot_target = env.DOT(TARGET, src_synth)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
-graph_target = env.Alias('graph', svg_target)
+graph_target = env.Alias("graph", svg_target)
 
 # --- Simulation
-# Since the simulation targets are dynamic due to the testbench selection, we 
+# Since the simulation targets are dynamic due to the testbench selection, we
 # create them only when running simulation.
-if 'sim' in COMMAND_LINE_TARGETS: 
-    assert 'test' not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
+if "sim" in COMMAND_LINE_TARGETS:
+    assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench.
         sim_testbench = TESTBENCH
     else:
         # No --testbench flag specified. If there is exactly one testbench then pick
-        # it, otherwise fail. 
+        # it, otherwise fail.
         if len(list_tb) == 0:
-            fatal_error(env, 'No testbench found for simulation.')
+            fatal_error(env, "No testbench found for simulation.")
         if len(list_tb) > 1:
             # TODO: consider to allow specifying the default testbench in apio.ini.
-            error(env, 'Found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
+            error(
+                env,
+                "Found {} testbranches, please use the --testbench flag.".format(
+                    len(list_tb)
+                ),
+            )
             for tb in list_tb:
-                print('- {}'.format(tb))
+                print("- {}".format(tb))
             Exit(1)
         sim_testbench = list_tb[0]  # Pick the only available testbench.
     # Here sim_testbench contains the testbench, e.g. my_module_tb.v.
@@ -236,30 +277,36 @@ if 'sim' in COMMAND_LINE_TARGETS:
     src_sim.extend(src_synth)  # All the .v files.
     src_sim.append(sim_testbench)
     # Create targets sim target and its dependent.
-    sim_name, _ = os.path.splitext(sim_testbench)  #e.g. my_module_tb
+    sim_name, _ = os.path.splitext(sim_testbench)  # e.g. my_module_tb
     sout_target = env.IVerilog(sim_name, src_sim)
     vcd_file_target = env.VCD(sout_target)
     # 'do_initial_zoom_fit' does max zoom only if .gtkw file not found.
-    waves_target = env.Alias('sim', vcd_file_target, 'gtkwave {0} {1} {2}.gtkw'.format(
-        '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
-        vcd_file_target[0], sim_name))
+    waves_target = env.Alias(
+        "sim",
+        vcd_file_target,
+        "gtkwave {0} {1} {2}.gtkw".format(
+            '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
+            vcd_file_target[0],
+            sim_name,
+        ),
+    )
     AlwaysBuild(waves_target)
 
 
 # --- Testing
-# Since the simulation targets are dynamic due to the testbench selection, we 
+# Since the simulation targets are dynamic due to the testbench selection, we
 # create them only when running simulation.
-if 'test' in COMMAND_LINE_TARGETS: 
-    assert 'sim' not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
+if "test" in COMMAND_LINE_TARGETS:
+    assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench. We test just that one.
-        test_tbs= [ TESTBENCH ]
+        test_tbs = [TESTBENCH]
     else:
         # No --testbench flag specified. We will test all them.
         if len(list_tb) == 0:
-            fatal_error(env, 'No testbench files found (*_tb.v).')
-        test_tbs= list_tb  # All testbenches.
-    tests = [] # Targets of all tests
+            fatal_error(env, "No testbench files found (*_tb.v).")
+        test_tbs = list_tb  # All testbenches.
+    tests = []  # Targets of all tests
     for test_tb in test_tbs:
         # Create a list of source files. All the modules + the current testbench.
         src_test = []
@@ -267,8 +314,8 @@ if 'test' in COMMAND_LINE_TARGETS:
         src_test.append(test_tb)
         # Create the targets for the 'out' and 'vcd' files of the testbench.
         # NOTE: Remove the two AlwaysBuild() calls below for an incremental test. Fast, correct,
-        # but may confuse the user seeing nothing happens. 
-        test_name, _ = os.path.splitext(test_tb)  #e.g. my_module_tb
+        # but may confuse the user seeing nothing happens.
+        test_name, _ = os.path.splitext(test_tb)  # e.g. my_module_tb
         test_out_target = env.IVerilog(test_name, src_test)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
@@ -276,52 +323,62 @@ if 'test' in COMMAND_LINE_TARGETS:
         test_target = env.Alias(test_name, [test_out_target, test_vcd_target])
         tests.append(test_target)
     # Create a target for the test command that depends on all the test targets.
-    tests_target = env.Alias('test', tests)
+    tests_target = env.Alias("test", tests)
     AlwaysBuild(tests_target)
+
 
 # -- Verilator config file builder
 def verilator_config_func(target, source, env):
-        with open(target[0].get_path(), 'w') as target_file:
-            target_file.write('`verilator_config\n'
-                f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
-                f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n')
-        return 0
+    with open(target[0].get_path(), "w") as target_file:
+        target_file.write(
+            "`verilator_config\n"
+            f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
+            f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n'
+        )
+    return 0
+
 
 verilator_config_builder = Builder(
     action=Action(verilator_config_func, "Creating verilator config file."),
-    suffix='.vlt',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'VerilatorConfig': verilator_config_builder})
+    suffix=".vlt",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
 # -- Verilator builder
 verilator_builder = Builder(
     action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP -DNO_ICE40_DEFAULT_ASSIGNMENTS {0} {1} {2} {3} $SOURCES "{4}"'.format(
-        '-Wall' if VERILATOR_ALL else '',
-        '-Wno-style' if VERILATOR_NO_STYLE else '',
+        "-Wall" if VERILATOR_ALL else "",
+        "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
-        '--top-module ' + TOP_MODULE if TOP_MODULE else '',
-        YOSYS_CELLS_PATH),
-    src_suffix='.v',
-    source_scanner=list_scanner)
-env.Append(BUILDERS={'Verilator': verilator_builder})
+        "--top-module " + TOP_MODULE if TOP_MODULE else "",
+        YOSYS_CELLS_PATH,
+    ),
+    src_suffix=".v",
+    source_scanner=list_scanner,
+)
+env.Append(BUILDERS={"Verilator": verilator_builder})
 
 # --- Lint
 lint_config_target = env.VerilatorConfig(TARGET, [])
-lint_out_target = env.Verilator(TARGET, [TARGET + ".vlt"] + src_synth + list_tb)
-lint_target = env.Alias('lint', lint_out_target)
+lint_out_target = env.Verilator(
+    TARGET, [TARGET + ".vlt"] + src_synth + list_tb
+)
+lint_target = env.Alias("lint", lint_out_target)
 AlwaysBuild(lint_target)
 
 Default(bitstream_target)
 
 # -- These is for cleaning the artifact files.
-if GetOption('clean'):
+if GetOption("clean"):
     # Identify additional files that may not be associated with targets and
     # associate them with a target such that they will be cleaned up as well.
     # This cleans for example artifacts of past simulation since the testbench
     # target are dynamic and changes with the selected testbench.
-    for glob_pattern in ['*.out', '*.vcd']:
+    for glob_pattern in ["*.out", "*.vcd"]:
         for node in Glob(glob_pattern):
             env.Clean(time_target, str(node))
 
-    env.Default([time_target, build_target, vout_target, graph_target, lint_target])
-
+    env.Default(
+        [time_target, build_target, vout_target, graph_target, lint_target]
+    )

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -10,10 +10,11 @@
 import os
 import re
 from platform import system
-from apio import scons_util
 from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
+from SCons.Script.SConscript import SConsEnvironment
+from apio.scons_util import get_constraint_file, error, fatal_error, update_env_force_colors
 
 # -- Load arguments
 PROG = ARGUMENTS.get('prog', '')
@@ -51,9 +52,16 @@ vars.Add('fpga_type', 'Set the ICE40 FPGA type (hx/lp)', FPGA_TYPE)
 vars.Add('fpga_pack', 'Set the ICE40 FPGA packages', FPGA_PACK)
 
 # -- Create environment
-env = DefaultEnvironment(ENV=os.environ,
-                         tools=[],
-                         variables=vars)
+env:SConsEnvironment = DefaultEnvironment(
+        ENV=os.environ,
+        tools=[],
+        variables=vars)
+
+update_env_force_colors(env, ARGUMENTS)
+
+# For debugging.
+# from apio.scons_util import dump_env_vars
+# dump_env_vars(env)
 
 # -- Show all the flags defined, when scons is invoked with -h
 Help(vars.GenerateHelpText(env))
@@ -69,8 +77,7 @@ if 'build' in COMMAND_LINE_TARGETS or \
 
     if 'upload' in COMMAND_LINE_TARGETS:
         if PROG == '':
-            print('Error: no programmer command found')
-            Exit(1)
+            fatal_error(env, 'No programmer command found.')
         assert "${SOURCE}" in PROG, f"{PROG = }"
 
 
@@ -110,7 +117,7 @@ src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
 # -- Get the PCF file name.
-PCF = scons_util.get_constraint_file(env, ".pcf", TOP_MODULE)
+PCF = get_constraint_file(env, ".pcf", TOP_MODULE)
 
 # -- Synthesizing Builder
 synth_builder = Builder(
@@ -260,11 +267,10 @@ if 'sim' in COMMAND_LINE_TARGETS:
         # No --testbench flag specified. If there is exactly one testbench then pick
         # it, otherwise fail. 
         if len(list_tb) == 0:
-            print('Error: no testbench found for simulation.')
-            Exit(1)
+            fatal_error(env, 'No testbench found for simulation.')
         if len(list_tb) > 1:
             # TODO: consider to allow specifying the default testbench in apio.ini.
-            print('Error: found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
+            error(env, 'Found {} testbranches, please use the --testbench flag.'.format(len(list_tb)))
             for tb in list_tb:
                 print('- {}'.format(tb))
             Exit(1)
@@ -296,8 +302,7 @@ if 'test' in COMMAND_LINE_TARGETS:
     else:
         # No --testbench flag specified. We will test all them.
         if len(list_tb) == 0:
-            print('Error: no testbenchs found for simulation.')
-            Exit(1)
+            fatal_error(env, 'No testbench files found (*_tb.v).')
         test_tbs= list_tb  # All testbenches.
     tests = [] # Targets of all tests
     for test_tb in test_tbs:

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -31,7 +31,6 @@ VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
 TESTBENCH = arg_str(env, 'testbench', '')
 VERILATOR_ALL = arg_bool(env, 'all', False)
 VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
-VERILATOR_TOP = arg_str(env, 'top', '')
 
 
 # Derived from args "nowarn" and "warn".
@@ -300,7 +299,7 @@ verilator_builder = Builder(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
         VERILATOR_PARAM_STR,
-        '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
+        '--top-module ' + TOP_MODULE if TOP_MODULE else '',
         YOSYS_CELLS_PATH),
     src_suffix='.v',
     source_scanner=list_scanner)

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -14,7 +14,10 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 from SCons.Script.SConscript import SConsEnvironment
-from apio.scons_util import get_constraint_file, error, fatal_error, update_env_force_colors
+from apio.scons_util import get_constraint_file, error, fatal_error, create_construction_env
+
+# -- Create the environment
+env = create_construction_env(ARGUMENTS)
 
 # -- Load arguments
 PROG = ARGUMENTS.get('prog', '')
@@ -40,31 +43,6 @@ for warn in VERILATOR_WARN:
     if warn != '':
         VERILATOR_PARAM_STR += ' -Wwarn-' + warn
 
-# -- Size. Possible values: 1k, 8k
-# -- Type. Possible values: hx, lp
-# -- Package. Possible values: swg16tr, cm36, cm49, cm81, cm121, cm225, qn84,
-# --   cb81, cb121, cb132, vq100, tq144, ct256
-
-# -- Add the FPGA flags as variables to be shown with the -h scons option
-vars = Variables()
-vars.Add('fpga_size', 'Set the ICE40 FPGA size (1k/8k)', FPGA_SIZE)
-vars.Add('fpga_type', 'Set the ICE40 FPGA type (hx/lp)', FPGA_TYPE)
-vars.Add('fpga_pack', 'Set the ICE40 FPGA packages', FPGA_PACK)
-
-# -- Create environment
-env:SConsEnvironment = DefaultEnvironment(
-        ENV=os.environ,
-        tools=[],
-        variables=vars)
-
-update_env_force_colors(env, ARGUMENTS)
-
-# For debugging.
-# from apio.scons_util import dump_env_vars
-# dump_env_vars(env)
-
-# -- Show all the flags defined, when scons is invoked with -h
-Help(vars.GenerateHelpText(env))
 
 # -- Just for debugging
 if 'build' in COMMAND_LINE_TARGETS or \

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -14,12 +14,13 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
 from apio.scons_util import (get_constraint_file, error, fatal_error, 
-                             create_construction_env, arg_bool, arg_str)
+                             create_construction_env, arg_bool, arg_str, 
+                             get_verilator_param_str)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
-# -- Load arguments
+# -- Get arguments
 PROG = arg_str(env, 'prog', '')
 FPGA_SIZE = arg_str(env, 'fpga_size', '')
 FPGA_TYPE = arg_str(env, 'fpga_type', '')
@@ -31,19 +32,10 @@ VERBOSE_PNR = arg_bool(env, 'verbose_pnr', False)
 TESTBENCH = arg_str(env, 'testbench', '')
 VERILATOR_ALL = arg_bool(env, 'all', False)
 VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
-VERILATOR_NO_WARN = arg_str(env, 'nowarn', '').split(',')
-VERILATOR_WARN = arg_str(env, 'warn', '').split(',')
 VERILATOR_TOP = arg_str(env, 'top', '')
 
-VERILATOR_PARAM_STR = ''
-for warn in VERILATOR_NO_WARN:
-    if warn != '':
-        VERILATOR_PARAM_STR += ' -Wno-' + warn
-
-for warn in VERILATOR_WARN:
-    if warn != '':
-        VERILATOR_PARAM_STR += ' -Wwarn-' + warn
-
+# Derived from args "nowarn" and "warn".
+VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
 # -- Just for debugging
 if 'build' in COMMAND_LINE_TARGETS or \
@@ -322,7 +314,7 @@ verilator_builder = Builder(
     action='verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD -Wno-MULTITOP -DNO_ICE40_DEFAULT_ASSIGNMENTS {0} {1} {2} {3} $SOURCES "{4}"'.format(
         '-Wall' if VERILATOR_ALL else '',
         '-Wno-style' if VERILATOR_NO_STYLE else '',
-        VERILATOR_PARAM_STR if VERILATOR_PARAM_STR else '',
+        VERILATOR_PARAM_STR,
         '--top-module ' + VERILATOR_TOP if VERILATOR_TOP else '',
         YOSYS_CELLS_PATH),
     src_suffix='.v',

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -10,7 +10,7 @@
 import os
 import re
 from platform import system
-
+from apio import scons_util
 from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBuild,
                           GetOption, Exit, COMMAND_LINE_TARGETS, ARGUMENTS,
                           Variables, Help, Glob)
@@ -109,17 +109,8 @@ v_files = [str(f) for f in v_nodes]
 src_synth = [f for f in v_files if f[-5:].upper() != '_TB.V']
 list_tb = [f for f in v_files if f[-5:].upper() == '_TB.V']
 
-# -- Get the PCF file
-PCF = ''
-PCF_list = Glob('*.pcf')
-
-try:
-    PCF = PCF_list[0]
-except IndexError:
-    print('\n---> WARNING: no PCF file found (.pcf)\n')
-
-# -- Debug
-# print('PCF Found: {}'.format(PCF))
+# -- Get the PCF file. 
+PCF = scons_util.get_constraint_file(".pcf", Glob)
 
 # -- Synthesizing Builder
 synth_builder = Builder(

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -15,13 +15,12 @@ from SCons.Script import (Builder, Action, DefaultEnvironment, Default, AlwaysBu
                           Variables, Help, Glob)
 from apio.scons_util import (get_constraint_file, error, fatal_error, 
                              create_construction_env, arg_bool, arg_str, 
-                             get_verilator_param_str)
+                             get_verilator_param_str, get_programmer_cmd)
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
 # -- Get arguments
-PROG = arg_str(env, 'prog', '')
 FPGA_SIZE = arg_str(env, 'fpga_size', '')
 FPGA_TYPE = arg_str(env, 'fpga_type', '')
 FPGA_PACK = arg_str(env, 'fpga_pack', '')
@@ -34,23 +33,9 @@ VERILATOR_ALL = arg_bool(env, 'all', False)
 VERILATOR_NO_STYLE = arg_bool(env, 'nostyle', False)
 VERILATOR_TOP = arg_str(env, 'top', '')
 
+
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
-
-# -- Just for debugging
-if 'build' in COMMAND_LINE_TARGETS or \
-   'upload' in COMMAND_LINE_TARGETS or \
-   'time' in COMMAND_LINE_TARGETS:
-
-    # print('FPGA_SIZE: {}'.format(FPGA_SIZE))
-    # print('FPGA_TYPE: {}'.format(FPGA_TYPE))
-    # print('FPGA_PACK: {}'.format(FPGA_PACK))
-
-    if 'upload' in COMMAND_LINE_TARGETS:
-        if PROG == '':
-            fatal_error(env, 'No programmer command found.')
-        assert "${SOURCE}" in PROG, f"{PROG = }"
-
 
 # -- Resources paths
 IVL_PATH = os.environ['IVL'] if 'IVL' in os.environ else ''
@@ -140,8 +125,8 @@ if(VERBOSE_ALL or VERBOSE_PNR):
     AlwaysBuild(asc_target)
 
 # -- Upload the bitstream into FPGA
-programmer = PROG.replace("${SOURCE}", "$SOURCE")
-upload_target = env.Alias('upload', bitstream_target, programmer)
+programmer_cmd = get_programmer_cmd(env)
+upload_target = env.Alias('upload', bitstream_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
 # -- Target time: calculate the time

--- a/apio/scons_util.py
+++ b/apio/scons_util.py
@@ -168,7 +168,7 @@ def dump_env_vars(env: SConsEnvironment) -> None:
     print("----- Env vars end -------")
 
 
-def get_verilator_param_str(env) -> str:
+def get_verilator_param_str(env: SConsEnvironment) -> str:
     """Construct from the nowwarn and warn arguments an option list
     for verilator. These values are specified by the user to the
     apio lint param.
@@ -189,3 +189,26 @@ def get_verilator_param_str(env) -> str:
             result += " -Wwarn-" + warn
 
     return result
+
+
+def get_programmer_cmd(env: SConsEnvironment) -> str:
+    """Return the programmer command as derived from the scons "prog" arg."""
+
+    # Get the programer command template arg.
+    prog_arg = arg_str(env, "prog", "")
+
+    # If empty then return as is.
+    if not prog_arg:
+        return prog_arg
+
+    # The programmer template is expected to contain the placeholder
+    # "${SOURCE}" that we need to convert to "$SOURCE" as expected by scons.
+    if "${SOURCE}" not in prog_arg:
+        fatal_error(
+            env,
+            "[Internal] 'prog' argument does not contain "
+            f"the '${{SOURCE}}' marker. [{prog_arg}]",
+        )
+
+    prog_cmd = prog_arg.replace("${SOURCE}", "$SOURCE")
+    return prog_cmd

--- a/apio/scons_util.py
+++ b/apio/scons_util.py
@@ -11,7 +11,63 @@
 be called only from the SConstruct.py files.
 """
 
+# NOTE: We pass the scons construction environment 'env' to the functions
+# below, even when not used, to discourage calling these from outside of a
+# SConstruct script.
+# pylint: disable=unused-argument
+
+from typing import Dict
 from SCons.Script.SConscript import SConsEnvironment
+import click
+
+
+def update_env_force_colors(
+    env: SConsEnvironment, args: Dict[str, str]
+) -> None:
+    """Sets the env FORCE_COLORS variable from the SConstruct arguments.
+    The apio app passes to the scons subprocess the variable force_colors=True
+    to preserved the text colors in the piped stdout.
+    """
+    raw_flag = args.get("force_colors", False)
+    flag = {"True": True, "False": False, False: False}[raw_flag]
+    assert isinstance(flag, bool)
+    env.Replace(FORCE_COLORS=flag)
+    if not flag:
+        warning(env, "Not forcing scons text colors.")
+
+
+def force_colors(env: SConsEnvironment) -> bool:
+    """Test if click.secho should be forced, even if piped.
+
+    By default click stips text colors when the stdout is piped,
+    for example from the scons subprocess to the apio app. To preserve
+    the sconstruct text colors, the apio app passes to the sconstract
+    scripts a flag to force the preservation of colors.
+    """
+    flag = env["FORCE_COLORS"]
+    assert isinstance(flag, bool)
+    return flag
+
+
+def info(env: SConsEnvironment, msg: str) -> None:
+    """Prints a short info message and continue."""
+    click.secho(f"Info: {msg}")
+
+
+def warning(env: SConsEnvironment, msg: str) -> None:
+    """Prints a short warning message and continue."""
+    click.secho(f"Warning: {msg}", fg="yellow", color=force_colors(env))
+
+
+def error(env: SConsEnvironment, msg: str) -> None:
+    """Prints a short error message and continue."""
+    click.secho(f"Error: {msg}", fg="red", color=force_colors(env))
+
+
+def fatal_error(env: SConsEnvironment, msg: str) -> None:
+    """Prints a short error message and exit with an error code."""
+    error(env, msg)
+    env.Exit(1)
 
 
 def get_constraint_file(
@@ -35,16 +91,25 @@ def get_constraint_file(
     # Case 1: No matching files.
     if n == 0:
         result = f"{top_module.lower()}{file_ext}"
-        print(f"Warning: No {file_ext} constraints file, assuming '{result}'.")
+        warning(env, f"No {file_ext} constraints file, assuming '{result}'.")
         return result
     # Case 2: Exactly one file found.
     if n == 1:
         result = str(files[0])
-        # print(f"Info: Found constraint file '{result}'.")
+        info(env, f"Found constraint file '{result}'.")
         return result
     # Case 3: Multiple matching files. Pick the first file (alphabetically).
     # We could improve the heuristic here, e.g. to prefer a file with
     # the top_module name, if exists.
     result = str(files[0])
-    print(f"Warning: Found multiple {file_ext} files, using '{result}'.")
+    warning(env, f"Found multiple {file_ext} files, using '{result}'.")
     return result
+
+
+def dump_env_vars(env: SConsEnvironment) -> None:
+    """Prints a list of the environment variables. For debugging."""
+    dictionary = env.Dictionary()
+    keys = list(dictionary.keys())
+    keys.sort()
+    for key in keys:
+        print(f"{key} = {env[key]}")

--- a/apio/scons_util.py
+++ b/apio/scons_util.py
@@ -166,3 +166,26 @@ def dump_env_vars(env: SConsEnvironment) -> None:
     for key in keys:
         print(f"{key} = {env[key]}")
     print("----- Env vars end -------")
+
+
+def get_verilator_param_str(env) -> str:
+    """Construct from the nowwarn and warn arguments an option list
+    for verilator. These values are specified by the user to the
+    apio lint param.
+
+    To test:  apio lint --warn aaa,bbb  --nowarn ccc,ddd
+    """
+
+    no_warn_list = arg_str(env, "nowarn", "").split(",")
+    warn_list = arg_str(env, "warn", "").split(",")
+    # No warn.
+    result = ""
+    for warn in no_warn_list:
+        if warn != "":
+            result += " -Wno-" + warn
+    # Warn.
+    for warn in warn_list:
+        if warn != "":
+            result += " -Wwarn-" + warn
+
+    return result

--- a/apio/scons_util.py
+++ b/apio/scons_util.py
@@ -7,37 +7,44 @@
 # ---- Platformio project
 # ---- (C) 2014-2016 Ivan Kravets <me@ikravets.com>
 # ---- Licence Apache v2
-"""Shared utilities for the various SConstruct.py.  The functions
-in this file are intended to be called only from the SConstruct files
-and should not be architecture specific.
+"""Shared utilities for the various SConstruct.py.  Functions here should
+be called only from the SConstruct.py files.
 """
 
-from typing import Callable, List
+from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_constraint_file(
-    file_ext: str, glob_func: Callable[[str], List[str]]
+    env: SConsEnvironment, file_ext: str, top_module: str
 ) -> str:
     """Returns the name of the constrain file to use.
 
-    file_ext is a string with the constrained file extension. E.g. ".pcf"
-    for ice40.
+    env is the sconstrution environment.
 
-    glob_func is a reference to the scon Glob function.
+    file_ext is a string with the constrained file extension.
+    E.g. ".pcf" for ice40.
 
-    Returns the file name or "" if not found.
+    top_module is the top module name. It's is used to construct the
+    default file name.
+
+    Returns the file name if found or a default name otherwise otherwise.
     """
     # Files in alphabetical order.
-    file_names = glob_func(f"*{file_ext}")
-    n = len(file_names)
+    files = env.Glob(f"*{file_ext}")
+    n = len(files)
     # Case 1: No matching files.
     if n == 0:
-        print(f"Warning: No {file_ext} constraints file.")
-        return ""
-    # Case 2: Exactly one matching file.
+        result = f"{top_module.lower()}{file_ext}"
+        print(f"Warning: No {file_ext} constraints file, assuming '{result}'.")
+        return result
+    # Case 2: Exactly one file found.
     if n == 1:
-        print(f"Info: Found constraint file {file_names[0]}.")
-        return file_names[0]
-    # Case 3: Multiple matching files.
-    print(f"Warning: Found multiple {file_ext} files, using {file_names[0]}.")
-    return file_names[0]
+        result = str(files[0])
+        # print(f"Info: Found constraint file '{result}'.")
+        return result
+    # Case 3: Multiple matching files. Pick the first file (alphabetically).
+    # We could improve the heuristic here, e.g. to prefer a file with
+    # the top_module name, if exists.
+    result = str(files[0])
+    print(f"Warning: Found multiple {file_ext} files, using '{result}'.")
+    return result

--- a/apio/scons_util.py
+++ b/apio/scons_util.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# -- This file is part of the Apio project
+# -- (C) 2016-2018 FPGAwars
+# -- Author Jesús Arroyo
+# -- Licence GPLv2
+# -- Derived from:
+# ---- Platformio project
+# ---- (C) 2014-2016 Ivan Kravets <me@ikravets.com>
+# ---- Licence Apache v2
+"""Shared utilities for the various SConstruct.py.  The functions
+in this file are intended to be called only from the SConstruct files
+and should not be architecture specific.
+"""
+
+from typing import Callable, List
+
+
+def get_constraint_file(
+    file_ext: str, glob_func: Callable[[str], List[str]]
+) -> str:
+    """Returns the name of the constrain file to use.
+
+    file_ext is a string with the constrained file extension. E.g. ".pcf"
+    for ice40.
+
+    glob_func is a reference to the scon Glob function.
+
+    Returns the file name or "" if not found.
+    """
+    # Files in alphabetical order.
+    file_names = glob_func(f"*{file_ext}")
+    n = len(file_names)
+    # Case 1: No matching files.
+    if n == 0:
+        print(f"Warning: No {file_ext} constraints file.")
+        return ""
+    # Case 2: Exactly one matching file.
+    if n == 1:
+        print(f"Info: Found constraint file {file_names[0]}.")
+        return file_names[0]
+    # Case 3: Multiple matching files.
+    print(f"Warning: Found multiple {file_ext} files, using {file_names[0]}.")
+    return file_names[0]

--- a/apio/util.py
+++ b/apio/util.py
@@ -653,7 +653,9 @@ def get_pypi_latest_version() -> str:
     # -- Read the latest apio version from pypi
     # -- More information: https://warehouse.pypa.io/api-reference/json.html
     try:
-        req = requests.get("https://pypi.python.org/pypi/apio/json", timeout=5)
+        req = requests.get(
+            "https://pypi.python.org/pypi/apio/json", timeout=10
+        )
         req.raise_for_status()
 
     # -- Connection error

--- a/scons_run.py
+++ b/scons_run.py
@@ -1,8 +1,8 @@
 #!venv/bin/python
-"""Run apio for debugging"""
+"""Run scons for debugging"""
 
 # ---------------------------------------------------
-# -- Run apio for debugging by apio developers.
+# -- Run scons for debugging by apio developers.
 # -- It is not part of apio and is not installed.
 # ---------------------------------------------------
 
@@ -11,12 +11,10 @@
 # targets at .vscode/launch.json.
 
 import sys
-
-# -- Import the apio entry point
-from apio.__main__ import cli as apio
+import SCons.Script
 
 try:
-    apio(None)
+    SCons.Script.main()
 
 except SystemExit as e:
-    print(f"Apio exit code: {e.code}")
+    print(f"Scons exit code: {e.code}")

--- a/tox.ini
+++ b/tox.ini
@@ -52,9 +52,6 @@ setenv=
   LINT_DIRS = apio test test-boards
 
 commands = 
-    # black  --version
-    # flake8 --version
-    # pylint --version
     black   {env:LINT_DIRS}
     flake8  {env:LINT_DIRS} 
     pylint  {env:LINT_DIRS}

--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,11 @@
 [tox]
 isolated_build = True
 
+# TODO: Add additional versions, e.g. py310, py311
 # Runs testenv:x for each env x here.
 envlist = 
     lint
     py312
-    py39
 
 # ----------------------------------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,66 @@
+# Automated testing.
+# https://tox.wiki/en/latest/config.html
+
+# Useful commands
+# 
+# Run everything:
+#  tox 
+#
+# Lint only:
+#  tox -e lint 
+#
+# Test only (in decreasing scope size)
+#  tox --skip-env lint
+#  tox -e py312
+#  tox -e py312 -- test/commands
+#  tox -e py312 -- test/commands/test_examples.py
+#  tox -e py312 -- test/commands/test_examples.py::test_examples
+#
+
+# ----------------------------------------------------
+
+# TODO: Which Python version do we want to test with?
+
 [tox]
 isolated_build = True
-envlist = py39
 
+# Runs testenv:x for each env x here.
+envlist = 
+    lint
+    py312
+    py39
+
+# ----------------------------------------------------
+
+# Lints the apio code and tests.
+[testenv:lint]
+deps =
+    black==24.8.0
+    flake8==7.1.1
+    pylint==3.3.0
+    pytest==8.3.3
+
+setenv=
+  LINT_DIRS = apio test test-boards
+
+commands = 
+    # black  --version
+    # flake8 --version
+    # pylint --version
+    black   {env:LINT_DIRS}
+    flake8  {env:LINT_DIRS} 
+    pylint  {env:LINT_DIRS}
+
+# ----------------------------------------------------
+
+# Runs the test that don't require connected boards.
+# This is a template for the pyxx envs listed above..
 [testenv]
 deps =
-    black
-    flake8
-    pylint
-    pytest
+    pytest==8.3.3
 
-# Keep the lint target list the same as in Makefile.
-commands = black  apio test test-boards  #-- Python formating
-           flake8 apio test test-boards  #-- python lint
-           pylint apio test test-boards  #-- python lint
-           pytest test                   #-- Tests
+commands = 
+    pytest test {posargs}
 
 
+# ----------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,11 @@
 #  tox -e py312 -- test/commands/test_examples.py::test_examples
 #
 
+# Installing python interpreters
+# Mac:   brew install python@3.10
+# Win:   ???
+# Linux: ???
+
 # ----------------------------------------------------
 
 # TODO: Which Python version do we want to test with?
@@ -29,6 +34,9 @@ isolated_build = True
 envlist = 
     lint
     py312
+    py311
+    py310
+    py39
 
 # ----------------------------------------------------
 


### PR DESCRIPTION
This PR contains assorted clean ups and refactoring. The full details are in the individual commits. 

Highlights:
1. Moving similar logic from the three SConstruct.py files to a shared scons_util.py library.
2. Scons scripts can now emit colored text to the terminal (was striped due to the piping).
3. More robust parsing of scons args. (It used to evaluate string values and bool("False") was considered to be true).
4. Added make/tox target to test also with older versions of python.
5. Cleaned up new lint error with the latest version of pylint.
6. Removed the loading of SConstruct files from the project directory. Rationale is in the commit description.
7. Fixed the shawn Hymel's complaint https://www.youtube.com/watch?v=gmaSjyUij9E&t=828s
