### PR TITLE
Cleaning up the SConstruct files.

### DIFF
--- a/apio/commands/lint.py
+++ b/apio/commands/lint.py
@@ -60,6 +60,8 @@ of the project that contains the apio.ini file.
 \b
 Examples:
   apio lint
+  apio lint -t my_module
+  apio lint --all
 """
 
 

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -262,7 +262,7 @@ class SCons:
             * sram: Perform SRAM programming
             * flash: Perform Flash programming
 
-        * OUTPUT: A string with the command+args to execute and a ${SOURCE}
+        * OUTPUT: A string with the command+args to execute and a $SOURCE
           placeholder for the bitstream file name.
         """
 
@@ -315,12 +315,11 @@ class SCons:
         # --   * "${PID}" (optional): USB Product id
         # --   * "${FTDI_ID}" (optional): FTDI id
         # --   * "${SERIAL_PORT}" (optional): Serial port name
-        # --   * "${SOURCE}" (required): Bitstream file name.
         programmer = self.serialize_programmer(
             board_data, prog[SRAM], prog[FLASH]
         )
         # -- The placeholder for the bitstream file name should always exist.
-        assert "${SOURCE}" in programmer, programmer
+        assert "$SOURCE" in programmer, programmer
 
         # -- Assign the parameters in the Template string
 
@@ -370,9 +369,9 @@ class SCons:
             programmer = programmer.replace("${SERIAL_PORT}", device)
 
         # -- Return the Command to execute for uploading the circuit
-        # -- to the given board. Scons will replace ${SOURCE} with the
+        # -- to the given board. Scons will replace $SOURCE with the
         # -- bitstream file name before executing the command.
-        assert "${SOURCE}" in programmer, programmer
+        assert "$SOURCE" in programmer, programmer
         return programmer
 
     @staticmethod
@@ -522,8 +521,8 @@ class SCons:
            * "${SERIAL_PORT}" (optional): Serial port name
 
           Example of output strings:
-          "'tinyprog --pyserial -c ${SERIAL_PORT} --program ${SOURCE}'"
-          "'iceprog -d i:0x${VID}:0x${PID}:${FTDI_ID} ${SOURCE}'"
+          "'tinyprog --pyserial -c ${SERIAL_PORT} --program $SOURCE'"
+          "'iceprog -d i:0x${VID}:0x${PID}:${FTDI_ID} $SOURCE'"
         """
 
         # -- Get the programmer type
@@ -551,7 +550,7 @@ class SCons:
         # -- Mark the expected location of the bitstream file name, before
         # -- we appened any arg to the command. Some programmers such as
         # -- dfu-util require it immediatly after the "args" string.
-        programmer += " ${SOURCE}"
+        programmer += " $SOURCE"
 
         # -- Some tools need extra arguments
         # -- (like dfu-util for example)

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -102,7 +102,7 @@ verilog_src_scanner = make_verilog_src_scanner(env)
 
 # -- Get a list of the synthesizable files (e.g. "main.v") and a list of
 # -- the testbench files (e.g. "main_tb.v")
-src_synth, list_tb = get_source_files(env)
+synth_srcs, test_srcs = get_source_files(env)
 
 # -- Get the LPF file name.
 LPF = get_constraint_file(env, ".lpf", TOP_MODULE)
@@ -173,7 +173,7 @@ env.Append(BUILDERS={"Time": time_rpt_builder})
 # -- Apio build/upload.
 # -- Targets.
 # -- (module).v -> hardware.json -> hardware.config -> hardware.report.
-synth_target = env.Synth(TARGET, [src_synth])
+synth_target = env.Synth(TARGET, [synth_srcs])
 pnr_target = env.PnR(TARGET, [synth_target, LPF])
 bin_target = env.Bin(TARGET, pnr_target)
 build_target = env.Alias("build", bin_target)
@@ -290,7 +290,7 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilog(TARGET, src_synth + list_tb)
+vout_target = env.IVerilog(TARGET, synth_srcs + test_srcs)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
@@ -300,7 +300,7 @@ verify_target = env.Alias("verify", vout_target)
 # -- (modules).v -> hardware.dot -> hardware.svg.
 #
 # TODO: Launch a portable SVG (or differentn format) viewer.
-dot_target = env.DOT(TARGET, src_synth)
+dot_target = env.DOT(TARGET, synth_srcs)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
@@ -311,7 +311,7 @@ graph_target = env.Alias("graph", svg_target)
 # -- Targets.
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
-    config = get_sim_config(env, TESTBENCH, src_synth)
+    config = get_sim_config(env, TESTBENCH, synth_srcs)
     sout_target = env.IVerilog(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
@@ -322,7 +322,7 @@ if "sim" in COMMAND_LINE_TARGETS:
 # -- Targets.
 # -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
 if "test" in COMMAND_LINE_TARGETS:
-    configs = get_tests_configs(env, TESTBENCH, src_synth, list_tb)
+    configs = get_tests_configs(env, TESTBENCH, synth_srcs, test_srcs)
     tests_targets = []
     for config in configs:
         test_out_target = env.IVerilog(config.top_module, config.srcs)
@@ -383,7 +383,7 @@ env.Append(BUILDERS={"Verilator": verilator_builder})
 # -- Targets.
 # -- (modules).v -> lint report to stdout.
 lint_config_target = env.VerilatorConfig(TARGET, [])
-lint_out_target = env.Verilator(TARGET, src_synth + list_tb)
+lint_out_target = env.Verilator(TARGET, synth_srcs + test_srcs)
 env.Depends(lint_out_target, lint_config_target)
 lint_target = env.Alias("lint", lint_out_target)
 AlwaysBuild(lint_target)

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -56,7 +56,6 @@ from apio.scons_util import (
     create_construction_env,
     arg_bool,
     arg_str,
-    get_verilator_warning_params,
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
@@ -65,6 +64,7 @@ from apio.scons_util import (
     get_tests_configs,
     make_waves_target,
     make_iverilog_action,
+    make_verilator_action,
 )
 
 # -- Create the environment
@@ -82,7 +82,8 @@ VERBOSE_PNR = arg_bool(env, "verbose_pnr", False)
 TESTBENCH = arg_str(env, "testbench", "")
 VERILATOR_ALL = arg_bool(env, "all", False)
 VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
-
+NOWARNS = arg_str(env, "nowarn", "").split(",")
+WARNS = arg_str(env, "warn", "").split(",")
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
@@ -370,16 +371,14 @@ env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 # -- Builder (verilator, verilog linter)
 # -- (modules + testbenches).v -> lint report to stdout builder.
 verilator_builder = Builder(
-    action=(
-        "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
-        '-Wno-MULTITOP {0} {1} {2} {3} -I"{4}" {5} $SOURCES'
-    ).format(
-        "-Wall" if VERILATOR_ALL else "",
-        "-Wno-style" if VERILATOR_NO_STYLE else "",
-        get_verilator_warning_params(env),
-        "--top-module " + TOP_MODULE if TOP_MODULE else "",
-        YOSYS_LIB_DIR,
-        TARGET + ".vlt",
+    action=make_verilator_action(
+        env,
+        warnings_all=VERILATOR_ALL,
+        warnings_no_style=VERILATOR_NO_STYLE,
+        no_warns=NOWARNS,
+        warns=WARNS,
+        top_module=TOP_MODULE,
+        lib_files=[YOSYS_LIB_DIR],
     ),
     src_suffix=".v",
     source_scanner=verilog_src_scanner,

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -94,9 +94,6 @@ isWindows = "Windows" == system()
 VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
 IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 
-IDCODE_PARAM = "" if not FPGA_IDCODE else "--idcode {0}".format(FPGA_IDCODE)
-
-FPGA_TYPE_PARAM = "25k" if (FPGA_TYPE == "12k") else "{0}".format(FPGA_TYPE)
 
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
@@ -137,7 +134,7 @@ pnr_builder = Builder(
         "nextpnr-ecp5 --{0} --package {1} --json $SOURCE --textcfg $TARGET "
         "--lpf {2} {3} --timing-allow-fail --force"
     ).format(
-        FPGA_TYPE_PARAM,
+        "25k" if (FPGA_TYPE == "12k") else FPGA_TYPE,
         FPGA_PACK,
         LPF,
         "" if VERBOSE_ALL or VERBOSE_PNR else "-q",
@@ -153,7 +150,8 @@ env.Append(BUILDERS={"PnR": pnr_builder})
 # -- hardware.config -> hardware.bit.
 bitstream_builder = Builder(
     action="ecppack --compress --db {0} {1} $SOURCE hardware.bit".format(
-        DATABASE_PATH, IDCODE_PARAM
+        DATABASE_PATH,
+        "" if not FPGA_IDCODE else f"--idcode {FPGA_IDCODE}",
     ),
     suffix=".bit",
     src_suffix=".config",

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -65,8 +65,7 @@ from apio.scons_util import (
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
-
-# -- Get arguments.
+# -- Get arguments
 FPGA_SIZE = arg_str(env, "fpga_size", "")
 FPGA_TYPE = arg_str(env, "fpga_type", "")
 FPGA_PACK = arg_str(env, "fpga_pack", "")
@@ -81,7 +80,6 @@ VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
-
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
@@ -117,7 +115,10 @@ list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
 # -- Get the LPF file name.
 LPF = get_constraint_file(env, ".lpf", TOP_MODULE)
 
-# -- Synthesizing Builder
+
+# -- Apio build/upload.
+# -- Builder (yosys, Synthesis).
+# -- (modules).v -> hardware.json.
 synth_builder = Builder(
     action='yosys -p "synth_ecp5 {0} -json $TARGET" {1} $SOURCES'.format(
         ("-top " + TOP_MODULE) if TOP_MODULE else "",
@@ -129,7 +130,10 @@ synth_builder = Builder(
 )
 env.Append(BUILDERS={"Synth": synth_builder})
 
-# -- Place and route Builder.
+
+# -- Apio build/upload.
+# -- builder (nextpnr, Place and route).
+# -- hardware.json -> hardware.config.
 pnr_builder = Builder(
     action=(
         "nextpnr-ecp5 --{0} --package {1} --json $SOURCE --textcfg $TARGET "
@@ -145,7 +149,10 @@ pnr_builder = Builder(
 )
 env.Append(BUILDERS={"PnR": pnr_builder})
 
-# -- Bitstream Builder.
+
+# -- Apio build/upload.
+# -- Builder (icepack, bitstream generator).
+# -- hardware.config -> hardware.bit.
 bitstream_builder = Builder(
     action="ecppack --compress --db {0} {1} $SOURCE hardware.bit".format(
         DATABASE_PATH, IDCODE_PARAM
@@ -155,7 +162,10 @@ bitstream_builder = Builder(
 )
 env.Append(BUILDERS={"Bin": bitstream_builder})
 
-# -- No time analysis report implemented for the ECP5 family
+
+# -- Apio time.
+# -- Builder | not implemented.
+# -- hardware.config -> hardware.rpt
 time_rpt_builder = Builder(
     action=(
         'echo "Time analysis report is not impelemnted for the ECP5 family." '
@@ -166,7 +176,10 @@ time_rpt_builder = Builder(
 )
 env.Append(BUILDERS={"Time": time_rpt_builder})
 
-# -- Generate the bitstream
+
+# -- Apio build/upload.
+# -- Targets.
+# -- (module).v -> hardware.json -> hardware.config -> hardware.report.
 synth_target = env.Synth(TARGET, [src_synth])
 pnr_target = env.PnR(TARGET, [synth_target, LPF])
 bin_target = env.Bin(TARGET, pnr_target)
@@ -179,25 +192,32 @@ if VERBOSE_PNR:
 if VERBOSE_ALL:
     AlwaysBuild(synth_target, pnr_target, build_target)
 
-# -- Upload the bitstream into FPGA
+
+# -- Apio upload.
+# -- Targets.
+# -- hardware.bit -> FPGA.
 programmer_cmd = get_programmer_cmd(env)
 upload_target = env.Alias("upload", bin_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
-# -- Target time: calculate the time
+
+# -- Apio time.
+# -- Targets.
+# -- hardware.config -> hardware.rpt
 time_rpt_target = env.Time(pnr_target)
 AlwaysBuild(time_rpt_target)
 time_target = env.Alias("time", time_rpt_target)
 
-# -- Icarus Verilog builders
 
-
+# -- Apio sim/test
+# -- Builder helper (iverolog command generator).
+# -- (modules).v -> hardware.out.
 def iverilog_generator(source, target, env, for_signature):
     """Constructs dynamically a commands for iverlog targets builders."""
     # E.g. "my_module" or "my_module_tb"
     target_name, _ = os.path.splitext(str(target[0]))
-    # Testbenches use the value macro VCD_OUTPUT to know the name of the waves
-    # output file. We also pass a dummy when the verify command to avoid a
+    # Testbenches use the macro VCD_OUTPUT to know the name of the waves
+    # output file.We also pass a dummy when the verify command to avoid a
     # warning about the undefined macro.
     is_testbench = target_name.upper().endswith("_TB")
     is_verify = "verify" in COMMAND_LINE_TARGETS
@@ -225,6 +245,9 @@ def iverilog_generator(source, target, env, for_signature):
     return result
 
 
+# -- Apio sim/test.
+# -- Builder (iverilog, verilog compiler).
+# -- (modules).v -> hardware.out.
 iverilog_builder = Builder(
     # Action string is computed automatically by the generator.
     generator=iverilog_generator,
@@ -234,11 +257,14 @@ iverilog_builder = Builder(
 )
 env.Append(BUILDERS={"IVerilog": iverilog_builder})
 
+
+# -- Apio graph.
+# -- Builder (yosys, .dot graph generator).
+# -- hardware.v -> hardware.dot.
 dot_builder = Builder(
     action=(
-        "yosys -f verilog -p "
-        '"show -format dot -colors 1 -prefix hardware {0}" '
-        "{1} $SOURCES"
+        'yosys -f verilog -p "show -format dot -colors 1 '
+        '-prefix hardware {0}" {1} $SOURCES'
     ).format(
         TOP_MODULE if TOP_MODULE else "unknown_top",
         "" if VERBOSE_ALL else "-q",
@@ -249,6 +275,10 @@ dot_builder = Builder(
 )
 env.Append(BUILDERS={"DOT": dot_builder})
 
+
+# -- Apio graph.
+# -- Builder  (dot, svg renderer).
+# -- hardware.dot -> hardware.svg.
 svg_builder = Builder(
     # Expecting graphviz dot to be installed and in the path.
     action="dot -Tsvg $SOURCES -o $TARGET",
@@ -257,41 +287,53 @@ svg_builder = Builder(
 )
 env.Append(BUILDERS={"SVG": svg_builder})
 
-# NOTE: output file name is defined in the iverilog call using VCD_OUTPUT macro
+
+# -- Apio sim/test.
+# -- Builder (vvp, simulator).
+# -- (testbench).out -> (testbench).vcd.
 vcd_builder = Builder(
     action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
 )
 env.Append(BUILDERS={"VCD": vcd_builder})
 
-# --- Verify
+
+# -- Apio verify.
+# -- Targets
+# -- (modules).v -> (modules).out
 vout_target = env.IVerilog(TARGET, src_synth + list_tb)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
-# --- Graph
-# TODO: Launch some portable SVG (or differentn format) viewer.
+
+# -- Apio graph.
+# -- Targets.
+# -- (modules).v -> hardware.dot -> hardware.svg.
+#
+# TODO: Launch a portable SVG (or differentn format) viewer.
 dot_target = env.DOT(TARGET, src_synth)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
 graph_target = env.Alias("graph", svg_target)
 
-# --- Simulation
-# Since the simulation targets are dynamic due to the testbench selection, we
-# create them only when running simulation.
+
+# -- Apio sim.
+# -- Targets.
+# -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
+#
+# NOTE: Since the simulation targets are dynamic due to the testbench
+# selection, we create them only when running simulations.
 if "sim" in COMMAND_LINE_TARGETS:
     assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench.
         sim_testbench = TESTBENCH
     else:
-        # No --testbench flag was specified. If there is exactly one testbench
+        # No --testbench flag is specified. If there is exactly one testbench
         # then pick it, otherwise fail.
         if len(list_tb) == 0:
             fatal_error(env, "No testbench found for simulation.")
         if len(list_tb) > 1:
-            # TODO: consider to allow specifying the default testbench
-            # in apio.ini.
             error(
                 env,
                 (
@@ -324,9 +366,12 @@ if "sim" in COMMAND_LINE_TARGETS:
     AlwaysBuild(waves_target)
 
 
-# --- Testing
-# Since the simulation targets are dynamic due to the testbench selection, we
-# create them only when running simulation.
+# -- Apio test.
+# -- Targets.
+# -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
+#
+# NOTE: Since the simulation targets are dynamic due to the testbench
+# selection, we create them only when running simulations.
 if "test" in COMMAND_LINE_TARGETS:
     assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
@@ -336,7 +381,7 @@ if "test" in COMMAND_LINE_TARGETS:
     else:
         # No --testbench flag specified. We will test all them.
         if len(list_tb) == 0:
-            fatal_error(env, "No testbenchs found for simulation.")
+            fatal_error(env, "No testbench files found (*_tb.v).")
         test_tbs = list_tb  # All testbenches.
     tests = []  # Targets of all tests
     for test_tb in test_tbs:
@@ -361,7 +406,9 @@ if "test" in COMMAND_LINE_TARGETS:
     AlwaysBuild(tests_target)
 
 
-# -- Verilator config file builder
+# -- Apio lint.
+# -- Builder (plain text generator)
+# -- (none) -> hardware.vlt builder.
 def verilator_config_func(target, source, env):
     """Creates a verilator .vlt config files."""
     with open(target[0].get_path(), "w", encoding="utf-8") as target_file:
@@ -380,7 +427,10 @@ verilator_config_builder = Builder(
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
-# -- Verilator builder
+
+# -- Apio lint.
+# -- Builder (verilator, verilog linter)
+# -- (modules).v -> lint report to stdout builder.
 verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
@@ -398,7 +448,10 @@ verilator_builder = Builder(
 )
 env.Append(BUILDERS={"Verilator": verilator_builder})
 
-# --- Lint
+
+# -- Apio lint.
+# -- Targets.
+# -- (modules).v -> lint report to stdout.
 lint_config_target = env.VerilatorConfig(TARGET, [])
 lint_out_target = env.Verilator(TARGET, src_synth + list_tb)
 env.Depends(lint_out_target, lint_config_target)

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -44,7 +44,6 @@ from SCons.Script import (
     Builder,
     AlwaysBuild,
     GetOption,
-    Exit,
     COMMAND_LINE_TARGETS,
     ARGUMENTS,
     Glob,
@@ -52,8 +51,6 @@ from SCons.Script import (
 from apio.scons_util import (
     TARGET,
     get_constraint_file,
-    error,
-    fatal_error,
     create_construction_env,
     arg_bool,
     arg_str,
@@ -61,6 +58,10 @@ from apio.scons_util import (
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
+    get_source_files,
+    get_sim_config,
+    get_tests_configs,
+    make_waves_target,
 )
 
 # -- Create the environment
@@ -98,14 +99,10 @@ IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
 
-# -- Get a list of all the verilog files in the src folfer, in ASCII, with
-# -- the full path. All these files are used for the simulation
-v_nodes = Glob("*.v")
-v_files = [str(f) for f in v_nodes]
 
-# Construct disjoint lists of .v module and testbench files.
-src_synth = [f for f in v_files if f[-5:].upper() != "_TB.V"]
-list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
+# -- Get a list of the synthesizable files (e.g. "main.v") and a list of
+# -- the testbench files (e.g. "main_tb.v")
+src_synth, list_tb = get_source_files(env)
 
 # -- Get the LPF file name.
 LPF = get_constraint_file(env, ".lpf", TOP_MODULE)
@@ -313,89 +310,33 @@ graph_target = env.Alias("graph", svg_target)
 # -- Apio sim.
 # -- Targets.
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
-#
-# NOTE: Since the simulation targets are dynamic due to the testbench
-# selection, we create them only when running simulations.
 if "sim" in COMMAND_LINE_TARGETS:
-    assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
-    if TESTBENCH:
-        # Explicit testbench file name is given via --testbench.
-        sim_testbench = TESTBENCH
-    else:
-        # No --testbench flag is specified. If there is exactly one testbench
-        # then pick it, otherwise fail.
-        if len(list_tb) == 0:
-            fatal_error(env, "No testbench found for simulation.")
-        if len(list_tb) > 1:
-            error(
-                env,
-                (
-                    "Found {} testbranches, please use the --testbench flag."
-                ).format(len(list_tb)),
-            )
-            for tb in list_tb:
-                print("- {}".format(tb))
-            Exit(1)
-        sim_testbench = list_tb[0]  # Pick the only available testbench.
-    # Here sim_testbench contains the testbench, e.g. my_module_tb.v.
-    # Construct list of files to build.
-    src_sim = []
-    src_sim.extend(src_synth)  # All the .v files.
-    src_sim.append(sim_testbench)
-    # Create targets sim target and its dependent.
-    sim_name, _ = os.path.splitext(sim_testbench)  # e.g. my_module_tb
-    sout_target = env.IVerilog(sim_name, src_sim)
+    config = get_sim_config(env, TESTBENCH, src_synth)
+    sout_target = env.IVerilog(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
-    # 'do_initial_zoom_fit' does max zoom only if .gtkw file not found.
-    waves_target = env.Alias(
-        "sim",
-        vcd_file_target,
-        "gtkwave {0} {1} {2}.gtkw".format(
-            '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
-            vcd_file_target[0],
-            sim_name,
-        ),
-    )
+    waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
 
 
 # -- Apio test.
 # -- Targets.
 # -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
-#
-# NOTE: Since the simulation targets are dynamic due to the testbench
-# selection, we create them only when running simulations.
 if "test" in COMMAND_LINE_TARGETS:
-    assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
-    if TESTBENCH:
-        # Explicit testbench file name is given via --testbench. We test just
-        # that one.
-        test_tbs = [TESTBENCH]
-    else:
-        # No --testbench flag specified. We will test all them.
-        if len(list_tb) == 0:
-            fatal_error(env, "No testbench files found (*_tb.v).")
-        test_tbs = list_tb  # All testbenches.
-    tests = []  # Targets of all tests
-    for test_tb in test_tbs:
-        # Create a list of source files. All the modules + the current
-        # testbench.
-        src_test = []
-        src_test.extend(src_synth)  # All the .v files.
-        src_test.append(test_tb)
-        # Create the targets for the 'out' and 'vcd' files of the testbench.
-        # NOTE: Remove the two AlwaysBuild() calls below for an incremental
-        # test. Fast, correct, but may confuse the user seeing nothing happens.
-        test_name, _ = os.path.splitext(test_tb)  # e.g. my_module_tb
-        test_out_target = env.IVerilog(test_name, src_test)
+    configs = get_tests_configs(env, TESTBENCH, src_synth, list_tb)
+    tests_targets = []
+    for config in configs:
+        test_out_target = env.IVerilog(config.top_module, config.srcs)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
         AlwaysBuild(test_vcd_target)
-        test_target = env.Alias(test_name, [test_out_target, test_vcd_target])
-        tests.append(test_target)
+        test_target = env.Alias(
+            config.top_module, [test_out_target, test_vcd_target]
+        )
+        tests_targets.append(test_target)
+
     # Create a target for the test command that depends on all the test
     # targets.
-    tests_target = env.Alias("test", tests)
+    tests_target = env.Alias("test", tests_targets)
     AlwaysBuild(tests_target)
 
 

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -56,7 +56,7 @@ from apio.scons_util import (
     create_construction_env,
     arg_bool,
     arg_str,
-    get_verilator_param_str,
+    get_verilator_warning_params,
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
@@ -83,8 +83,6 @@ TESTBENCH = arg_str(env, "testbench", "")
 VERILATOR_ALL = arg_bool(env, "all", False)
 VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 
-# Derived from args "nowarn" and "warn".
-VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
@@ -379,7 +377,7 @@ verilator_builder = Builder(
     ).format(
         "-Wall" if VERILATOR_ALL else "",
         "-Wno-style" if VERILATOR_NO_STYLE else "",
-        VERILATOR_PARAM_STR,
+        get_verilator_warning_params(env),
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
         YOSYS_LIB_DIR,
         TARGET + ".vlt",

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -42,7 +42,6 @@ import os
 from platform import system
 from SCons.Script import (
     Builder,
-    Action,
     AlwaysBuild,
     GetOption,
     Exit,
@@ -51,6 +50,7 @@ from SCons.Script import (
     Glob,
 )
 from apio.scons_util import (
+    TARGET,
     get_constraint_file,
     error,
     fatal_error,
@@ -60,6 +60,7 @@ from apio.scons_util import (
     get_verilator_param_str,
     get_programmer_cmd,
     make_verilog_src_scanner,
+    make_verilator_config_builder,
 )
 
 # -- Create the environment
@@ -87,7 +88,7 @@ TRELLIS_PATH = os.environ["TRELLIS"] if "TRELLIS" in os.environ else ""
 DATABASE_PATH = os.path.join(TRELLIS_PATH, "database")
 CHIPDB_PATH = os.path.join(TRELLIS_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
 YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
-YOSYS_CELLS_PATH = f"{YOSYS_PATH}/ecp5/cells_sim.v"
+YOSYS_CELLS_DIR = f"{YOSYS_PATH}/ecp5"
 
 isWindows = "Windows" == system()
 VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
@@ -96,9 +97,6 @@ IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 IDCODE_PARAM = "" if not FPGA_IDCODE else "--idcode {0}".format(FPGA_IDCODE)
 
 FPGA_TYPE_PARAM = "25k" if (FPGA_TYPE == "12k") else "{0}".format(FPGA_TYPE)
-
-# -- Target name
-TARGET = "hardware"
 
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
@@ -209,7 +207,7 @@ AlwaysBuild(time_rpt_target)
 time_target = env.Alias("time", time_rpt_target)
 
 
-# -- Apio sim/test
+# -- Apio sim/test/verify
 # -- Builder helper (iverolog command generator).
 # -- (modules).v -> hardware.out.
 def iverilog_generator(source, target, env, for_signature):
@@ -222,30 +220,27 @@ def iverilog_generator(source, target, env, for_signature):
     is_testbench = target_name.upper().endswith("_TB")
     is_verify = "verify" in COMMAND_LINE_TARGETS
     vcd_output_flag = (
-        "-D VCD_OUTPUT=dummy_vcd_output"
+        "-DVCD_OUTPUT=dummy_vcd_output"
         if is_verify
-        else f"-D VCD_OUTPUT={target_name}" if is_testbench else ""
+        else f"-DVCD_OUTPUT={target_name}" if is_testbench else ""
     )
     verbose_flag = "-v" if VERBOSE_ALL else ""
     # The INTERACTIVE_SIM macro allow testbenchs to distinguish between an
     # automatic simulation (apio test) and interactive simulation (apio sim),
     # For example, for continuing despire errors in interactive mode.
     is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
-    interactive_sim_flag = "-D INTERACTIVE_SIM" if is_interactive_sim else ""
-    result = (
-        "iverilog {0} {1} -o $TARGET {2} {3} -D NO_INCLUDES "
-        '"{3}/ecp5/cells_bb.v" "{4}" $SOURCES'
-    ).format(
+    interactive_sim_flag = "-DINTERACTIVE_SIM" if is_interactive_sim else ""
+    result = ('iverilog {0} {1} -o $TARGET {2} {3} -I"{4}" $SOURCES').format(
         IVER_PATH,
         verbose_flag,
         vcd_output_flag,
         interactive_sim_flag,
-        YOSYS_CELLS_PATH,
+        YOSYS_CELLS_DIR,
     )
     return result
 
 
-# -- Apio sim/test.
+# -- Apio sim/test/verify.
 # -- Builder (iverilog, verilog compiler).
 # -- (modules).v -> hardware.out.
 iverilog_builder = Builder(
@@ -409,21 +404,17 @@ if "test" in COMMAND_LINE_TARGETS:
 # -- Apio lint.
 # -- Builder (plain text generator)
 # -- (none) -> hardware.vlt builder.
-def verilator_config_func(target, source, env):
-    """Creates a verilator .vlt config files."""
-    with open(target[0].get_path(), "w", encoding="utf-8") as target_file:
-        # NOTE: This config was copied from ICE40. Adjust as needed.
-        target_file.write(
-            "`verilator_config\n"
-            f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
-            f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n'
-        )
-    return 0
-
-
-verilator_config_builder = Builder(
-    action=Action(verilator_config_func, "Creating verilator config file."),
-    suffix=".vlt",
+verilator_config_builder = make_verilator_config_builder(
+    env,
+    (
+        "`verilator_config\n"
+        f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_DIR}/*"\n'
+        f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_DIR}/*"\n'
+        f'lint_off -rule PINMISSING   -file "{YOSYS_CELLS_DIR}/*"\n'
+        f'lint_off -rule ASSIGNIN     -file "{YOSYS_CELLS_DIR}/*"\n'
+        f'lint_off -rule WIDTHTRUNC   -file "{YOSYS_CELLS_DIR}/*"\n'
+        f'lint_off -rule INITIALDLY   -file "{YOSYS_CELLS_DIR}/*"\n'
+    ),
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
@@ -434,14 +425,14 @@ env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
-        '-Wno-MULTITOP {0} {1} {2} {3} {4} $SOURCES "{5}"'
+        '-Wno-MULTITOP {0} {1} {2} {3} -I"{4}" {5} $SOURCES'
     ).format(
         "-Wall" if VERILATOR_ALL else "",
         "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
+        YOSYS_CELLS_DIR,
         TARGET + ".vlt",
-        YOSYS_CELLS_PATH,
     ),
     src_suffix=".v",
     source_scanner=verilog_src_scanner,

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -88,7 +88,6 @@ VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
 TRELLIS_PATH = os.environ["TRELLIS"] if "TRELLIS" in os.environ else ""
 DATABASE_PATH = os.path.join(TRELLIS_PATH, "database")
-CHIPDB_PATH = os.path.join(TRELLIS_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
 YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
 YOSYS_LIB_DIR = YOSYS_PATH + "/ecp5"
 

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -39,7 +39,6 @@
 
 
 import os
-from platform import system
 from SCons.Script import (
     Builder,
     AlwaysBuild,
@@ -50,6 +49,9 @@ from SCons.Script import (
 )
 from apio.scons_util import (
     TARGET,
+    is_testbench,
+    basename,
+    is_windows,
     get_constraint_file,
     create_construction_env,
     arg_bool,
@@ -62,6 +64,7 @@ from apio.scons_util import (
     get_sim_config,
     get_tests_configs,
     make_waves_target,
+    make_iverilog_action,
 )
 
 # -- Create the environment
@@ -89,20 +92,15 @@ TRELLIS_PATH = os.environ["TRELLIS"] if "TRELLIS" in os.environ else ""
 DATABASE_PATH = os.path.join(TRELLIS_PATH, "database")
 CHIPDB_PATH = os.path.join(TRELLIS_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
 YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
-YOSYS_CELLS_DIR = f"{YOSYS_PATH}/ecp5"
-
-isWindows = "Windows" == system()
-VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
-IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
-
+YOSYS_LIB_DIR = YOSYS_PATH + "/ecp5"
 
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
 
-
 # -- Get a list of the synthesizable files (e.g. "main.v") and a list of
 # -- the testbench files (e.g. "main_tb.v")
 synth_srcs, test_srcs = get_source_files(env)
+
 
 # -- Get the LPF file name.
 LPF = get_constraint_file(env, ".lpf", TOP_MODULE)
@@ -202,50 +200,59 @@ AlwaysBuild(time_rpt_target)
 time_target = env.Alias("time", time_rpt_target)
 
 
-# -- Apio sim/test/verify
-# -- Builder helper (iverolog command generator).
-# -- (modules).v -> hardware.out.
-def iverilog_generator(source, target, env, for_signature):
-    """Constructs dynamically a commands for iverlog targets builders."""
-    # E.g. "my_module" or "my_module_tb"
-    target_name, _ = os.path.splitext(str(target[0]))
-    # Testbenches use the macro VCD_OUTPUT to know the name of the waves
-    # output file.We also pass a dummy when the verify command to avoid a
-    # warning about the undefined macro.
-    is_testbench = target_name.upper().endswith("_TB")
-    is_verify = "verify" in COMMAND_LINE_TARGETS
-    vcd_output_flag = (
-        "-DVCD_OUTPUT=dummy_vcd_output"
-        if is_verify
-        else f"-DVCD_OUTPUT={target_name}" if is_testbench else ""
-    )
-    verbose_flag = "-v" if VERBOSE_ALL else ""
-    # The INTERACTIVE_SIM macro allow testbenchs to distinguish between an
-    # automatic simulation (apio test) and interactive simulation (apio sim),
-    # For example, for continuing despire errors in interactive mode.
-    is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
-    interactive_sim_flag = "-DINTERACTIVE_SIM" if is_interactive_sim else ""
-    result = ('iverilog {0} {1} -o $TARGET {2} {3} -I"{4}" $SOURCES').format(
-        IVER_PATH,
-        verbose_flag,
-        vcd_output_flag,
-        interactive_sim_flag,
-        YOSYS_CELLS_DIR,
-    )
-    return result
-
-
-# -- Apio sim/test/verify.
+# -- Apio verify.
 # -- Builder (iverilog, verilog compiler).
-# -- (modules).v -> hardware.out.
-iverilog_builder = Builder(
-    # Action string is computed automatically by the generator.
-    generator=iverilog_generator,
+# -- (modules + testbenches).v -> hardware.out.
+iverilog_verify_builder = Builder(
+    action=make_iverilog_action(
+        env,
+        ivl_path=IVL_PATH,
+        verbose=VERBOSE_ALL,
+        vcd_output_name="dummy_vcd_output",
+        is_interactive=False,
+        lib_dirs=[YOSYS_LIB_DIR],
+    ),
     suffix=".out",
     src_suffix=".v",
     source_scanner=verilog_src_scanner,
 )
-env.Append(BUILDERS={"IVerilog": iverilog_builder})
+env.Append(BUILDERS={"IVerilogVerify": iverilog_verify_builder})
+
+
+# -- Apio sim/test
+# -- Builder helper (iverolog command generator).
+# -- (modules + testbench).v -> (testbench).out.
+def iverilog_tb_generator(source, target, env, for_signature):
+    """Construct the action string for the iverilog_tb_builder builder
+    for a given testbench target."""
+    # Extract testbench name from target file name.
+    testbench_file = str(target[0])
+    assert is_testbench(env, testbench_file), testbench_file
+    testbench_name = basename(env, testbench_file)
+
+    # Construct the command line.
+    action = make_iverilog_action(
+        env,
+        ivl_path=IVL_PATH,
+        verbose=VERBOSE_ALL,
+        vcd_output_name=testbench_name,
+        is_interactive=("sim" in COMMAND_LINE_TARGETS),
+        lib_dirs=[YOSYS_LIB_DIR],
+    )
+    return action
+
+
+# -- Apio sim/test.
+# -- Builder (iverilog, verilog compiler).
+# -- (modules + testbench).v -> (testbench).out.
+iverilog_tb_builder = Builder(
+    # Action string is different for sim and for
+    generator=iverilog_tb_generator,
+    suffix=".out",
+    src_suffix=".v",
+    source_scanner=verilog_src_scanner,
+)
+env.Append(BUILDERS={"IVerilogTestbench": iverilog_tb_builder})
 
 
 # -- Apio graph.
@@ -282,7 +289,11 @@ env.Append(BUILDERS={"SVG": svg_builder})
 # -- Builder (vvp, simulator).
 # -- (testbench).out -> (testbench).vcd.
 vcd_builder = Builder(
-    action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
+    action="vvp {0} $SOURCE".format(
+        "" if (is_windows(env) or not IVL_PATH) else f'-M "{IVL_PATH}"'
+    ),
+    suffix=".vcd",
+    src_suffix=".out",
 )
 env.Append(BUILDERS={"VCD": vcd_builder})
 
@@ -290,7 +301,7 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilog(TARGET, synth_srcs + test_srcs)
+vout_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
@@ -312,7 +323,7 @@ graph_target = env.Alias("graph", svg_target)
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
     config = get_sim_config(env, TESTBENCH, synth_srcs)
-    sout_target = env.IVerilog(config.top_module, config.srcs)
+    sout_target = env.IVerilogTestbench(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
@@ -325,7 +336,7 @@ if "test" in COMMAND_LINE_TARGETS:
     configs = get_tests_configs(env, TESTBENCH, synth_srcs, test_srcs)
     tests_targets = []
     for config in configs:
-        test_out_target = env.IVerilog(config.top_module, config.srcs)
+        test_out_target = env.IVerilogTestbench(config.top_module, config.srcs)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
         AlwaysBuild(test_vcd_target)
@@ -347,12 +358,12 @@ verilator_config_builder = make_verilator_config_builder(
     env,
     (
         "`verilator_config\n"
-        f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_DIR}/*"\n'
-        f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_DIR}/*"\n'
-        f'lint_off -rule PINMISSING   -file "{YOSYS_CELLS_DIR}/*"\n'
-        f'lint_off -rule ASSIGNIN     -file "{YOSYS_CELLS_DIR}/*"\n'
-        f'lint_off -rule WIDTHTRUNC   -file "{YOSYS_CELLS_DIR}/*"\n'
-        f'lint_off -rule INITIALDLY   -file "{YOSYS_CELLS_DIR}/*"\n'
+        f'lint_off -rule COMBDLY      -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule PINMISSING   -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule ASSIGNIN     -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule WIDTHTRUNC   -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule INITIALDLY   -file "{YOSYS_LIB_DIR}/*"\n'
     ),
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
@@ -360,7 +371,7 @@ env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
 # -- Apio lint.
 # -- Builder (verilator, verilog linter)
-# -- (modules).v -> lint report to stdout builder.
+# -- (modules + testbenches).v -> lint report to stdout builder.
 verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
@@ -370,7 +381,7 @@ verilator_builder = Builder(
         "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
-        YOSYS_CELLS_DIR,
+        YOSYS_LIB_DIR,
         TARGET + ".vlt",
     ),
     src_suffix=".v",

--- a/apio/resources/ecp5/SConstruct
+++ b/apio/resources/ecp5/SConstruct
@@ -299,9 +299,9 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
-AlwaysBuild(vout_target)
-verify_target = env.Alias("verify", vout_target)
+verify_out_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
+AlwaysBuild(verify_out_target)
+verify_target = env.Alias("verify", verify_out_target)
 
 
 # -- Apio graph.
@@ -321,8 +321,8 @@ graph_target = env.Alias("graph", svg_target)
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
     config = get_sim_config(env, TESTBENCH, synth_srcs)
-    sout_target = env.IVerilogTestbench(config.top_module, config.srcs)
-    vcd_file_target = env.VCD(sout_target)
+    sim_out_target = env.IVerilogTestbench(config.top_module, config.srcs)
+    vcd_file_target = env.VCD(sim_out_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
 

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -294,9 +294,9 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
-AlwaysBuild(vout_target)
-verify_target = env.Alias("verify", vout_target)
+verify_out_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
+AlwaysBuild(verify_out_target)
+verify_target = env.Alias("verify", verify_out_target)
 
 
 # -- Apio graph.
@@ -316,8 +316,8 @@ graph_target = env.Alias("graph", svg_target)
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
     config = get_sim_config(env, TESTBENCH, synth_srcs)
-    sout_target = env.IVerilogTestbench(config.top_module, config.srcs)
-    vcd_file_target = env.VCD(sout_target)
+    sim_out_target = env.IVerilogTestbench(config.top_module, config.srcs)
+    vcd_file_target = env.VCD(sim_out_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
 
@@ -398,5 +398,11 @@ if GetOption("clean"):
             env.Clean(time_target, str(node))
 
     env.Default(
-        [time_target, build_target, vout_target, graph_target, lint_target]
+        [
+            time_target,
+            build_target,
+            verify_out_target,
+            graph_target,
+            lint_target,
+        ]
     )

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -66,7 +66,7 @@ from apio.scons_util import (
 env = create_construction_env(ARGUMENTS)
 
 
-# -- Get arguments
+# -- Get arguments.
 FPGA_MODEL = arg_str(env, "fpga_model", "")
 FPGA_SIZE = arg_str(env, "fpga_size", "")
 FPGA_TYPE = arg_str(env, "fpga_type", "")
@@ -81,7 +81,6 @@ VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
-
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
@@ -112,7 +111,9 @@ list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
 # -- Get the CST file name.
 CST = get_constraint_file(env, ".cst", TOP_MODULE)
 
-# -- Synthesizing Builder
+# -- Apio build/upload.
+# -- Builder (yosys, Synthesis).
+# -- (modules).v -> hardware.json.
 synth_builder = Builder(
     action=(
         'yosys -D LEDS_NR=6 -p "synth_gowin {0} -json $TARGET" {1} $SOURCES'
@@ -126,7 +127,10 @@ synth_builder = Builder(
 )
 env.Append(BUILDERS={"Synth": synth_builder})
 
-# -- Place and route Builder.
+
+# -- Apio build/upload.
+# -- builder (nextpnr, Place and route).
+# -- hardware.json -> hardware.pnr.json.
 pnr_builder = Builder(
     action=(
         "nextpnr-himbaechel --device {0} --json $SOURCE --write $TARGET "
@@ -142,7 +146,10 @@ pnr_builder = Builder(
 )
 env.Append(BUILDERS={"PnR": pnr_builder})
 
-# -- Bitstream Builder.
+
+# -- Apio build/upload.
+# -- Builder (icepack, bitstream generator).
+# -- hardware.pnr.json -> hardware.fs.
 bitstream_builder = Builder(
     action="gowin_pack -d {0} -o $TARGET $SOURCE".format(FPGA_TYPE.upper()),
     suffix=".fs",
@@ -150,8 +157,10 @@ bitstream_builder = Builder(
 )
 env.Append(BUILDERS={"Bin": bitstream_builder})
 
-# -- Time report builder
-# https://github.com/cliffordwolf/icestorm/issues/57
+
+# -- Apio time.
+# -- Builder | not implemented.
+# -- hardware.pnr.json -> hardware.rpt
 time_rpt_builder = Builder(
     action=(
         'echo "Time analysis report is not impelemnted for the Gowin family." '
@@ -162,7 +171,10 @@ time_rpt_builder = Builder(
 )
 env.Append(BUILDERS={"Time": time_rpt_builder})
 
-# -- Generate the bitstream
+
+# -- Apio build/upload.
+# -- Targets.
+# -- (module).v -> hardware.json -> hardware.pnr.json -> hardware.bin.
 synth_target = env.Synth(TARGET, [src_synth])
 pnr_target = env.PnR(TARGET, [synth_target, CST])
 bin_target = env.Bin(TARGET, pnr_target)
@@ -175,22 +187,29 @@ if VERBOSE_PNR:
 if VERBOSE_ALL:
     AlwaysBuild(synth_target, pnr_target, build_target)
 
-# -- Upload the bitstream into FPGA
+
+# -- Apio upload.
+# -- Targets.
+# -- hardware.fs -> FPGA.
 programmer_cmd = get_programmer_cmd(env)
 upload_target = env.Alias("upload", bin_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
-# -- Target time: calculate the time
-rpt_target = env.Time(pnr_target)
-AlwaysBuild(rpt_target)
-time_target = env.Alias("time", rpt_target)
 
-# -- Icarus Verilog builders
+# -- Apio time.
+# -- Targets.
+# -- hardware.asc -> hardware.rpt
+time_rpt_target = env.Time(pnr_target)
+AlwaysBuild(time_rpt_target)
+time_target = env.Alias("time", time_rpt_target)
 
 
+# -- Apio sim/test
+# -- Builder helper (iverolog command generator).
+# -- (modules).v -> hardware.out.
 def iverilog_generator(source, target, env, for_signature):
     """Constructs dynamically a commands for iverlog targets builders."""
-    # E.g. "my_module" or"my_module_tb"
+    # E.g. "my_module" or "my_module_tb"
     target_name, _ = os.path.splitext(str(target[0]))
     # Testbenches use the macro VCD_OUTPUT to know the name of the waves
     # output file.We also pass a dummy when the verify command to avoid a
@@ -218,6 +237,9 @@ def iverilog_generator(source, target, env, for_signature):
     return result
 
 
+# -- Apio sim/test.
+# -- Builder (iverilog, verilog compiler).
+# -- (modules).v -> hardware.out.
 iverilog_builder = Builder(
     # Action string is computed automatically by the generator.
     generator=iverilog_generator,
@@ -227,10 +249,14 @@ iverilog_builder = Builder(
 )
 env.Append(BUILDERS={"IVerilog": iverilog_builder})
 
+
+# -- Apio graph.
+# -- Builder (yosys, .dot graph generator).
+# -- hardware.v -> hardware.dot.
 dot_builder = Builder(
     action=(
-        'yosys -f verilog -p "show -format dot -colors 1 -prefix hardware '
-        '{0}" {1} $SOURCES'
+        'yosys -f verilog -p "show -format dot -colors 1 '
+        '-prefix hardware {0}" {1} $SOURCES'
     ).format(
         TOP_MODULE if TOP_MODULE else "unknown_top",
         "" if VERBOSE_ALL else "-q",
@@ -241,6 +267,10 @@ dot_builder = Builder(
 )
 env.Append(BUILDERS={"DOT": dot_builder})
 
+
+# -- Apio graph.
+# -- Builder  (dot, svg renderer).
+# -- hardware.dot -> hardware.svg.
 svg_builder = Builder(
     # Expecting graphviz dot to be installed and in the path.
     action="dot -Tsvg $SOURCES -o $TARGET",
@@ -249,41 +279,53 @@ svg_builder = Builder(
 )
 env.Append(BUILDERS={"SVG": svg_builder})
 
-# NOTE: output file name is defined in the iverilog call using VCD_OUTPUT macro
+
+# -- Apio sim/test.
+# -- Builder (vvp, simulator).
+# -- (testbench).out -> (testbench).vcd.
 vcd_builder = Builder(
     action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
 )
 env.Append(BUILDERS={"VCD": vcd_builder})
 
-# --- Verify
+
+# -- Apio verify.
+# -- Targets
+# -- (modules).v -> (modules).out
 vout_target = env.IVerilog(TARGET, src_synth + list_tb)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
-# --- Graph
-# TODO: Launch some portable SVG (or differentn format) viewer.
+
+# -- Apio graph.
+# -- Targets.
+# -- (modules).v -> hardware.dot -> hardware.svg.
+#
+# TODO: Launch a portable SVG (or differentn format) viewer.
 dot_target = env.DOT(TARGET, src_synth)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
 graph_target = env.Alias("graph", svg_target)
 
-# --- Simulation
-# Since the simulation targets are dynamic due to the testbench selection, we
-# create them only when running simulation.
+
+# -- Apio sim.
+# -- Targets.
+# -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
+#
+# NOTE: Since the simulation targets are dynamic due to the testbench
+# selection, we create them only when running simulations.
 if "sim" in COMMAND_LINE_TARGETS:
     assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench.
         sim_testbench = TESTBENCH
     else:
-        # No --testbench flag specified. If there is exactly one testbench then
-        # pick it, otherwise fail.
+        # No --testbench flag is specified. If there is exactly one testbench
+        # then pick it, otherwise fail.
         if len(list_tb) == 0:
             fatal_error(env, "No testbench found for simulation.")
         if len(list_tb) > 1:
-            # TODO: consider to allow specifying the default testbench
-            # in apio.ini.
             error(
                 env,
                 (
@@ -316,9 +358,12 @@ if "sim" in COMMAND_LINE_TARGETS:
     AlwaysBuild(waves_target)
 
 
-# --- Testing
-# Since the simulation targets are dynamic due to the testbench selection, we
-# create them only when running simulation.
+# -- Apio test.
+# -- Targets.
+# -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
+#
+# NOTE: Since the simulation targets are dynamic due to the testbench
+# selection, we create them only when running simulations.
 if "test" in COMMAND_LINE_TARGETS:
     assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
@@ -328,7 +373,7 @@ if "test" in COMMAND_LINE_TARGETS:
     else:
         # No --testbench flag specified. We will test all them.
         if len(list_tb) == 0:
-            fatal_error(env, "No testbenchs found for simulation.")
+            fatal_error(env, "No testbench files found (*_tb.v).")
         test_tbs = list_tb  # All testbenches.
     tests = []  # Targets of all tests
     for test_tb in test_tbs:
@@ -339,8 +384,7 @@ if "test" in COMMAND_LINE_TARGETS:
         src_test.append(test_tb)
         # Create the targets for the 'out' and 'vcd' files of the testbench.
         # NOTE: Remove the two AlwaysBuild() calls below for an incremental
-        # test. Fast, correct,
-        # but may confuse the user seeing nothing happens.
+        # test. Fast, correct, but may confuse the user seeing nothing happens.
         test_name, _ = os.path.splitext(test_tb)  # e.g. my_module_tb
         test_out_target = env.IVerilog(test_name, src_test)
         AlwaysBuild(test_out_target)
@@ -354,11 +398,13 @@ if "test" in COMMAND_LINE_TARGETS:
     AlwaysBuild(tests_target)
 
 
-# -- Verilator config file builder
+# -- Apio lint.
+# -- Builder (plain text generator)
+# -- (none) -> hardware.vlt builder.
 def verilator_config_func(target, source, env):
     """Creates a verilator .vlt config files."""
     with open(target[0].get_path(), "w", encoding="utf-8") as target_file:
-        # NOTE: This config was copied from ICE40. Adjust as needed.
+        # NOTE: This config was copied from ICE40. Fix it.
         target_file.write(
             "`verilator_config\n"
             f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
@@ -373,7 +419,10 @@ verilator_config_builder = Builder(
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
-# -- Verilator builder
+
+# -- Apio lint.
+# -- Builder (verilator, verilog linter)
+# -- (modules).v -> lint report to stdout builder.
 verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
@@ -387,10 +436,14 @@ verilator_builder = Builder(
         YOSYS_CELLS_PATH,
     ),
     src_suffix=".v",
+    source_scanner=verilog_src_scanner,
 )
 env.Append(BUILDERS={"Verilator": verilator_builder})
 
-# --- Lint
+
+# -- Apio lint.
+# -- Targets.
+# -- (modules).v -> lint report to stdout.
 lint_config_target = env.VerilatorConfig(TARGET, [])
 lint_out_target = env.Verilator(TARGET, src_synth + list_tb)
 env.Depends(lint_out_target, lint_config_target)

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -56,7 +56,6 @@ from apio.scons_util import (
     create_construction_env,
     arg_bool,
     arg_str,
-    get_verilator_warning_params,
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
@@ -65,6 +64,7 @@ from apio.scons_util import (
     get_tests_configs,
     make_waves_target,
     make_iverilog_action,
+    make_verilator_action,
 )
 
 # -- Create the environment
@@ -82,7 +82,8 @@ VERBOSE_PNR = arg_bool(env, "verbose_pnr", False)
 TESTBENCH = arg_str(env, "testbench", "")
 VERILATOR_ALL = arg_bool(env, "all", False)
 VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
-
+NOWARNS = arg_str(env, "nowarn", "").split(",")
+WARNS = arg_str(env, "warn", "").split(",")
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
@@ -361,16 +362,14 @@ env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 # -- Builder (verilator, verilog linter)
 # -- (modules + testbenches).v -> lint report to stdout builder.
 verilator_builder = Builder(
-    action=(
-        "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
-        '-Wno-MULTITOP {0} {1} {2} {3} -I"{4}" {5} $SOURCES'
-    ).format(
-        "-Wall" if VERILATOR_ALL else "",
-        "-Wno-style" if VERILATOR_NO_STYLE else "",
-        get_verilator_warning_params(env),
-        "--top-module " + TOP_MODULE if TOP_MODULE else "",
-        YOSYS_LIB_DIR,
-        TARGET + ".vlt",
+    action=make_verilator_action(
+        env,
+        warnings_all=VERILATOR_ALL,
+        warnings_no_style=VERILATOR_NO_STYLE,
+        no_warns=NOWARNS,
+        warns=WARNS,
+        top_module=TOP_MODULE,
+        lib_dirs=[YOSYS_LIB_DIR],
     ),
     src_suffix=".v",
     source_scanner=verilog_src_scanner,

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -56,7 +56,7 @@ from apio.scons_util import (
     create_construction_env,
     arg_bool,
     arg_str,
-    get_verilator_param_str,
+    get_verilator_warning_params,
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
@@ -83,8 +83,6 @@ TESTBENCH = arg_str(env, "testbench", "")
 VERILATOR_ALL = arg_bool(env, "all", False)
 VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 
-# Derived from args "nowarn" and "warn".
-VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
@@ -371,7 +369,7 @@ verilator_builder = Builder(
     ).format(
         "-Wall" if VERILATOR_ALL else "",
         "-Wno-style" if VERILATOR_NO_STYLE else "",
-        VERILATOR_PARAM_STR,
+        get_verilator_warning_params(env),
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
         YOSYS_LIB_DIR,
         TARGET + ".vlt",

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -39,7 +39,6 @@
 
 
 import os
-from platform import system
 from SCons.Script import (
     Builder,
     AlwaysBuild,
@@ -50,6 +49,9 @@ from SCons.Script import (
 )
 from apio.scons_util import (
     TARGET,
+    is_testbench,
+    basename,
+    is_windows,
     get_constraint_file,
     create_construction_env,
     arg_bool,
@@ -62,11 +64,11 @@ from apio.scons_util import (
     get_sim_config,
     get_tests_configs,
     make_waves_target,
+    make_iverilog_action,
 )
 
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
-
 
 # -- Get arguments.
 FPGA_MODEL = arg_str(env, "fpga_model", "")
@@ -89,11 +91,7 @@ IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
 ICEBOX_PATH = os.environ["ICEBOX"] if "ICEBOX" in os.environ else ""
 CHIPDB_PATH = os.path.join(ICEBOX_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
 YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
-YOSYS_CELLS_DIR = f"{YOSYS_PATH}/gowin"
-
-isWindows = "Windows" == system()
-VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
-IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
+YOSYS_LIB_DIR = YOSYS_PATH + "/gowin"
 
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
@@ -197,50 +195,60 @@ AlwaysBuild(time_rpt_target)
 time_target = env.Alias("time", time_rpt_target)
 
 
-# -- Apio sim/test
-# -- Builder helper (iverolog command generator).
-# -- (modules).v -> hardware.out.
-def iverilog_generator(source, target, env, for_signature):
-    """Constructs dynamically a commands for iverlog targets builders."""
-    # E.g. "my_module" or "my_module_tb"
-    target_name, _ = os.path.splitext(str(target[0]))
-    # Testbenches use the macro VCD_OUTPUT to know the name of the waves
-    # output file.We also pass a dummy when the verify command to avoid a
-    # warning about the undefined macro.
-    is_testbench = target_name.upper().endswith("_TB")
-    is_verify = "verify" in COMMAND_LINE_TARGETS
-    vcd_output_flag = (
-        "-DVCD_OUTPUT=dummy_vcd_output"
-        if is_verify
-        else f"-DVCD_OUTPUT={target_name}" if is_testbench else ""
-    )
-    verbose_flag = "-v" if VERBOSE_ALL else ""
-    # The INTERACTIVE_SIM macro allow testbenchs to distinguish between an
-    # automatic simulation (apio test) and interactive simulation (apio sim),
-    # For example, for continuing despire errors in interactive mode.
-    is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
-    interactive_sim_flag = "-DINTERACTIVE_SIM" if is_interactive_sim else ""
-    result = 'iverilog {0} {1} -o $TARGET {2} {3} -I"{4}" $SOURCES'.format(
-        IVER_PATH,
-        verbose_flag,
-        vcd_output_flag,
-        interactive_sim_flag,
-        YOSYS_CELLS_DIR,
-    )
-    return result
-
-
-# -- Apio sim/test.
+# -- Apio verify.
 # -- Builder (iverilog, verilog compiler).
-# -- (modules).v -> hardware.out.
-iverilog_builder = Builder(
-    # Action string is computed automatically by the generator.
-    generator=iverilog_generator,
+# -- (modules + testbenches).v -> hardware.out.
+iverilog_verify_builder = Builder(
+    action=make_iverilog_action(
+        env,
+        ivl_path=IVL_PATH,
+        verbose=VERBOSE_ALL,
+        vcd_output_name="dummy_vcd_output",
+        is_interactive=False,
+        lib_dirs=[YOSYS_LIB_DIR],
+    ),
     suffix=".out",
     src_suffix=".v",
     source_scanner=verilog_src_scanner,
 )
-env.Append(BUILDERS={"IVerilog": iverilog_builder})
+env.Append(BUILDERS={"IVerilogVerify": iverilog_verify_builder})
+
+
+# -- Apio sim/test
+# -- Builder helper (iverolog command generator).
+# -- (modules + testbench).v -> (testbench).out.
+def iverilog_tb_generator(source, target, env, for_signature):
+    """Construct the action string for the iverilog_tb_builder builder
+    for a given testbench target."""
+    # Extract testbench name from target file name.
+    testbench_file = str(target[0])
+    assert is_testbench(env, testbench_file), testbench_file
+    testbench_name = basename(env, testbench_file)
+
+    # Construct the command line.
+    action = make_iverilog_action(
+        env,
+        ivl_path=IVL_PATH,
+        verbose=VERBOSE_ALL,
+        vcd_output_name=testbench_name,
+        is_interactive=("sim" in COMMAND_LINE_TARGETS),
+        extra_params=["-DNO_ICE40_DEFAULT_ASSIGNMENTS"],
+        lib_dirs=[YOSYS_LIB_DIR],
+    )
+    return action
+
+
+# -- Apio sim/test.
+# -- Builder (iverilog, verilog compiler).
+# -- (modules + testbench).v -> (testbench).out.
+iverilog_tb_builder = Builder(
+    # Action string is different for sim and for
+    generator=iverilog_tb_generator,
+    suffix=".out",
+    src_suffix=".v",
+    source_scanner=verilog_src_scanner,
+)
+env.Append(BUILDERS={"IVerilogTestbench": iverilog_tb_builder})
 
 
 # -- Apio graph.
@@ -277,7 +285,11 @@ env.Append(BUILDERS={"SVG": svg_builder})
 # -- Builder (vvp, simulator).
 # -- (testbench).out -> (testbench).vcd.
 vcd_builder = Builder(
-    action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
+    action="vvp {0} $SOURCE".format(
+        "" if (is_windows(env) or not IVL_PATH) else f'-M "{IVL_PATH}"'
+    ),
+    suffix=".vcd",
+    src_suffix=".out",
 )
 env.Append(BUILDERS={"VCD": vcd_builder})
 
@@ -285,7 +297,7 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilog(TARGET, synth_srcs + test_srcs)
+vout_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
@@ -307,7 +319,7 @@ graph_target = env.Alias("graph", svg_target)
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
     config = get_sim_config(env, TESTBENCH, synth_srcs)
-    sout_target = env.IVerilog(config.top_module, config.srcs)
+    sout_target = env.IVerilogTestbench(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
@@ -320,7 +332,7 @@ if "test" in COMMAND_LINE_TARGETS:
     configs = get_tests_configs(env, TESTBENCH, synth_srcs, test_srcs)
     tests_targets = []
     for config in configs:
-        test_out_target = env.IVerilog(config.top_module, config.srcs)
+        test_out_target = env.IVerilogTestbencg(config.top_module, config.srcs)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
         AlwaysBuild(test_vcd_target)
@@ -340,16 +352,18 @@ if "test" in COMMAND_LINE_TARGETS:
 # -- (none) -> hardware.vlt builder.
 verilator_config_builder = make_verilator_config_builder(
     env,
-    "`verilator_config\n"
-    f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_DIR}/*"\n'
-    f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_DIR}/*"\n',
+    (
+        "`verilator_config\n"
+        f'lint_off -rule COMBDLY      -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_LIB_DIR}/*"\n'
+    ),
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
 
 # -- Apio lint.
 # -- Builder (verilator, verilog linter)
-# -- (modules).v -> lint report to stdout builder.
+# -- (modules + testbenches).v -> lint report to stdout builder.
 verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
@@ -359,7 +373,7 @@ verilator_builder = Builder(
         "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
-        YOSYS_CELLS_DIR,
+        YOSYS_LIB_DIR,
         TARGET + ".vlt",
     ),
     src_suffix=".v",

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -42,7 +42,6 @@ import os
 from platform import system
 from SCons.Script import (
     Builder,
-    Action,
     AlwaysBuild,
     GetOption,
     Exit,
@@ -51,6 +50,7 @@ from SCons.Script import (
     Glob,
 )
 from apio.scons_util import (
+    TARGET,
     get_constraint_file,
     error,
     fatal_error,
@@ -60,6 +60,7 @@ from apio.scons_util import (
     get_verilator_param_str,
     get_programmer_cmd,
     make_verilog_src_scanner,
+    make_verilator_config_builder,
 )
 
 # -- Create the environment
@@ -87,14 +88,11 @@ IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
 ICEBOX_PATH = os.environ["ICEBOX"] if "ICEBOX" in os.environ else ""
 CHIPDB_PATH = os.path.join(ICEBOX_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
 YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
-YOSYS_CELLS_PATH = f"{YOSYS_PATH}/gowin/cells_sim.v"
+YOSYS_CELLS_DIR = f"{YOSYS_PATH}/gowin"
 
 isWindows = "Windows" == system()
 VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
 IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
-
-# -- Target name
-TARGET = "hardware"
 
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
@@ -115,9 +113,7 @@ CST = get_constraint_file(env, ".cst", TOP_MODULE)
 # -- Builder (yosys, Synthesis).
 # -- (modules).v -> hardware.json.
 synth_builder = Builder(
-    action=(
-        'yosys -D LEDS_NR=6 -p "synth_gowin {0} -json $TARGET" {1} $SOURCES'
-    ).format(
+    action=('yosys -p "synth_gowin {0} -json $TARGET" {1} $SOURCES').format(
         ("-top " + TOP_MODULE) if TOP_MODULE else "",
         "" if VERBOSE_ALL or VERBOSE_YOSYS else "-q",
     ),
@@ -217,22 +213,22 @@ def iverilog_generator(source, target, env, for_signature):
     is_testbench = target_name.upper().endswith("_TB")
     is_verify = "verify" in COMMAND_LINE_TARGETS
     vcd_output_flag = (
-        "-D VCD_OUTPUT=dummy_vcd_output"
+        "-DVCD_OUTPUT=dummy_vcd_output"
         if is_verify
-        else f"-D VCD_OUTPUT={target_name}" if is_testbench else ""
+        else f"-DVCD_OUTPUT={target_name}" if is_testbench else ""
     )
     verbose_flag = "-v" if VERBOSE_ALL else ""
     # The INTERACTIVE_SIM macro allow testbenchs to distinguish between an
     # automatic simulation (apio test) and interactive simulation (apio sim),
     # For example, for continuing despire errors in interactive mode.
     is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
-    interactive_sim_flag = "-D INTERACTIVE_SIM" if is_interactive_sim else ""
-    result = 'iverilog {0} {1} -o $TARGET {2} {3} "{4}" $SOURCES'.format(
+    interactive_sim_flag = "-DINTERACTIVE_SIM" if is_interactive_sim else ""
+    result = 'iverilog {0} {1} -o $TARGET {2} {3} -I"{4}" $SOURCES'.format(
         IVER_PATH,
         verbose_flag,
         vcd_output_flag,
         interactive_sim_flag,
-        YOSYS_CELLS_PATH,
+        YOSYS_CELLS_DIR,
     )
     return result
 
@@ -401,21 +397,11 @@ if "test" in COMMAND_LINE_TARGETS:
 # -- Apio lint.
 # -- Builder (plain text generator)
 # -- (none) -> hardware.vlt builder.
-def verilator_config_func(target, source, env):
-    """Creates a verilator .vlt config files."""
-    with open(target[0].get_path(), "w", encoding="utf-8") as target_file:
-        # NOTE: This config was copied from ICE40. Fix it.
-        target_file.write(
-            "`verilator_config\n"
-            f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
-            f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n'
-        )
-    return 0
-
-
-verilator_config_builder = Builder(
-    action=Action(verilator_config_func, "Creating verilator config file."),
-    suffix=".vlt",
+verilator_config_builder = make_verilator_config_builder(
+    env,
+    "`verilator_config\n"
+    f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_DIR}/*"\n'
+    f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_DIR}/*"\n',
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
@@ -426,14 +412,14 @@ env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
-        '-Wno-MULTITOP {0} {1} {2} {3} {4} $SOURCES "{5}"'
+        '-Wno-MULTITOP {0} {1} {2} {3} -I"{4}" {5} $SOURCES'
     ).format(
         "-Wall" if VERILATOR_ALL else "",
         "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
+        YOSYS_CELLS_DIR,
         TARGET + ".vlt",
-        YOSYS_CELLS_PATH,
     ),
     src_suffix=".v",
     source_scanner=verilog_src_scanner,

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -44,7 +44,6 @@ from SCons.Script import (
     Builder,
     AlwaysBuild,
     GetOption,
-    Exit,
     COMMAND_LINE_TARGETS,
     ARGUMENTS,
     Glob,
@@ -52,8 +51,6 @@ from SCons.Script import (
 from apio.scons_util import (
     TARGET,
     get_constraint_file,
-    error,
-    fatal_error,
     create_construction_env,
     arg_bool,
     arg_str,
@@ -61,6 +58,10 @@ from apio.scons_util import (
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
+    get_source_files,
+    get_sim_config,
+    get_tests_configs,
+    make_waves_target,
 )
 
 # -- Create the environment
@@ -97,14 +98,10 @@ IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
 
-# -- Get a list of all the verilog files in the src folfer, in ASCII, with
-# -- the full path. All these files are used for the simulation
-v_nodes = Glob("*.v")
-v_files = [str(f) for f in v_nodes]
+# -- Get a list of the synthesizable files (e.g. "main.v") and a list of
+# -- the testbench files (e.g. "main_tb.v")
+src_synth, list_tb = get_source_files(env)
 
-# Construct disjoint lists of .v module and testbench files.
-src_synth = [f for f in v_files if f[-5:].upper() != "_TB.V"]
-list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
 
 # -- Get the CST file name.
 CST = get_constraint_file(env, ".cst", TOP_MODULE)
@@ -308,89 +305,33 @@ graph_target = env.Alias("graph", svg_target)
 # -- Apio sim.
 # -- Targets.
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
-#
-# NOTE: Since the simulation targets are dynamic due to the testbench
-# selection, we create them only when running simulations.
 if "sim" in COMMAND_LINE_TARGETS:
-    assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
-    if TESTBENCH:
-        # Explicit testbench file name is given via --testbench.
-        sim_testbench = TESTBENCH
-    else:
-        # No --testbench flag is specified. If there is exactly one testbench
-        # then pick it, otherwise fail.
-        if len(list_tb) == 0:
-            fatal_error(env, "No testbench found for simulation.")
-        if len(list_tb) > 1:
-            error(
-                env,
-                (
-                    "Found {} testbranches, please use the --testbench flag."
-                ).format(len(list_tb)),
-            )
-            for tb in list_tb:
-                print("- {}".format(tb))
-            Exit(1)
-        sim_testbench = list_tb[0]  # Pick the only available testbench.
-    # Here sim_testbench contains the testbench, e.g. my_module_tb.v.
-    # Construct list of files to build.
-    src_sim = []
-    src_sim.extend(src_synth)  # All the .v files.
-    src_sim.append(sim_testbench)
-    # Create targets sim target and its dependent.
-    sim_name, _ = os.path.splitext(sim_testbench)  # e.g. my_module_tb
-    sout_target = env.IVerilog(sim_name, src_sim)
+    config = get_sim_config(env, TESTBENCH, src_synth)
+    sout_target = env.IVerilog(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
-    # 'do_initial_zoom_fit' does max zoom only if .gtkw file not found.
-    waves_target = env.Alias(
-        "sim",
-        vcd_file_target,
-        "gtkwave {0} {1} {2}.gtkw".format(
-            '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
-            vcd_file_target[0],
-            sim_name,
-        ),
-    )
+    waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
 
 
 # -- Apio test.
 # -- Targets.
 # -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
-#
-# NOTE: Since the simulation targets are dynamic due to the testbench
-# selection, we create them only when running simulations.
 if "test" in COMMAND_LINE_TARGETS:
-    assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
-    if TESTBENCH:
-        # Explicit testbench file name is given via --testbench. We test just
-        # that one.
-        test_tbs = [TESTBENCH]
-    else:
-        # No --testbench flag specified. We will test all them.
-        if len(list_tb) == 0:
-            fatal_error(env, "No testbench files found (*_tb.v).")
-        test_tbs = list_tb  # All testbenches.
-    tests = []  # Targets of all tests
-    for test_tb in test_tbs:
-        # Create a list of source files. All the modules + the current
-        # testbench.
-        src_test = []
-        src_test.extend(src_synth)  # All the .v files.
-        src_test.append(test_tb)
-        # Create the targets for the 'out' and 'vcd' files of the testbench.
-        # NOTE: Remove the two AlwaysBuild() calls below for an incremental
-        # test. Fast, correct, but may confuse the user seeing nothing happens.
-        test_name, _ = os.path.splitext(test_tb)  # e.g. my_module_tb
-        test_out_target = env.IVerilog(test_name, src_test)
+    configs = get_tests_configs(env, TESTBENCH, src_synth, list_tb)
+    tests_targets = []
+    for config in configs:
+        test_out_target = env.IVerilog(config.top_module, config.srcs)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
         AlwaysBuild(test_vcd_target)
-        test_target = env.Alias(test_name, [test_out_target, test_vcd_target])
-        tests.append(test_target)
+        test_target = env.Alias(
+            config.top_module, [test_out_target, test_vcd_target]
+        )
+        tests_targets.append(test_target)
+
     # Create a target for the test command that depends on all the test
     # targets.
-    tests_target = env.Alias("test", tests)
+    tests_target = env.Alias("test", tests_targets)
     AlwaysBuild(tests_target)
 
 

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -100,7 +100,7 @@ verilog_src_scanner = make_verilog_src_scanner(env)
 
 # -- Get a list of the synthesizable files (e.g. "main.v") and a list of
 # -- the testbench files (e.g. "main_tb.v")
-src_synth, list_tb = get_source_files(env)
+synth_srcs, test_srcs = get_source_files(env)
 
 
 # -- Get the CST file name.
@@ -168,7 +168,7 @@ env.Append(BUILDERS={"Time": time_rpt_builder})
 # -- Apio build/upload.
 # -- Targets.
 # -- (module).v -> hardware.json -> hardware.pnr.json -> hardware.bin.
-synth_target = env.Synth(TARGET, [src_synth])
+synth_target = env.Synth(TARGET, [synth_srcs])
 pnr_target = env.PnR(TARGET, [synth_target, CST])
 bin_target = env.Bin(TARGET, pnr_target)
 build_target = env.Alias("build", bin_target)
@@ -285,7 +285,7 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilog(TARGET, src_synth + list_tb)
+vout_target = env.IVerilog(TARGET, synth_srcs + test_srcs)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
@@ -295,7 +295,7 @@ verify_target = env.Alias("verify", vout_target)
 # -- (modules).v -> hardware.dot -> hardware.svg.
 #
 # TODO: Launch a portable SVG (or differentn format) viewer.
-dot_target = env.DOT(TARGET, src_synth)
+dot_target = env.DOT(TARGET, synth_srcs)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
@@ -306,7 +306,7 @@ graph_target = env.Alias("graph", svg_target)
 # -- Targets.
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
-    config = get_sim_config(env, TESTBENCH, src_synth)
+    config = get_sim_config(env, TESTBENCH, synth_srcs)
     sout_target = env.IVerilog(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
@@ -317,7 +317,7 @@ if "sim" in COMMAND_LINE_TARGETS:
 # -- Targets.
 # -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
 if "test" in COMMAND_LINE_TARGETS:
-    configs = get_tests_configs(env, TESTBENCH, src_synth, list_tb)
+    configs = get_tests_configs(env, TESTBENCH, synth_srcs, test_srcs)
     tests_targets = []
     for config in configs:
         test_out_target = env.IVerilog(config.top_module, config.srcs)
@@ -372,7 +372,7 @@ env.Append(BUILDERS={"Verilator": verilator_builder})
 # -- Targets.
 # -- (modules).v -> lint report to stdout.
 lint_config_target = env.VerilatorConfig(TARGET, [])
-lint_out_target = env.Verilator(TARGET, src_synth + list_tb)
+lint_out_target = env.Verilator(TARGET, synth_srcs + test_srcs)
 env.Depends(lint_out_target, lint_config_target)
 lint_target = env.Alias("lint", lint_out_target)
 AlwaysBuild(lint_target)

--- a/apio/resources/gowin/SConstruct
+++ b/apio/resources/gowin/SConstruct
@@ -86,8 +86,6 @@ VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
-ICEBOX_PATH = os.environ["ICEBOX"] if "ICEBOX" in os.environ else ""
-CHIPDB_PATH = os.path.join(ICEBOX_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
 YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
 YOSYS_LIB_DIR = YOSYS_PATH + "/gowin"
 

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -42,7 +42,6 @@ import os
 from platform import system
 from SCons.Script import (
     Builder,
-    Action,
     AlwaysBuild,
     GetOption,
     Exit,
@@ -51,6 +50,7 @@ from SCons.Script import (
     Glob,
 )
 from apio.scons_util import (
+    TARGET,
     get_constraint_file,
     error,
     fatal_error,
@@ -60,6 +60,7 @@ from apio.scons_util import (
     get_verilator_param_str,
     get_programmer_cmd,
     make_verilog_src_scanner,
+    make_verilator_config_builder,
 )
 
 # -- Create the environment
@@ -85,14 +86,11 @@ IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
 ICEBOX_PATH = os.environ["ICEBOX"] if "ICEBOX" in os.environ else ""
 CHIPDB_PATH = os.path.join(ICEBOX_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
 YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
-YOSYS_CELLS_PATH = f"{YOSYS_PATH}/ice40/cells_sim.v"
+YOSYS_CELLS_DIR = f"{YOSYS_PATH}/ice40"
 
 isWindows = "Windows" == system()
 VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
 IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
-
-# -- Target name
-TARGET = "hardware"
 
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
@@ -199,7 +197,7 @@ AlwaysBuild(time_rpt_target)
 time_target = env.Alias("time", time_rpt_target)
 
 
-# -- Apio sim/test
+# -- Apio sim/test/verify
 # -- Builder helper (iverolog command generator).
 # -- (modules).v -> hardware.out.
 def iverilog_generator(source, target, env, for_signature):
@@ -212,30 +210,30 @@ def iverilog_generator(source, target, env, for_signature):
     is_testbench = target_name.upper().endswith("_TB")
     is_verify = "verify" in COMMAND_LINE_TARGETS
     vcd_output_flag = (
-        "-D VCD_OUTPUT=dummy_vcd_output"
+        "-DVCD_OUTPUT=dummy_vcd_output"
         if is_verify
-        else f"-D VCD_OUTPUT={target_name}" if is_testbench else ""
+        else f"-DVCD_OUTPUT={target_name}" if is_testbench else ""
     )
     verbose_flag = "-v" if VERBOSE_ALL else ""
     # The INTERACTIVE_SIM macro allow testbenchs to distinguish between an
     # automatic simulation (apio test) and interactive simulation (apio sim),
     # For example, for continuing despire errors in interactive mode.
     is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
-    interactive_sim_flag = "-D INTERACTIVE_SIM" if is_interactive_sim else ""
+    interactive_sim_flag = "-DINTERACTIVE_SIM" if is_interactive_sim else ""
     result = (
-        "iverilog {0} {1} -o $TARGET {2} {3} -D NO_ICE40_DEFAULT_ASSIGNMENTS "
-        '"{4}" $SOURCES'
+        "iverilog {0} {1} -o $TARGET {2} {3} -DNO_ICE40_DEFAULT_ASSIGNMENTS "
+        '-I"{4}" $SOURCES'
     ).format(
         IVER_PATH,
         verbose_flag,
         vcd_output_flag,
         interactive_sim_flag,
-        YOSYS_CELLS_PATH,
+        YOSYS_CELLS_DIR,
     )
     return result
 
 
-# -- Apio sim/test.
+# -- Apio sim/test/verify.
 # -- Builder (iverilog, verilog compiler).
 # -- (modules).v -> hardware.out.
 iverilog_builder = Builder(
@@ -399,20 +397,11 @@ if "test" in COMMAND_LINE_TARGETS:
 # -- Apio lint.
 # -- Builder (plain text generator)
 # -- (none) -> hardware.vlt builder.
-def verilator_config_func(target, source, env):
-    """Creates a verilator .vlt config files."""
-    with open(target[0].get_path(), "w", encoding="utf-8") as target_file:
-        target_file.write(
-            "`verilator_config\n"
-            f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_PATH}"\n'
-            f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_PATH}"\n'
-        )
-    return 0
-
-
-verilator_config_builder = Builder(
-    action=Action(verilator_config_func, "Creating verilator config file."),
-    suffix=".vlt",
+verilator_config_builder = make_verilator_config_builder(
+    env,
+    "`verilator_config\n"
+    f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_DIR}/*"\n'
+    f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_DIR}/*"\n',
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
@@ -424,14 +413,14 @@ verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
         "-Wno-MULTITOP -DNO_ICE40_DEFAULT_ASSIGNMENTS {0} {1} {2} {3} "
-        '{4} $SOURCES "{5}"'
+        '-I"{4}" {5} $SOURCES'
     ).format(
         "-Wall" if VERILATOR_ALL else "",
         "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
+        YOSYS_CELLS_DIR,
         TARGET + ".vlt",
-        YOSYS_CELLS_PATH,
     ),
     src_suffix=".v",
     source_scanner=verilog_src_scanner,

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -44,7 +44,6 @@ from SCons.Script import (
     Builder,
     AlwaysBuild,
     GetOption,
-    Exit,
     COMMAND_LINE_TARGETS,
     ARGUMENTS,
     Glob,
@@ -52,8 +51,6 @@ from SCons.Script import (
 from apio.scons_util import (
     TARGET,
     get_constraint_file,
-    error,
-    fatal_error,
     create_construction_env,
     arg_bool,
     arg_str,
@@ -61,6 +58,10 @@ from apio.scons_util import (
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
+    get_source_files,
+    get_sim_config,
+    get_tests_configs,
+    make_waves_target,
 )
 
 # -- Create the environment
@@ -95,14 +96,10 @@ IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
 
-# -- Get a list of all the verilog files in the src folfer, in ASCII, with
-# -- the full path. All these files are used for the simulation
-v_nodes = Glob("*.v")
-v_files = [str(f) for f in v_nodes]
+# -- Get a list of the synthesizable files (e.g. "main.v") and a list of
+# -- the testbench files (e.g. "main_tb.v")
+src_synth, list_tb = get_source_files(env)
 
-# Construct disjoint lists of .v module and testbench files.
-src_synth = [f for f in v_files if f[-5:].upper() != "_TB.V"]
-list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
 
 # -- Get the PCF file name.
 PCF = get_constraint_file(env, ".pcf", TOP_MODULE)
@@ -308,89 +305,33 @@ graph_target = env.Alias("graph", svg_target)
 # -- Apio sim.
 # -- Targets.
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
-#
-# NOTE: Since the simulation targets are dynamic due to the testbench
-# selection, we create them only when running simulations.
 if "sim" in COMMAND_LINE_TARGETS:
-    assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
-    if TESTBENCH:
-        # Explicit testbench file name is given via --testbench.
-        sim_testbench = TESTBENCH
-    else:
-        # No --testbench flag is specified. If there is exactly one testbench
-        # then pick it, otherwise fail.
-        if len(list_tb) == 0:
-            fatal_error(env, "No testbench found for simulation.")
-        if len(list_tb) > 1:
-            error(
-                env,
-                (
-                    "Found {} testbranches, please use the --testbench flag."
-                ).format(len(list_tb)),
-            )
-            for tb in list_tb:
-                print("- {}".format(tb))
-            Exit(1)
-        sim_testbench = list_tb[0]  # Pick the only available testbench.
-    # Here sim_testbench contains the testbench, e.g. my_module_tb.v.
-    # Construct list of files to build.
-    src_sim = []
-    src_sim.extend(src_synth)  # All the .v files.
-    src_sim.append(sim_testbench)
-    # Create targets sim target and its dependent.
-    sim_name, _ = os.path.splitext(sim_testbench)  # e.g. my_module_tb
-    sout_target = env.IVerilog(sim_name, src_sim)
+    config = get_sim_config(env, TESTBENCH, src_synth)
+    sout_target = env.IVerilog(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
-    # 'do_initial_zoom_fit' does max zoom only if .gtkw file not found.
-    waves_target = env.Alias(
-        "sim",
-        vcd_file_target,
-        "gtkwave {0} {1} {2}.gtkw".format(
-            '--rcvar "splash_disable on" --rcvar "do_initial_zoom_fit 1"',
-            vcd_file_target[0],
-            sim_name,
-        ),
-    )
+    waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
 
 
 # -- Apio test.
 # -- Targets.
 # -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
-#
-# NOTE: Since the simulation targets are dynamic due to the testbench
-# selection, we create them only when running simulations.
 if "test" in COMMAND_LINE_TARGETS:
-    assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
-    if TESTBENCH:
-        # Explicit testbench file name is given via --testbench. We test just
-        # that one.
-        test_tbs = [TESTBENCH]
-    else:
-        # No --testbench flag specified. We will test all them.
-        if len(list_tb) == 0:
-            fatal_error(env, "No testbench files found (*_tb.v).")
-        test_tbs = list_tb  # All testbenches.
-    tests = []  # Targets of all tests
-    for test_tb in test_tbs:
-        # Create a list of source files. All the modules + the current
-        # testbench.
-        src_test = []
-        src_test.extend(src_synth)  # All the .v files.
-        src_test.append(test_tb)
-        # Create the targets for the 'out' and 'vcd' files of the testbench.
-        # NOTE: Remove the two AlwaysBuild() calls below for an incremental
-        # test. Fast, correct, but may confuse the user seeing nothing happens.
-        test_name, _ = os.path.splitext(test_tb)  # e.g. my_module_tb
-        test_out_target = env.IVerilog(test_name, src_test)
+    configs = get_tests_configs(env, TESTBENCH, src_synth, list_tb)
+    tests_targets = []
+    for config in configs:
+        test_out_target = env.IVerilog(config.top_module, config.srcs)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
         AlwaysBuild(test_vcd_target)
-        test_target = env.Alias(test_name, [test_out_target, test_vcd_target])
-        tests.append(test_target)
+        test_target = env.Alias(
+            config.top_module, [test_out_target, test_vcd_target]
+        )
+        tests_targets.append(test_target)
+
     # Create a target for the test command that depends on all the test
     # targets.
-    tests_target = env.Alias("test", tests)
+    tests_target = env.Alias("test", tests_targets)
     AlwaysBuild(tests_target)
 
 

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -56,7 +56,7 @@ from apio.scons_util import (
     create_construction_env,
     arg_bool,
     arg_str,
-    get_verilator_param_str,
+    get_verilator_warning_params,
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
@@ -81,9 +81,6 @@ VERBOSE_PNR = arg_bool(env, "verbose_pnr", False)
 TESTBENCH = arg_str(env, "testbench", "")
 VERILATOR_ALL = arg_bool(env, "all", False)
 VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
-
-# Derived from args "nowarn" and "warn".
-VERILATOR_PARAM_STR = get_verilator_param_str(env)
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
@@ -372,7 +369,7 @@ verilator_builder = Builder(
     ).format(
         "-Wall" if VERILATOR_ALL else "",
         "-Wno-style" if VERILATOR_NO_STYLE else "",
-        VERILATOR_PARAM_STR,
+        get_verilator_warning_params(env),
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
         TARGET + ".vlt",
         YOSYS_LIB_FILE,

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -98,7 +98,7 @@ verilog_src_scanner = make_verilog_src_scanner(env)
 
 # -- Get a list of the synthesizable files (e.g. "main.v") and a list of
 # -- the testbench files (e.g. "main_tb.v")
-src_synth, list_tb = get_source_files(env)
+synth_srcs, test_srcs = get_source_files(env)
 
 
 # -- Get the PCF file name.
@@ -165,7 +165,7 @@ env.Append(BUILDERS={"Time": time_rpt_builder})
 # -- Apio build/upload.
 # -- Targets.
 # -- (module).v -> hardware.json -> hardware.asc -> hardware.bin.
-synth_target = env.Synth(TARGET, [src_synth])
+synth_target = env.Synth(TARGET, [synth_srcs])
 pnr_target = env.PnR(TARGET, [synth_target, PCF])
 bin_target = env.Bin(TARGET, pnr_target)
 build_target = env.Alias("build", bin_target)
@@ -285,7 +285,7 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilog(TARGET, src_synth + list_tb)
+vout_target = env.IVerilog(TARGET, synth_srcs + test_srcs)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
@@ -295,7 +295,7 @@ verify_target = env.Alias("verify", vout_target)
 # -- (modules).v -> hardware.dot -> hardware.svg.
 #
 # TODO: Launch a portable SVG (or differentn format) viewer.
-dot_target = env.DOT(TARGET, src_synth)
+dot_target = env.DOT(TARGET, synth_srcs)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
@@ -306,7 +306,7 @@ graph_target = env.Alias("graph", svg_target)
 # -- Targets.
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
-    config = get_sim_config(env, TESTBENCH, src_synth)
+    config = get_sim_config(env, TESTBENCH, synth_srcs)
     sout_target = env.IVerilog(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
@@ -317,7 +317,7 @@ if "sim" in COMMAND_LINE_TARGETS:
 # -- Targets.
 # -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
 if "test" in COMMAND_LINE_TARGETS:
-    configs = get_tests_configs(env, TESTBENCH, src_synth, list_tb)
+    configs = get_tests_configs(env, TESTBENCH, synth_srcs, test_srcs)
     tests_targets = []
     for config in configs:
         test_out_target = env.IVerilog(config.top_module, config.srcs)
@@ -373,7 +373,7 @@ env.Append(BUILDERS={"Verilator": verilator_builder})
 # -- Targets.
 # -- (modules).v -> lint report to stdout.
 lint_config_target = env.VerilatorConfig(TARGET, [])
-lint_out_target = env.Verilator(TARGET, src_synth + list_tb)
+lint_out_target = env.Verilator(TARGET, synth_srcs + test_srcs)
 env.Depends(lint_out_target, lint_config_target)
 lint_target = env.Alias("lint", lint_out_target)
 AlwaysBuild(lint_target)

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -56,7 +56,6 @@ from apio.scons_util import (
     create_construction_env,
     arg_bool,
     arg_str,
-    get_verilator_warning_params,
     get_programmer_cmd,
     make_verilog_src_scanner,
     make_verilator_config_builder,
@@ -65,6 +64,7 @@ from apio.scons_util import (
     get_tests_configs,
     make_waves_target,
     make_iverilog_action,
+    make_verilator_action,
 )
 
 # -- Create the environment
@@ -81,6 +81,9 @@ VERBOSE_PNR = arg_bool(env, "verbose_pnr", False)
 TESTBENCH = arg_str(env, "testbench", "")
 VERILATOR_ALL = arg_bool(env, "all", False)
 VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
+NOWARNS = arg_str(env, "nowarn", "").split(",")
+WARNS = arg_str(env, "warn", "").split(",")
+
 
 # -- Resources paths
 IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
@@ -362,17 +365,15 @@ env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 # -- Builder (verilator, verilog linter)
 # -- (modules + testbenches).v -> lint report to stdout builder.
 verilator_builder = Builder(
-    action=(
-        "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
-        "-Wno-MULTITOP -DNO_ICE40_DEFAULT_ASSIGNMENTS {0} {1} {2} {3} "
-        '{4} "{5}" $SOURCES'
-    ).format(
-        "-Wall" if VERILATOR_ALL else "",
-        "-Wno-style" if VERILATOR_NO_STYLE else "",
-        get_verilator_warning_params(env),
-        "--top-module " + TOP_MODULE if TOP_MODULE else "",
-        TARGET + ".vlt",
-        YOSYS_LIB_FILE,
+    action=make_verilator_action(
+        env,
+        warnings_all=VERILATOR_ALL,
+        warnings_no_style=VERILATOR_NO_STYLE,
+        no_warns=NOWARNS,
+        warns=WARNS,
+        top_module=TOP_MODULE,
+        extra_params=["-DNO_ICE40_DEFAULT_ASSIGNMENTS"],
+        lib_files=[YOSYS_LIB_FILE],
     ),
     src_suffix=".v",
     source_scanner=verilog_src_scanner,

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -39,7 +39,6 @@
 
 
 import os
-from platform import system
 from SCons.Script import (
     Builder,
     AlwaysBuild,
@@ -50,6 +49,9 @@ from SCons.Script import (
 )
 from apio.scons_util import (
     TARGET,
+    is_testbench,
+    basename,
+    is_windows,
     get_constraint_file,
     create_construction_env,
     arg_bool,
@@ -62,6 +64,7 @@ from apio.scons_util import (
     get_sim_config,
     get_tests_configs,
     make_waves_target,
+    make_iverilog_action,
 )
 
 # -- Create the environment
@@ -87,11 +90,8 @@ IVL_PATH = os.environ["IVL"] if "IVL" in os.environ else ""
 ICEBOX_PATH = os.environ["ICEBOX"] if "ICEBOX" in os.environ else ""
 CHIPDB_PATH = os.path.join(ICEBOX_PATH, "chipdb-{0}.txt".format(FPGA_SIZE))
 YOSYS_PATH = os.environ["YOSYS_LIB"] if "YOSYS_LIB" in os.environ else ""
-YOSYS_CELLS_DIR = f"{YOSYS_PATH}/ice40"
-
-isWindows = "Windows" == system()
-VVP_PATH = "" if isWindows or not IVL_PATH else '-M "{0}"'.format(IVL_PATH)
-IVER_PATH = "" if isWindows or not IVL_PATH else '-B "{0}"'.format(IVL_PATH)
+YOSYS_LIB_DIR = YOSYS_PATH + "/ice40"
+YOSYS_LIB_FILE = YOSYS_LIB_DIR + "/cells_sim.v"
 
 # -- Create scannenr to identify dependencies in verilog files.
 verilog_src_scanner = make_verilog_src_scanner(env)
@@ -194,53 +194,61 @@ AlwaysBuild(time_rpt_target)
 time_target = env.Alias("time", time_rpt_target)
 
 
-# -- Apio sim/test/verify
-# -- Builder helper (iverolog command generator).
-# -- (modules).v -> hardware.out.
-def iverilog_generator(source, target, env, for_signature):
-    """Constructs dynamically a commands for iverlog targets builders."""
-    # E.g. "my_module" or "my_module_tb"
-    target_name, _ = os.path.splitext(str(target[0]))
-    # Testbenches use the macro VCD_OUTPUT to know the name of the waves
-    # output file.We also pass a dummy when the verify command to avoid a
-    # warning about the undefined macro.
-    is_testbench = target_name.upper().endswith("_TB")
-    is_verify = "verify" in COMMAND_LINE_TARGETS
-    vcd_output_flag = (
-        "-DVCD_OUTPUT=dummy_vcd_output"
-        if is_verify
-        else f"-DVCD_OUTPUT={target_name}" if is_testbench else ""
-    )
-    verbose_flag = "-v" if VERBOSE_ALL else ""
-    # The INTERACTIVE_SIM macro allow testbenchs to distinguish between an
-    # automatic simulation (apio test) and interactive simulation (apio sim),
-    # For example, for continuing despire errors in interactive mode.
-    is_interactive_sim = is_testbench and "sim" in COMMAND_LINE_TARGETS
-    interactive_sim_flag = "-DINTERACTIVE_SIM" if is_interactive_sim else ""
-    result = (
-        "iverilog {0} {1} -o $TARGET {2} {3} -DNO_ICE40_DEFAULT_ASSIGNMENTS "
-        '-I"{4}" $SOURCES'
-    ).format(
-        IVER_PATH,
-        verbose_flag,
-        vcd_output_flag,
-        interactive_sim_flag,
-        YOSYS_CELLS_DIR,
-    )
-    return result
-
-
-# -- Apio sim/test/verify.
+# -- Apio verify.
 # -- Builder (iverilog, verilog compiler).
-# -- (modules).v -> hardware.out.
-iverilog_builder = Builder(
-    # Action string is computed automatically by the generator.
-    generator=iverilog_generator,
+# -- (modules + testbenches).v -> hardware.out.
+iverilog_verify_builder = Builder(
+    action=make_iverilog_action(
+        env,
+        ivl_path=IVL_PATH,
+        verbose=VERBOSE_ALL,
+        vcd_output_name="dummy_vcd_output",
+        is_interactive=False,
+        extra_params=["-DNO_ICE40_DEFAULT_ASSIGNMENTS"],
+        lib_files=[YOSYS_LIB_FILE],
+    ),
     suffix=".out",
     src_suffix=".v",
     source_scanner=verilog_src_scanner,
 )
-env.Append(BUILDERS={"IVerilog": iverilog_builder})
+env.Append(BUILDERS={"IVerilogVerify": iverilog_verify_builder})
+
+
+# -- Apio sim/test
+# -- Builder helper (iverolog command generator).
+# -- (modules + testbench).v -> (testbench).out.
+def iverilog_tb_generator(source, target, env, for_signature):
+    """Construct the action string for the iverilog_tb_builder builder
+    for a given testbench target."""
+    # Extract testbench name from target file name.
+    testbench_file = str(target[0])
+    assert is_testbench(env, testbench_file), testbench_file
+    testbench_name = basename(env, testbench_file)
+
+    # Construct the command line.
+    action = make_iverilog_action(
+        env,
+        ivl_path=IVL_PATH,
+        verbose=VERBOSE_ALL,
+        vcd_output_name=testbench_name,
+        is_interactive=("sim" in COMMAND_LINE_TARGETS),
+        extra_params=["-DNO_ICE40_DEFAULT_ASSIGNMENTS"],
+        lib_files=[YOSYS_LIB_FILE],
+    )
+    return action
+
+
+# -- Apio sim/test.
+# -- Builder (iverilog, verilog compiler).
+# -- (modules + testbench).v -> (testbench).out.
+iverilog_tb_builder = Builder(
+    # Action string is different for sim and for
+    generator=iverilog_tb_generator,
+    suffix=".out",
+    src_suffix=".v",
+    source_scanner=verilog_src_scanner,
+)
+env.Append(BUILDERS={"IVerilogTestbench": iverilog_tb_builder})
 
 
 # -- Apio graph.
@@ -277,7 +285,11 @@ env.Append(BUILDERS={"SVG": svg_builder})
 # -- Builder (vvp, simulator).
 # -- (testbench).out -> (testbench).vcd.
 vcd_builder = Builder(
-    action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
+    action="vvp {0} $SOURCE".format(
+        "" if (is_windows(env) or not IVL_PATH) else f'-M "{IVL_PATH}"'
+    ),
+    suffix=".vcd",
+    src_suffix=".out",
 )
 env.Append(BUILDERS={"VCD": vcd_builder})
 
@@ -285,7 +297,7 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilog(TARGET, synth_srcs + test_srcs)
+vout_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
@@ -307,7 +319,7 @@ graph_target = env.Alias("graph", svg_target)
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
     config = get_sim_config(env, TESTBENCH, synth_srcs)
-    sout_target = env.IVerilog(config.top_module, config.srcs)
+    sout_target = env.IVerilogTestbench(config.top_module, config.srcs)
     vcd_file_target = env.VCD(sout_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
@@ -320,7 +332,7 @@ if "test" in COMMAND_LINE_TARGETS:
     configs = get_tests_configs(env, TESTBENCH, synth_srcs, test_srcs)
     tests_targets = []
     for config in configs:
-        test_out_target = env.IVerilog(config.top_module, config.srcs)
+        test_out_target = env.IVerilogTestbench(config.top_module, config.srcs)
         AlwaysBuild(test_out_target)
         test_vcd_target = env.VCD(test_out_target)
         AlwaysBuild(test_vcd_target)
@@ -340,28 +352,30 @@ if "test" in COMMAND_LINE_TARGETS:
 # -- (none) -> hardware.vlt builder.
 verilator_config_builder = make_verilator_config_builder(
     env,
-    "`verilator_config\n"
-    f'lint_off -rule COMBDLY      -file "{YOSYS_CELLS_DIR}/*"\n'
-    f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_CELLS_DIR}/*"\n',
+    (
+        "`verilator_config\n"
+        f'lint_off -rule COMBDLY      -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_LIB_DIR}/*"\n'
+    ),
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
 
 # -- Apio lint.
 # -- Builder (verilator, verilog linter)
-# -- (modules).v -> lint report to stdout builder.
+# -- (modules + testbenches).v -> lint report to stdout builder.
 verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
         "-Wno-MULTITOP -DNO_ICE40_DEFAULT_ASSIGNMENTS {0} {1} {2} {3} "
-        '-I"{4}" {5} $SOURCES'
+        '{4} "{5}" $SOURCES'
     ).format(
         "-Wall" if VERILATOR_ALL else "",
         "-Wno-style" if VERILATOR_NO_STYLE else "",
         VERILATOR_PARAM_STR,
         "--top-module " + TOP_MODULE if TOP_MODULE else "",
-        YOSYS_CELLS_DIR,
         TARGET + ".vlt",
+        YOSYS_LIB_FILE,
     ),
     src_suffix=".v",
     source_scanner=verilog_src_scanner,

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -65,7 +65,7 @@ from apio.scons_util import (
 # -- Create the environment
 env = create_construction_env(ARGUMENTS)
 
-# -- Get arguments
+# -- Get arguments.
 FPGA_SIZE = arg_str(env, "fpga_size", "")
 FPGA_TYPE = arg_str(env, "fpga_type", "")
 FPGA_PACK = arg_str(env, "fpga_pack", "")
@@ -76,7 +76,6 @@ VERBOSE_PNR = arg_bool(env, "verbose_pnr", False)
 TESTBENCH = arg_str(env, "testbench", "")
 VERILATOR_ALL = arg_bool(env, "all", False)
 VERILATOR_NO_STYLE = arg_bool(env, "nostyle", False)
-
 
 # Derived from args "nowarn" and "warn".
 VERILATOR_PARAM_STR = get_verilator_param_str(env)
@@ -110,7 +109,10 @@ list_tb = [f for f in v_files if f[-5:].upper() == "_TB.V"]
 # -- Get the PCF file name.
 PCF = get_constraint_file(env, ".pcf", TOP_MODULE)
 
-# -- Synthesizing Builder
+
+# -- Apio build/upload.
+# -- Builder (yosys, Synthesis).
+# -- (modules).v -> hardware.json.
 synth_builder = Builder(
     action='yosys -p "synth_ice40 {0} -json $TARGET" {1} $SOURCES'.format(
         ("-top " + TOP_MODULE) if TOP_MODULE else "",
@@ -122,7 +124,10 @@ synth_builder = Builder(
 )
 env.Append(BUILDERS={"Synth": synth_builder})
 
-# -- Place and route Builder.
+
+# -- Apio build/upload.
+# -- builder (nextpnr, Place and route).
+# -- hardware.json -> hardware.asc.
 pnr_builder = Builder(
     action=(
         "nextpnr-ice40 --{0}{1} --package {2} --json $SOURCE --asc $TARGET "
@@ -139,14 +144,19 @@ pnr_builder = Builder(
 )
 env.Append(BUILDERS={"PnR": pnr_builder})
 
-# -- Bitstream Builder.
+
+# -- Apio build/upload.
+# -- Builder (icepack, bitstream generator).
+# -- hardware.asc -> hardware.bin.
 bitstream_builder = Builder(
     action="icepack $SOURCE $TARGET", suffix=".bin", src_suffix=".asc"
 )
 env.Append(BUILDERS={"Bin": bitstream_builder})
 
-# -- Time report builder
-# https://github.com/cliffordwolf/icestorm/issues/57
+
+# -- Apio time.
+# -- Builder | icetime | Time reports.
+# -- hardware.asc -> hardware.rpt
 time_rpt_builder = Builder(
     action='icetime -d {0}{1} -P {2} -C "{3}" -mtr $TARGET $SOURCE'.format(
         FPGA_TYPE, FPGA_SIZE, FPGA_PACK, CHIPDB_PATH
@@ -156,7 +166,10 @@ time_rpt_builder = Builder(
 )
 env.Append(BUILDERS={"Time": time_rpt_builder})
 
-# -- Generate the bitstream
+
+# -- Apio build/upload.
+# -- Targets.
+# -- (module).v -> hardware.json -> hardware.asc -> hardware.bin.
 synth_target = env.Synth(TARGET, [src_synth])
 pnr_target = env.PnR(TARGET, [synth_target, PCF])
 bin_target = env.Bin(TARGET, pnr_target)
@@ -169,19 +182,26 @@ if VERBOSE_PNR:
 if VERBOSE_ALL:
     AlwaysBuild(synth_target, pnr_target, build_target)
 
-# -- Upload the bitstream into FPGA
+
+# -- Apio upload.
+# -- Targets.
+# -- hardware.bin -> FPGA.
 programmer_cmd = get_programmer_cmd(env)
 upload_target = env.Alias("upload", bin_target, programmer_cmd)
 AlwaysBuild(upload_target)
 
-# -- Target time: calculate the time
-rpt_target = env.Time(pnr_target)
-AlwaysBuild(rpt_target)
-time_target = env.Alias("time", rpt_target)
 
-# -- Icarus Verilog builders
+# -- Apio time.
+# -- Targets.
+# -- hardware.asc -> hardware.rpt
+time_rpt_target = env.Time(pnr_target)
+AlwaysBuild(time_rpt_target)
+time_target = env.Alias("time", time_rpt_target)
 
 
+# -- Apio sim/test
+# -- Builder helper (iverolog command generator).
+# -- (modules).v -> hardware.out.
 def iverilog_generator(source, target, env, for_signature):
     """Constructs dynamically a commands for iverlog targets builders."""
     # E.g. "my_module" or "my_module_tb"
@@ -215,6 +235,9 @@ def iverilog_generator(source, target, env, for_signature):
     return result
 
 
+# -- Apio sim/test.
+# -- Builder (iverilog, verilog compiler).
+# -- (modules).v -> hardware.out.
 iverilog_builder = Builder(
     # Action string is computed automatically by the generator.
     generator=iverilog_generator,
@@ -224,6 +247,10 @@ iverilog_builder = Builder(
 )
 env.Append(BUILDERS={"IVerilog": iverilog_builder})
 
+
+# -- Apio graph.
+# -- Builder (yosys, .dot graph generator).
+# -- hardware.v -> hardware.dot.
 dot_builder = Builder(
     action=(
         'yosys -f verilog -p "show -format dot -colors 1 '
@@ -238,6 +265,10 @@ dot_builder = Builder(
 )
 env.Append(BUILDERS={"DOT": dot_builder})
 
+
+# -- Apio graph.
+# -- Builder  (dot, svg renderer).
+# -- hardware.dot -> hardware.svg.
 svg_builder = Builder(
     # Expecting graphviz dot to be installed and in the path.
     action="dot -Tsvg $SOURCES -o $TARGET",
@@ -246,41 +277,53 @@ svg_builder = Builder(
 )
 env.Append(BUILDERS={"SVG": svg_builder})
 
-# NOTE: output file name is defined in the iverilog call using VCD_OUTPUT macro
+
+# -- Apio sim/test.
+# -- Builder (vvp, simulator).
+# -- (testbench).out -> (testbench).vcd.
 vcd_builder = Builder(
     action="vvp {0} $SOURCE".format(VVP_PATH), suffix=".vcd", src_suffix=".out"
 )
 env.Append(BUILDERS={"VCD": vcd_builder})
 
-# --- Verify
+
+# -- Apio verify.
+# -- Targets
+# -- (modules).v -> (modules).out
 vout_target = env.IVerilog(TARGET, src_synth + list_tb)
 AlwaysBuild(vout_target)
 verify_target = env.Alias("verify", vout_target)
 
-# --- Graph
-# TODO: Launch some portable SVG (or differentn format) viewer.
+
+# -- Apio graph.
+# -- Targets.
+# -- (modules).v -> hardware.dot -> hardware.svg.
+#
+# TODO: Launch a portable SVG (or differentn format) viewer.
 dot_target = env.DOT(TARGET, src_synth)
 AlwaysBuild(dot_target)
 svg_target = env.SVG(TARGET, dot_target)
 AlwaysBuild(svg_target)
 graph_target = env.Alias("graph", svg_target)
 
-# --- Simulation
-# Since the simulation targets are dynamic due to the testbench selection, we
-# create them only when running simulation.
+
+# -- Apio sim.
+# -- Targets.
+# -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
+#
+# NOTE: Since the simulation targets are dynamic due to the testbench
+# selection, we create them only when running simulations.
 if "sim" in COMMAND_LINE_TARGETS:
     assert "test" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
         # Explicit testbench file name is given via --testbench.
         sim_testbench = TESTBENCH
     else:
-        # No --testbench flag specified. If there is exactly one testbench then
-        # pick it, otherwise fail.
+        # No --testbench flag is specified. If there is exactly one testbench
+        # then pick it, otherwise fail.
         if len(list_tb) == 0:
             fatal_error(env, "No testbench found for simulation.")
         if len(list_tb) > 1:
-            # TODO: consider to allow specifying the default testbench in
-            # apio.ini.
             error(
                 env,
                 (
@@ -313,9 +356,12 @@ if "sim" in COMMAND_LINE_TARGETS:
     AlwaysBuild(waves_target)
 
 
-# --- Testing
-# Since the simulation targets are dynamic due to the testbench selection, we
-# create them only when running simulation.
+# -- Apio test.
+# -- Targets.
+# -- (modules).v -> (testbenchs).out -> (testbenchs).vcd
+#
+# NOTE: Since the simulation targets are dynamic due to the testbench
+# selection, we create them only when running simulations.
 if "test" in COMMAND_LINE_TARGETS:
     assert "sim" not in COMMAND_LINE_TARGETS, COMMAND_LINE_TARGETS
     if TESTBENCH:
@@ -336,8 +382,7 @@ if "test" in COMMAND_LINE_TARGETS:
         src_test.append(test_tb)
         # Create the targets for the 'out' and 'vcd' files of the testbench.
         # NOTE: Remove the two AlwaysBuild() calls below for an incremental
-        # test. Fast, correct,
-        # but may confuse the user seeing nothing happens.
+        # test. Fast, correct, but may confuse the user seeing nothing happens.
         test_name, _ = os.path.splitext(test_tb)  # e.g. my_module_tb
         test_out_target = env.IVerilog(test_name, src_test)
         AlwaysBuild(test_out_target)
@@ -351,7 +396,9 @@ if "test" in COMMAND_LINE_TARGETS:
     AlwaysBuild(tests_target)
 
 
-# -- Verilator config file builder
+# -- Apio lint.
+# -- Builder (plain text generator)
+# -- (none) -> hardware.vlt builder.
 def verilator_config_func(target, source, env):
     """Creates a verilator .vlt config files."""
     with open(target[0].get_path(), "w", encoding="utf-8") as target_file:
@@ -369,7 +416,10 @@ verilator_config_builder = Builder(
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})
 
-# -- Verilator builder
+
+# -- Apio lint.
+# -- Builder (verilator, verilog linter)
+# -- (modules).v -> lint report to stdout builder.
 verilator_builder = Builder(
     action=(
         "verilator --lint-only --bbox-unsup --timing -Wno-TIMESCALEMOD "
@@ -388,7 +438,10 @@ verilator_builder = Builder(
 )
 env.Append(BUILDERS={"Verilator": verilator_builder})
 
-# --- Lint
+
+# -- Apio lint.
+# -- Targets.
+# -- (modules).v -> lint report to stdout.
 lint_config_target = env.VerilatorConfig(TARGET, [])
 lint_out_target = env.Verilator(TARGET, src_synth + list_tb)
 env.Depends(lint_out_target, lint_config_target)

--- a/apio/resources/ice40/SConstruct
+++ b/apio/resources/ice40/SConstruct
@@ -297,9 +297,9 @@ env.Append(BUILDERS={"VCD": vcd_builder})
 # -- Apio verify.
 # -- Targets
 # -- (modules).v -> (modules).out
-vout_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
-AlwaysBuild(vout_target)
-verify_target = env.Alias("verify", vout_target)
+verify_out_target = env.IVerilogVerify(TARGET, synth_srcs + test_srcs)
+AlwaysBuild(verify_out_target)
+verify_target = env.Alias("verify", verify_out_target)
 
 
 # -- Apio graph.
@@ -319,8 +319,8 @@ graph_target = env.Alias("graph", svg_target)
 # -- (modules).v -> (testbench).out -> (testbench).vcd -> gtkwave
 if "sim" in COMMAND_LINE_TARGETS:
     config = get_sim_config(env, TESTBENCH, synth_srcs)
-    sout_target = env.IVerilogTestbench(config.top_module, config.srcs)
-    vcd_file_target = env.VCD(sout_target)
+    sim_out_target = env.IVerilogTestbench(config.top_module, config.srcs)
+    vcd_file_target = env.VCD(sim_out_target)
     waves_target = make_waves_target(env, vcd_file_target, config.top_module)
     AlwaysBuild(waves_target)
 
@@ -402,5 +402,11 @@ if GetOption("clean"):
             env.Clean(time_target, str(node))
 
     env.Default(
-        [time_target, build_target, vout_target, graph_target, lint_target]
+        [
+            time_target,
+            build_target,
+            verify_out_target,
+            graph_target,
+            lint_target,
+        ]
     )

--- a/apio/scons_util.py
+++ b/apio/scons_util.py
@@ -201,7 +201,7 @@ def dump_env_vars(env: SConsEnvironment) -> None:
     print("----- Env vars end -------")
 
 
-def get_verilator_param_str(env: SConsEnvironment) -> str:
+def get_verilator_warning_params(env: SConsEnvironment) -> str:
     """Construct from the nowwarn and warn arguments an option list
     for verilator. These values are specified by the user to the
     apio lint param.

--- a/apio/scons_util.py
+++ b/apio/scons_util.py
@@ -25,6 +25,9 @@ from SCons.Script.SConscript import SConsEnvironment
 import SCons.Node.FS
 import click
 
+# -- Target name
+TARGET = "hardware"
+
 
 def create_construction_env(args: Dict[str, str]) -> SConsEnvironment:
     """Creates a scons env. Should be called very early in SConstruct.py"""
@@ -264,3 +267,21 @@ def make_verilog_src_scanner(env: SConsEnvironment) -> SCons.Scanner:
         return env.File(includes_list)
 
     return env.Scanner(function=verilog_src_scanner_func)
+
+
+def make_verilator_config_builder(env: SConsEnvironment, config_text: str):
+    """Create a scons Builder that writes a verilator config file
+    (hardware.vlt) with the given text."""
+
+    def verilator_config_func(target, source, env):
+        """Creates a verilator .vlt config files."""
+        with open(target[0].get_path(), "w", encoding="utf-8") as target_file:
+            target_file.write(config_text)
+        return 0
+
+    return env.Builder(
+        action=env.Action(
+            verilator_config_func, "Creating verilator config file."
+        ),
+        suffix=".vlt",
+    )

--- a/apio/scons_util.py
+++ b/apio/scons_util.py
@@ -252,21 +252,21 @@ def get_programmer_cmd(env: SConsEnvironment) -> str:
     # Get the programer command template arg.
     prog_arg = arg_str(env, "prog", "")
 
-    # If empty then return as is.
+    # If empty then return as is. This must be an apio command that doesn't use
+    # the programmer.
     if not prog_arg:
         return prog_arg
 
-    # The programmer template is expected to contain the placeholder
-    # "${SOURCE}" that we need to convert to "$SOURCE" as expected by scons.
-    if "${SOURCE}" not in prog_arg:
+    # It's an error if the programmer command doesn't have the $SOURCE
+    # placeholder when scons inserts the binary file name.
+    if "$SOURCE" not in prog_arg:
         fatal_error(
             env,
             "[Internal] 'prog' argument does not contain "
-            f"the '${{SOURCE}}' marker. [{prog_arg}]",
+            f"the '$SOURCE' marker. [{prog_arg}]",
         )
 
-    prog_cmd = prog_arg.replace("${SOURCE}", "$SOURCE")
-    return prog_cmd
+    return prog_arg
 
 
 def make_verilog_src_scanner(env: SConsEnvironment) -> SCons.Scanner:


### PR DESCRIPTION
The goals of this PR

1.  Moving shared functionality from the three SConstruct files to the library file scons_util.py.
2. Making the three SConstruct files simpler and more readable.
3. Eliminating unnecessary differences between the three SConstruct files.

Details in the commits' descriptions.
