### PR TITLE
Cleaned up the apio example -l report.

### DIFF
--- a/apio/commands/boards.py
+++ b/apio/commands/boards.py
@@ -39,8 +39,9 @@ of the project that contains the apio.ini file.
 
 \b
 Examples:
-  apio boards --list  # List boards
-  apio boards --fpga  # List FPGAs
+  apio boards --list           # List boards
+  apio boards --fpga           # List FPGAs
+  apio boards -l | grep ecp5   # Filter boards results
 
 [Advanced] Boards with wide availability can be added by contacting the
 apio team. A custom one-of board can be added to your project by

--- a/apio/commands/boards.py
+++ b/apio/commands/boards.py
@@ -42,6 +42,7 @@ Examples:
   apio boards --list           # List boards
   apio boards --fpga           # List FPGAs
   apio boards -l | grep ecp5   # Filter boards results
+  apio boards -f | grep gowin  # Filter FPGA results.
 
 [Advanced] Boards with wide availability can be added by contacting the
 apio team. A custom one-of board can be added to your project by

--- a/apio/commands/examples.py
+++ b/apio/commands/examples.py
@@ -49,10 +49,11 @@ board/name where board is the board id and name is the example name.
 
 \b
 Examples:
-  apio examples --list            # List all examples
-  apio examples -f icezum/leds    # Fetch example files
-  apio examples -s icezum/leds    # Fetch example directory
-  apio examples -d icezum         # Fetch all board examples
+  apio examples --list               # List all examples
+  apio examples -l | grep -i icezum  # Filter examples.
+  apio examples -f icezum/leds       # Fetch example files
+  apio examples -s icezum/leds       # Fetch example directory
+  apio examples -d icezum            # Fetch all board examples
 """
 
 

--- a/apio/commands/system.py
+++ b/apio/commands/system.py
@@ -133,6 +133,11 @@ def cli(
         # -- Print apio package directory.
         click.secho("Package:  ", nl=False)
         click.secho(util.get_path_in_apio_package(""), fg="yellow")
+
+        # -- Print apio home directory.
+        click.secho("Home:     ", nl=False)
+        click.secho(util.get_home_dir(), fg="yellow")
+
         ctx.exit(0)
 
     # -- Invalid option. Just show the help

--- a/apio/commands/uninstall.py
+++ b/apio/commands/uninstall.py
@@ -23,7 +23,7 @@ def _uninstall(packages: list, platform: str, resources: Resources):
     """Uninstall the given list of packages"""
 
     # -- Ask the user for confirmation
-    if click.confirm("Do you want to continue?"):
+    if click.confirm("Do you want to uninstall?"):
 
         # -- Uninstall packages, one by one
         for package in packages:

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -7,9 +7,10 @@
 # -- Licence GPLv2
 
 import shutil
-from pathlib import Path
+from pathlib import Path, PosixPath
+from dataclasses import dataclass
+from typing import Optional, Tuple, List
 import click
-
 from apio import util
 from apio.profile import Profile
 from apio.resources import Resources
@@ -28,6 +29,15 @@ Example of use:
 
 Type 'apio examples -h' for more details.
 """
+
+
+@dataclass
+class ExampleInfo:
+    """Information about a single example."""
+
+    name: str
+    path: PosixPath
+    description: str
 
 
 class Examples:
@@ -53,84 +63,99 @@ class Examples:
         # -- Get the version restrictions
         self.spec_version = util.get_package_spec_version(self.name, resources)
 
-    def list_examples(self):
-        """Print all the examples available"""
+    def get_examples_infos(self) -> Optional[List[ExampleInfo]]:
+        """Scans the examples and returns a list of ExampleInfos.
+        Returns null if an error."""
 
         # -- Check if the example package is installed
         installed = util.check_package(
             self.name, self.version, self.spec_version, self.examples_dir
         )
 
-        # -- No package installed: return
         if not installed:
+            # -- A message was already printed.
+            return None
+
+        # -- Collect the examples home dir each board.
+        boards_dirs: List[PosixPath] = []
+
+        for board_dir in self.examples_dir.iterdir():
+            if board_dir.is_dir():
+                boards_dirs.append(board_dir)
+
+        # -- Collect the examples of each boards.
+        examples: List[Tuple[str, PosixPath]] = []
+        for board_dir in boards_dirs:
+
+            # -- Iterate board's example subdirectories.
+            for example_dir in board_dir.iterdir():
+
+                # -- Skip files. We care just about directories.
+                if not example_dir.is_dir():
+                    continue
+
+                # -- Try to load description from the example info file.
+                info_file = example_dir / "info"
+                if info_file.exists():
+                    with open(info_file, "r", encoding="utf-8") as f:
+                        description = f.read().replace("\n", "")
+                else:
+                    description = ""
+
+                # -- Append this example to the list.
+                name = f"{board_dir.name}/{example_dir.name}"
+                example_info = ExampleInfo(name, example_dir, description)
+                examples.append(example_info)
+
+        # -- Sort in-place by ascceding example name, case insensitive.
+        examples.sort(key=lambda x: x.name.lower())
+
+        return examples
+
+    def list_examples(self) -> None:
+        """Print all the examples available. Return a process exit
+        code, 0 if ok, non zero otherwise."""
+
+        # -- Get list of examples.
+        examples: List[ExampleInfo] = self.get_examples_infos()
+        if examples is None:
+            # -- Error message is aleady printed.
             return 1
 
-        # -- Calculate the terminal width
-        terminal_width, _ = shutil.get_terminal_size()
+        # -- Get terminal configuration. We format the report differently for
+        # -- a terminal and for a pipe.
+        output_config = util.get_terminal_config()
 
-        # -- String with a horizontal line with the same width
-        # -- as the terminal
-        line = "─" * terminal_width
+        # -- For terminal, print a header with an horizontal line across the
+        # -- terminal.
+        if output_config.terminal_mode():
+            terminal_seperator_line = "─" * output_config.terminal_width
+            click.echo()
+            click.echo(terminal_seperator_line)
 
-        # -- Print the header
-        click.echo()
-        click.echo(line)
+        # -- For a pipe, determine the max example name length.
+        if output_config.pipe_mode():
+            max_example_name_len = max(len(x.name) for x in examples)
 
-        # -- Collect all the board (every folder in the examples packages
-        # -- correspond to a board)
-        boards = []
+        # -- Emit the examples
+        for example in examples:
+            if output_config.pipe_mode():
+                # -- For a pipe, single line, no colors.
+                click.secho(
+                    f"{example.name:<{max_example_name_len}}  |  "
+                    f"{example.description}"
+                )
+            else:
+                # -- For a terminal. Multi lines and colors.
+                click.secho(f"{example.name}", fg="blue", bold=True)
+                click.secho(f"{example.description}")
+                click.secho(terminal_seperator_line)
 
-        for board in sorted(self.examples_dir.iterdir()):
-            if board.is_dir():
-                boards.append(board)
+        # -- For a terminal, emit additional summary.
+        if output_config.terminal_mode():
+            click.secho(f"Total: {len(examples)}")
+            click.secho(USAGE_EXAMPLE, fg="green")
 
-        # -- Collect the examples for each board
-        # -- Valid examples are folders...
-        examples = []
-        examples_names = []
-
-        # -- Every board...
-        for board in boards:
-
-            # -- Has one or more examples...
-            for example in board.iterdir():
-
-                # -- The examples are folders...
-                if example.is_dir():
-
-                    # -- Store the example name
-                    example_str = f"{board.name}/{example.name}"
-                    examples_names.append(example_str)
-
-                    # -- Store the example path
-                    examples.append(example)
-
-        # -- For each example, collect the information in the info file
-        # -- It contains the example description
-        for example, name in zip(examples, examples_names):
-
-            # -- info file
-            info = example / "info"
-
-            # -- Not all the folder has info...
-            if info.exists():
-
-                # -- Open info file
-                with open(info, "r", encoding="utf-8") as info_file:
-
-                    # -- Read info file and remove the new line characters
-                    info_data = info_file.read().replace("\n", "")
-
-                    # -- Print the example name and description!
-                    click.secho(f"{name}", fg="blue", bold=True)
-                    click.secho(f"{info_data}")
-                    click.secho(line)
-
-        # -- Print the total examples
-        click.secho(f"Total: {len(examples)}")
-
-        # -- Print more info about the examples
-        click.secho(USAGE_EXAMPLE, fg="green")
         return 0
 
     def copy_example_dir(self, example: str, project_dir: Path, sayno: bool):

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -134,22 +134,21 @@ class Examples:
             click.echo(terminal_seperator_line)
 
         # -- For a pipe, determine the max example name length.
-        if output_config.pipe_mode():
-            max_example_name_len = max(len(x.name) for x in examples)
+        max_example_name_len = max(len(x.name) for x in examples)
 
         # -- Emit the examples
         for example in examples:
-            if output_config.pipe_mode():
+            if output_config.terminal_mode():
+                # -- For a terminal. Multi lines and colors.
+                click.secho(f"{example.name}", fg="blue", bold=True)
+                click.secho(f"{example.description}")
+                click.secho(terminal_seperator_line)
+            else:
                 # -- For a pipe, single line, no colors.
                 click.secho(
                     f"{example.name:<{max_example_name_len}}  |  "
                     f"{example.description}"
                 )
-            else:
-                # -- For a terminal. Multi lines and colors.
-                click.secho(f"{example.name}", fg="blue", bold=True)
-                click.secho(f"{example.description}")
-                click.secho(terminal_seperator_line)
 
         # -- For a terminal, emit additional summary.
         if output_config.terminal_mode():

--- a/test/commands/test_uninstall.py
+++ b/test/commands/test_uninstall.py
@@ -27,5 +27,5 @@ def test_uninstall(clirunner, configenv, validate_cliresult):
             cmd_uninstall, ["missing_package"], input="y"
         )
         assert result.exit_code == 1, result.output
-        assert "Do you want to continue?" in result.output
+        assert "Do you want to uninstall?" in result.output
         assert "Error: no such package" in result.output

--- a/test/test_complete.py
+++ b/test/test_complete.py
@@ -56,7 +56,7 @@ def test_complete(clirunner, validate_cliresult, configenv, offline):
 
         # -- Execute "apio uninstall examples"
         result = clirunner.invoke(cmd_uninstall, ["examples"], input="y")
-        assert "Do you want to continue?" in result.output
+        assert "Do you want to uninstall?" in result.output
         assert "Error: package 'examples' is not installed" in result.output
 
         # -- Execute "apio install examples@X"
@@ -229,5 +229,5 @@ def test_complete3(clirunner, validate_cliresult, configenv, offline):
         result = clirunner.invoke(cmd_uninstall, ["examples"], input="y")
         validate_cliresult(result)
         assert "Uninstalling examples package" in result.output
-        assert "Do you want to continue?" in result.output
+        assert "Do you want to uninstall?" in result.output
         assert "has been successfully uninstalled!" in result.output


### PR DESCRIPTION
The examples report generated by the ``apio examples -l`` had two issues that were fixed by this PR. 

1. Examples with no 'info' file where excluded from the report (but not from the printed total count).

2. Grepping the report output gave confusing results. For example

```
$ apio examples -l | grep -i leds
Blinking LEDs D0-D5
Blinking LEDs D0-D5
go-board/leds
Hello world example for the Nandland go board. Turning all the leds on

...

kefir/leds
Hello world example for the Kéfir I board. Turning all the leds on
Blinking LEDs D0-D5
Blinking LEDs D0-D5
Blinking LEDs D0-D5
Blinking the RGB LEDs using the SB_RGBA_DRV primitive.
```

This PR introduce a dual mode terminal/pipe where the report is formatted different when the output is piped. Below is an example. When printing to a terminal there is not change in the format. Also, the examples name sorting is now case insensitive.

```
$ apio examples -l | grep -i leds
ColoLight-5A-75E-V71_FT2232H/Ledon      |  Blinking LEDs D0-D5
ColorLight-5A-75B-V8/Ledon              |  Blinking LEDs D0-D5
go-board/leds                           |  Hello world example for the Nandland go board. Turning all the leds on
iCE40-HX1K-EVB/leds                     |  Verilog example for controlling leds with but on iCE40-HX1K-EVB.
iCE40-HX8K-EVB/leds                     |  Verilog example for controlling leds with but on iCE40-HX1K-EVB.
iCE40-HX8K/leds                         |  Hello world example for the iCE40-HX8K board. Turning all the leds on
iCEBreaker/blink                        |  Blink the on board Red and Green LEDs as well as the 5 LEDs found on the default PMOD P2 module.
icestick/leds                           |  Hello world example for the Icestick board. Turning all the leds on
iCESugar_1_5/Blinky                     |  Blink the on board Red, Green and Blue LEDs
icezum/leds                             |  Hello world example for the Icezum board. Turning all the leds on
icoboard/leds                           |  Hello world example for the Icoboard board. Turning all the leds on
kefir/leds                              |  Hello world example for the Kéfir I board. Turning all the leds on
ulx3s-12f/Blinky                        |  Blinking LEDs D0-D5
ulx3s-45f/Blinky                        |  Blinking LEDs D0-D5
ulx3s-85f/Blinky                        |  Blinking LEDs D0-D5
upduino31/blinky                        |  Blinking the RGB LEDs using the SB_RGBA_DRV primitive.
```