### PR TITLE
Restoring  iCE40-HX4K-TQ144 FPGA definitions and adding test coverage report.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ hardware.config
 .DS_Store
 abc.history
 temp-*
+.run.sh

--- a/apio/resources/fpgas.json
+++ b/apio/resources/fpgas.json
@@ -146,8 +146,8 @@
   "iCE40-HX4K-TQ144": {
     "arch": "ice40",
     "type": "hx",
-    "size": "4k",
-    "pack": "tq144"
+    "size": "8k",
+    "pack": "tq144:4k"
   },
   "iCE40-HX4K-BG121": {
     "arch": "ice40",

--- a/tox.ini
+++ b/tox.ini
@@ -70,9 +70,10 @@ commands =
 [testenv]
 deps =
     pytest==8.3.3
+    pytest-cov==5.0.0
 
 commands = 
-    pytest test {posargs}
+    python -m pytest --cov-report html --cov apio test
 
 
 # ----------------------------------------------------


### PR DESCRIPTION
Assorted commits:

1. Restored the old  iCE40-HX4K-TQ144 FPGA definitions to make the 'apio time' command working again with Alhambra II. 

2. The automatic testing now generates also a html coverage report. The report itself is ignored by git.
