### PR TITLE
Changed the oss-cad-suite package definition to load the official FPGAwars release.

### DIFF
--- a/apio/resources/packages.json
+++ b/apio/resources/packages.json
@@ -18,7 +18,7 @@
   "oss-cad-suite": {
     "repository": {
       "name": "tools-oss-cad-suite",
-      "organization": "zapta"
+      "organization": "FPGAwars"
     },
     "release": {
       "tag_name": "v%V",
@@ -26,7 +26,7 @@
       "uncompressed_name": "",
       "folder_name": "tools-oss-cad-suite",
       "extension": "tar.gz",
-      "url_version": "https://github.com/zapta/tools-oss-cad-suite/raw/main/VERSION_DEV"
+      "url_version": "https://github.com/FPGAwars/tools-oss-cad-suite/raw/main/VERSION_DEV"
     },
     "description": "YosysHQ/oss-cad-suite",
     "env": {


### PR DESCRIPTION
After merging this request and updating your pip apio, run this to verify that indeed it's loaded from FPGAwars.

```sh
apio packages --install --verbose --force oss-cad-suite
```