### PR TITLE
Assorted changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,7 +71,7 @@
             "program": "${workspaceFolder}/apio_run.py",
             "args": [
                 "drivers",
-                "--ftdi-enable"
+                "--ftdi-install"
             ],
             "console": "integratedTerminal",
             "justMyCode": false,

--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -27,11 +27,9 @@ COMMAND_GROUPS = {
         "clean",
     ],
     "Verification commands": [
-        "verify",
         "lint",
         "sim",
         "test",
-        "time",
         "report",
         "graph",
     ],
@@ -40,8 +38,6 @@ COMMAND_GROUPS = {
         "modify",
         "packages",
         "drivers",
-        "install",
-        "uninstall",
     ],
     "Utility commands": [
         "boards",
@@ -49,6 +45,12 @@ COMMAND_GROUPS = {
         "raw",
         "system",
         "upgrade",
+    ],
+    "Deprecated commands": [
+        "time",
+        "verify",
+        "install",
+        "uninstall",
     ],
 }
 

--- a/apio/commands/drivers.py
+++ b/apio/commands/drivers.py
@@ -17,35 +17,35 @@ from apio.resources import Resources
 # ---------------------------
 # -- COMMAND SPECIFIC OPTIONS
 # ---------------------------
-frdi_enable_option = click.option(
-    "ftdi_enable",  # Var name.
-    "--ftdi-enable",
+ftdi_install_option = click.option(
+    "ftdi_install",  # Var name.
+    "--ftdi-install",
     is_flag=True,
-    help="Enable FTDI drivers.",
+    help="Install the FTDI driver.",
     cls=cmd_util.ApioOption,
 )
 
-ftdi_disable_option = click.option(
-    "ftdi_disable",  # Var name.
-    "--ftdi-disable",
+ftdi_uninstall_option = click.option(
+    "ftdi_uninstall",  # Var name.
+    "--ftdi-uninstall",
     is_flag=True,
-    help="Disable FTDI drivers.",
+    help="Uninstall the FTDI driver.",
     cls=cmd_util.ApioOption,
 )
 
-serial_enable_option = click.option(
-    "serial_enable",  # Var name.
-    "--serial-enable",
+serial_install_option = click.option(
+    "serial_install",  # Var name.
+    "--serial-install",
     is_flag=True,
-    help="Enable Serial drivers.",
+    help="Install the Serial driver.",
     cls=cmd_util.ApioOption,
 )
 
-serial_disable_option = click.option(
-    "serial_disable",  # Var name.
-    "--serial-disable",
+serial_uninstall_option = click.option(
+    "serial_uninstall",  # Var name.
+    "--serial-uninstall",
     is_flag=True,
-    help="Disable Serial drivers.",
+    help="Uninstall the Serial driver.",
     cls=cmd_util.ApioOption,
 )
 
@@ -61,10 +61,10 @@ and affects all the projects on the local host.
 
 \b
 Examples:
-  apio drivers --ftdi-enable     # Install FTDI driver
-  apio drivers --ftdi-disable    # Uninstall FTDI driver
-  apio drivers --serial-enable   # Install serial driver
-  apio drivers --serial-disable  # Uninstall serial driver
+  apio drivers --ftdi-install      # Install the FTDI driver.
+  apio drivers --ftdi-uninstall    # Uninstall the FTDI driver.
+  apio drivers --serial-install    # Install the serial driver.
+  apio drivers --serial-uninstall  # Uninstall the serial driver.
 
   Do not specify more than flag per command invocation.
 """
@@ -77,47 +77,48 @@ Examples:
     cls=cmd_util.ApioCommand,
 )
 @click.pass_context
-@frdi_enable_option
-@ftdi_disable_option
-@serial_enable_option
-@serial_disable_option
+@ftdi_install_option
+@ftdi_uninstall_option
+@serial_install_option
+@serial_uninstall_option
 def cli(
     ctx: Context,
     # Options:
-    ftdi_enable: bool,
-    ftdi_disable: bool,
-    serial_enable: bool,
-    serial_disable: bool,
+    ftdi_install: bool,
+    ftdi_uninstall: bool,
+    serial_install: bool,
+    serial_uninstall: bool,
 ):
     """Implements the drivers command."""
 
     # Make sure these params are exclusive.
     cmd_util.check_at_most_one_param(
-        ctx, nameof(ftdi_enable, ftdi_disable, serial_enable, serial_disable)
+        ctx,
+        nameof(ftdi_install, ftdi_uninstall, serial_install, serial_uninstall),
     )
 
     # -- Access to the Drivers
     resources = Resources(project_scope=False)
     drivers = Drivers(resources)
 
-    # -- FTDI enable option
-    if ftdi_enable:
-        exit_code = drivers.ftdi_enable()
+    # -- FTDI install option
+    if ftdi_install:
+        exit_code = drivers.ftdi_install()
         ctx.exit(exit_code)
 
-    # -- FTDI disable option
-    if ftdi_disable:
-        exit_code = drivers.ftdi_disable()
+    # -- FTDI uninstall option
+    if ftdi_uninstall:
+        exit_code = drivers.ftdi_uninstall()
         ctx.exit(exit_code)
 
-    # -- Serial enable option
-    if serial_enable:
-        exit_code = drivers.serial_enable()
+    # -- Serial install option
+    if serial_install:
+        exit_code = drivers.serial_install()
         ctx.exit(exit_code)
 
-    # -- Serial disable option
-    if serial_disable:
-        exit_code = drivers.serial_disable()
+    # -- Serial uninstall option
+    if serial_uninstall:
+        exit_code = drivers.serial_uninstall()
         ctx.exit(exit_code)
 
     # -- No options. Show the help

--- a/apio/commands/install.py
+++ b/apio/commands/install.py
@@ -51,8 +51,8 @@ def install_packages(
 # -- COMMAND
 # ---------------------------
 HELP = """
-The install command has been deprecated. Please use the 'apio packages' command
-instead.
+The command 'apio install' has been deprecated. Please use the command
+'apio packages' command instead.
 """
 
 

--- a/apio/commands/time.py
+++ b/apio/commands/time.py
@@ -20,8 +20,8 @@ from apio.resources import Resources
 # -- COMMAND
 # ---------------------------
 HELP = """
-The time command has been deprecated. Please use the 'apio report' command
-instead.
+The command 'apio time' has been deprecated. Please use the command
+'apio report' instead.
 """
 
 

--- a/apio/commands/uninstall.py
+++ b/apio/commands/uninstall.py
@@ -50,8 +50,8 @@ def _uninstall(
 # -- COMMAND
 # ---------------------------
 HELP = """
-The uninstall command has been deprecated. Please use the 'apio packages'
-command instead.
+The command 'apio uninstall' has been deprecated. Please use the
+command 'apio packages' instead.
 """
 
 

--- a/apio/commands/verify.py
+++ b/apio/commands/verify.py
@@ -21,23 +21,14 @@ from apio.resources import Resources
 # ---------------------------
 
 HELP = """
-The verify command performs a shallow verification of the verilog code
-it finds without requiring a top module or a constraint file.
-Is useful mainly in early stages of the project, before the
-strictier build and lint commands can be used.
-The verify commands is typically used in the root directory
-of the project that contains the apio.ini file.
-
-\b
-Examples:
-  apio verify
-
+The command 'apio verify' has been deprecated. Please use the command
+'apio lint' instead.
 """
 
 
 @click.command(
     "verify",
-    short_help="Verify the verilog code.",
+    short_help="[Depreciated] Verify the verilog code.",
     help=HELP,
     cls=cmd_util.ApioCommand,
 )

--- a/apio/managers/drivers.py
+++ b/apio/managers/drivers.py
@@ -15,7 +15,7 @@ from apio import util
 from apio import pkg_util
 from apio.resources import Resources
 
-FTDI_ENABLE_INSTRUCTIONS_WINDOWS = """
+FTDI_INSTALL_INSTRUCTIONS_WINDOWS = """
 Please follow these steps:
 
   1. Make sure your FPGA board is connected to the computer.
@@ -45,7 +45,7 @@ Please follow these steps:
      your board is listed.
 """
 
-FTDI_DISABLE_INSTRUCTIONS_WINDOWS = """
+FTDI_UNINSTALL_INSTRUCTIONS_WINDOWS = """
 Please follow these steps:
 
   1. Make sure your FPGA board is NOT connected to the computer.
@@ -61,7 +61,7 @@ Please follow these steps:
      section).
 
      NOTE: If your board does not show up or if it's listed as a
-     COM port, it may not have the FTDI driver enabled for it.
+     COM port, it may not have the FTDI driver installed for it.
 
   6. Right click on your board entry and select 'Uninstall device'.
 
@@ -73,7 +73,7 @@ Please follow these steps:
   9. Close the Device Manager window.
 """
 
-SERIAL_ENABLE_INSTRUCTIONS_WINDOWS = """
+SERIAL_INSTALL_INSTRUCTIONS_WINDOWS = """
 Please follow these steps:
 
   1. Make sure your FPGA board is connected to the computer.
@@ -86,7 +86,7 @@ Please follow these steps:
       'apio system --lsserial'.
 """
 
-SERIAL_DISABLE_INSTRUCTIONS_WINDOWS = """
+SERIAL_UNINSTALL_INSTRUCTIONS_WINDOWS = """
 Please follow these steps:
 
   1. Make sure your FPGA board is NOT connected to the computer.
@@ -101,7 +101,7 @@ Please follow these steps:
   5. Identify the entry of your board (typically in the Ports section).
 
      NOTE: If your board does not show up as a COM port, it may not
-     have the 'apio drivers --serial-enable' applied to it.
+     have the 'apio drivers --serial-install' applied to it.
 
   6. Right click on your board entry and select 'Uninstall device'.
 
@@ -138,68 +138,68 @@ class Drivers:
 
         self.resources = resources
 
-    def ftdi_enable(self) -> int:
-        """Enables the FTDI driver. Function is platform dependent.
+    def ftdi_install(self) -> int:
+        """Installs the FTDI driver. Function is platform dependent.
         Returns a process exit code.
         """
 
         if util.is_linux():
-            return self._ftdi_enable_linux()
+            return self._ftdi_install_linux()
 
         if util.is_darwin():
-            return self._ftdi_enable_darwin()
+            return self._ftdi_install_darwin()
 
         if util.is_windows():
-            return self._ftdi_enable_windows()
+            return self._ftdi_install_windows()
 
         click.secho(f"Error: unknown platform '{util.get_system_type()}'.")
         return 1
 
-    def ftdi_disable(self) -> int:
-        """Disables the FTDI driver. Function is platform dependent.
+    def ftdi_uninstall(self) -> int:
+        """Uninstalls the FTDI driver. Function is platform dependent.
         Returns a process exit code.
         """
         if util.is_linux():
-            return self._ftdi_disable_linux()
+            return self._ftdi_uninstall_linux()
 
         if util.is_darwin():
-            return self._ftdi_disable_darwin()
+            return self._ftdi_uninstall_darwin()
 
         if util.is_windows():
-            return self._ftdi_disable_windows()
+            return self._ftdi_uninstall_windows()
 
         click.secho(f"Error: unknown platform '{util.get_system_type()}'.")
         return 1
 
-    def serial_enable(self) -> int:
-        """Enables the serial driver. Function is platform dependent.
+    def serial_install(self) -> int:
+        """Installs the serial driver. Function is platform dependent.
         Returns a process exit code.
         """
 
         if util.is_linux():
-            return self._serial_enable_linux()
+            return self._serial_install_linux()
 
         if util.is_darwin():
-            return self._serial_enable_darwin()
+            return self._serial_install_darwin()
 
         if util.is_windows():
-            return self._serial_enable_windows()
+            return self._serial_install_windows()
 
         click.secho(f"Error: unknown platform '{util.get_system_type()}'.")
         return 1
 
-    def serial_disable(self) -> int:
-        """Disables the serial driver. Function is platform dependent.
+    def serial_uninstall(self) -> int:
+        """Uninstalls the serial driver. Function is platform dependent.
         Returns a process exit code.
         """
         if util.is_linux():
-            return self._serial_disable_linux()
+            return self._serial_uninstall_linux()
 
         if util.is_darwin():
-            return self._serial_disable_darwin()
+            return self._serial_uninstall_darwin()
 
         if util.is_windows():
-            return self._serial_disable_windows()
+            return self._serial_uninstall_windows()
 
         click.secho(f"Error: unknown platform '{util.get_system_type()}'.")
         return 1
@@ -218,8 +218,8 @@ class Drivers:
         if util.is_darwin():
             self._post_upload_darwin()
 
-    def _ftdi_enable_linux(self) -> int:
-        """Drivers enable on Linux. It copies the .rules file into
+    def _ftdi_install_linux(self) -> int:
+        """Drivers install on Linux. It copies the .rules file into
         the corresponding folder. Return process exit code."""
 
         click.secho("Configure FTDI drivers for FPGA")
@@ -241,15 +241,15 @@ class Drivers:
             # -- Execute the commands for reloading the udev system
             self._reload_rules_linux()
 
-            click.secho("FTDI drivers enabled", fg="green")
+            click.secho("FTDI drivers installed", fg="green")
             click.secho("Unplug and reconnect your board", fg="yellow")
         else:
-            click.secho("Already enabled", fg="yellow")
+            click.secho("Already installed", fg="yellow")
 
         return 0
 
-    def _ftdi_disable_linux(self):
-        """Disable the FTDI drivers on linux. Returns process exist code."""
+    def _ftdi_uninstall_linux(self):
+        """Uninstall the FTDI drivers on linux. Returns process exist code."""
 
         # -- For disabling the FTDI driver the .rules files should be
         # -- removed from the /etc/udev/rules.d/ folder
@@ -264,15 +264,15 @@ class Drivers:
             # -- # -- Execute the commands for reloading the udev system
             self._reload_rules_linux()
 
-            click.secho("FTDI drivers disabled", fg="green")
+            click.secho("FTDI drivers uninstalled", fg="green")
             click.secho("Unplug and reconnect your board", fg="yellow")
         else:
-            click.secho("Already disabled", fg="yellow")
+            click.secho("Already uninstalled", fg="yellow")
 
         return 0
 
-    def _serial_enable_linux(self):
-        """Serial drivers enable on Linux. Returns process exit code."""
+    def _serial_install_linux(self):
+        """Serial drivers install on Linux. Returns process exit code."""
 
         click.secho("Configure Serial drivers for FPGA")
 
@@ -296,20 +296,20 @@ class Drivers:
             # -- Execute the commands for reloading the udev system
             self._reload_rules_linux()
 
-            click.secho("Serial drivers enabled", fg="green")
+            click.secho("Serial drivers installed", fg="green")
             click.secho("Unplug and reconnect your board", fg="yellow")
             if group_added:
                 click.secho(
-                    "Restart your machine to enable the dialout group",
+                    "Restart your machine to install the dialout group",
                     fg="yellow",
                 )
         else:
-            click.secho("Already enabled", fg="yellow")
+            click.secho("Already installed", fg="yellow")
 
         return 0
 
-    def _serial_disable_linux(self) -> int:
-        """Disable the serial driver on Linux. Return process exit code."""
+    def _serial_uninstall_linux(self) -> int:
+        """Uninstall the serial driver on Linux. Return process exit code."""
 
         # -- For disabling the serial driver the corresponding .rules file
         # -- should be removed, it it exists
@@ -321,10 +321,10 @@ class Drivers:
 
             # -- Execute the commands for reloading the udev system
             self._reload_rules_linux()
-            click.secho("Serial drivers disabled", fg="green")
+            click.secho("Serial drivers uninstalled", fg="green")
             click.secho("Unplug and reconnect your board", fg="yellow")
         else:
-            click.secho("Already disabled", fg="yellow")
+            click.secho("Already uninstalled", fg="yellow")
 
         return 0
 
@@ -352,51 +352,51 @@ class Drivers:
             return True
         return None
 
-    def _ftdi_enable_darwin(self) -> int:
-        """Enables FTDI driver on darwin. Returns process status code."""
+    def _ftdi_install_darwin(self) -> int:
+        """Installs FTDI driver on darwin. Returns process status code."""
         # Check homebrew
         brew = subprocess.call("which brew > /dev/null", shell=True)
         if brew != 0:
             click.secho("Error: homebrew is required", fg="red")
             return 1
 
-        click.secho("Enable FTDI drivers for FPGA")
+        click.secho("Install FTDI drivers for FPGA")
         subprocess.call(["brew", "update"])
         self._brew_install_darwin("libffi")
         self._brew_install_darwin("libftdi")
         self.resources.profile.add_setting("macos_ftdi_drivers", True)
         self.resources.profile.save()
-        click.secho("FTDI drivers enabled", fg="green")
+        click.secho("FTDI drivers installed", fg="green")
         return 0
 
-    def _ftdi_disable_darwin(self):
-        """Disables FTDI driver on darwin. Returns process status code."""
-        click.secho("Disable FTDI drivers configuration")
+    def _ftdi_uninstall_darwin(self):
+        """Uninstalls FTDI driver on darwin. Returns process status code."""
+        click.secho("Uninstall FTDI drivers configuration")
         self.resources.profile.add_setting("macos_ftdi_drivers", False)
         self.resources.profile.save()
-        click.secho("FTDI drivers disabled", fg="green")
+        click.secho("FTDI drivers uninstalled", fg="green")
         return 0
 
-    def _serial_enable_darwin(self):
-        """Enables serial driver on darwin. Returns process status code."""
+    def _serial_install_darwin(self):
+        """Installs serial driver on darwin. Returns process status code."""
         # Check homebrew
         brew = subprocess.call("which brew > /dev/null", shell=True)
         if brew != 0:
             click.secho("Error: homebrew is required", fg="red")
             return 1
 
-        click.secho("Enable Serial drivers for FPGA")
+        click.secho("Install Serial drivers for FPGA")
         subprocess.call(["brew", "update"])
         self._brew_install_darwin("libffi")
         self._brew_install_darwin("libusb")
         # self._brew_install_serial_drivers_darwin()
-        click.secho("Serial drivers enabled", fg="green")
+        click.secho("Serial drivers installed", fg="green")
         return 0
 
-    def _serial_disable_darwin(self):
-        """Disables serial driver on darwin. Returns process status code."""
-        click.secho("Disable Serial drivers configuration")
-        click.secho("Serial drivers disabled", fg="green")
+    def _serial_uninstall_darwin(self):
+        """Uninstalls serial driver on darwin. Returns process status code."""
+        click.secho("Uninstall Serial drivers configuration")
+        click.secho("Serial drivers uninstalled", fg="green")
         return 0
 
     def _brew_install_darwin(self, brew_package):
@@ -440,7 +440,7 @@ class Drivers:
 
     # W0703: Catching too general exception Exception (broad-except)
     # pylint: disable=W0703
-    def _ftdi_enable_windows(self) -> int:
+    def _ftdi_install_windows(self) -> int:
         # -- Check that the required packages are installed.
         pkg_util.check_required_packages(["drivers"], self.resources)
 
@@ -463,7 +463,7 @@ class Drivers:
         click.secho(
             "\nStarting the interactive config tool zadig.exe.", fg="green"
         )
-        click.secho(FTDI_ENABLE_INSTRUCTIONS_WINDOWS, fg="yellow")
+        click.secho(FTDI_INSTALL_INSTRUCTIONS_WINDOWS, fg="yellow")
 
         # -- Execute zadig!
         # -- We execute it using os.system() rather than by
@@ -479,12 +479,12 @@ class Drivers:
 
         return exit_code
 
-    def _ftdi_disable_windows(self) -> int:
+    def _ftdi_uninstall_windows(self) -> int:
         # -- Check that the required packages exist.
         pkg_util.check_required_packages(["drivers"], self.resources)
 
         click.secho("\nStarting the interactive Device Manager.", fg="green")
-        click.secho(FTDI_DISABLE_INSTRUCTIONS_WINDOWS, fg="yellow")
+        click.secho(FTDI_UNINSTALL_INSTRUCTIONS_WINDOWS, fg="yellow")
 
         # -- We launch the device manager using os.system() rather than with
         # -- util.exec_command() because util.exec_command() does not support
@@ -494,7 +494,7 @@ class Drivers:
 
     # W0703: Catching too general exception Exception (broad-except)
     # pylint: disable=W0703
-    def _serial_enable_windows(self) -> int:
+    def _serial_install_windows(self) -> int:
         # -- Check that the required packages exist.
         pkg_util.check_required_packages(["drivers"], self.resources)
 
@@ -502,7 +502,7 @@ class Drivers:
         drivers_bin_dir = drivers_base_dir / "bin"
 
         click.secho("\nStarting the interactive Serial Installer.", fg="green")
-        click.secho(SERIAL_ENABLE_INSTRUCTIONS_WINDOWS, fg="yellow")
+        click.secho(SERIAL_INSTALL_INSTRUCTIONS_WINDOWS, fg="yellow")
 
         # -- We launch the device manager using os.system() rather than with
         # -- util.exec_command() because util.exec_command() does not support
@@ -513,12 +513,12 @@ class Drivers:
 
         return exit_code
 
-    def _serial_disable_windows(self) -> int:
+    def _serial_uninstall_windows(self) -> int:
         # -- Check that the required packages exist.
         pkg_util.check_required_packages(["drivers"], self.resources)
 
         click.secho("\nStarting the interactive Device Manager.", fg="green")
-        click.secho(SERIAL_DISABLE_INSTRUCTIONS_WINDOWS, fg="yellow")
+        click.secho(SERIAL_UNINSTALL_INSTRUCTIONS_WINDOWS, fg="yellow")
 
         # -- We launch the device manager using os.system() rather than with
         # -- util.exec_command() because util.exec_command() does not support

--- a/apio/managers/system.py
+++ b/apio/managers/system.py
@@ -35,8 +35,8 @@ class System:  # pragma: no cover
             click.secho(
                 "\n"
                 "Hint:\n"
-                "  The FTDI driver may not be enabled yet.\n"
-                "  Try running the command 'apio drivers --ftdi-enable'",
+                "The FTDI driver may not be enabled yet.\n"
+                "Try running the command 'apio drivers --ftdi-install'",
                 fg="yellow",
             )
             sys.exit(1)

--- a/apio/resources/distribution.json
+++ b/apio/resources/distribution.json
@@ -1,5 +1,6 @@
 {
   "packages": {
+    "system": ">=1.1.2",
     "drivers": ">=1.1.0",
     "examples": ">=0.0.7",
     "graphviz": ">=12.1.2",

--- a/apio/resources/packages.json
+++ b/apio/resources/packages.json
@@ -92,5 +92,30 @@
         "%p/bin"
       ]
     }
+  },
+  "system": {
+    "repository": {
+      "name": "tools-system",
+      "organization": "FPGAwars"
+    },
+    "release": {
+      "tag_name": "v%V",
+      "compressed_name": "tools-system-%P-%V",
+      "uncompressed_name": "",
+      "folder_name": "tools-system",
+      "extension": "tar.gz",
+      "url_version": "https://github.com/FPGAwars/tools-system/raw/master/VERSION",
+      "available_platforms": [
+        "windows",
+        "windows_x86",
+        "windows_amd64"
+      ]
+    },
+    "description": "System tools",
+    "env": {
+      "path": [
+        "%p/bin"
+      ]
+    }
   }
 }


### PR DESCRIPTION
1. In ``apio drivers`` renamed options names from enable/disable to install/uninstall.

2. In ``apio -h``, created a ``Deprecated commands`` group with the commands ``time``, ``verify``, ``install``, ``uninstall``.  These commands are planned to be removed once we confirm that icestudio doesn't depend on them. The functionality of the commands was not changed.

3. Added to apio package definitions the tools-system package to have ftdi_eeprom for manufacturing and other purposes. The goal is to decouple ftdi_eeprom from the tools-oss-cad-suite package. The new package is currently enabled for windows  others platforms will be added as needed. Below is a log that demonstrate executing ftdi_eeprom on windows from the new package.

```
~/projects/apio_dev/repo$ apio packages --list

═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Installed packages:
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
• examples 0.0.36
  Verilog examples
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
• oss-cad-suite 0.2.0
  YosysHQ/oss-cad-suite
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
• graphviz 12.1.2
  Graphviz tool for Windows
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
• drivers 1.2.0
  Drivers tools for Windows
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
• system 1.1.2
  System tools
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Total: 5


~/projects/apio_dev/repo$ rm ~/.apio/packages/tools-oss-cad-suite/bin/ftdi_eeprom.exe
~/projects/apio_dev/repo$
~/projects/apio_dev/repo$ apio raw ftdi_eeprom
Setting the envinronment.

FTDI eeprom generator v0.17
(c) Intra2net AG and the libftdi developers <opensource@intra2net.com>
Syntax: ftdi_eeprom [...options...] <config-file>
Valid Options:
--device <description>  Specify device to open by description string. One of:
         d:<devicenode>
         i:<vendor>:<product>
         i:<vendor>:<product>:<index>
         s:<vendor>:<product>:<serial>
--read-eeprom           Read eeprom and write to -filename- from config-file
--build-eeprom          Build eeprom image
--erase-eeprom          Erase eeprom
--flash-eeprom          Flash eeprom
~/projects/apio_dev/repo$

```

