### PR TITLE
Added handling of broken package installations.

### DIFF
--- a/apio/commands/packages.py
+++ b/apio/commands/packages.py
@@ -105,11 +105,12 @@ def _list(resources: Resources, verbose: bool) -> int:
     # -- Print an hint or summary based on the findings.
     if scan.num_errors():
         click.secho(
-            "[Hint] run 'apio packages -c' to fix the errors.", fg="yellow"
+            "[Hint] run 'apio packages -fix' to fix the errors.", fg="yellow"
         )
     elif scan.uninstalled_package_ids:
         click.secho(
-            "[Hint] run 'apio packages -i' to install all available packages.",
+            "[Hint] run 'apio packages -install' to install all "
+            "available packages.",
             fg="yellow",
         )
     else:

--- a/apio/pkg_util.py
+++ b/apio/pkg_util.py
@@ -344,9 +344,10 @@ def scan_packages(resources: Resources) -> PackageScanResults:
 def _list_section(title: str, items: List[List[str]], color: str) -> None:
     """A helper function for printing one serction of list_packages()."""
     # -- Construct horizontal lines at terminal width.
-    output_config = util.get_terminal_config()
-    line = "─" * output_config.terminal_width
-    dline = "═" * output_config.terminal_width
+    config = util.get_terminal_config()
+    line_width = config.terminal_width if config.terminal_mode() else 80
+    line = "─" * line_width
+    dline = "═" * line_width
 
     # -- Print the section.
     click.secho()

--- a/apio/util.py
+++ b/apio/util.py
@@ -15,7 +15,7 @@ import json
 import shutil
 from enum import Enum
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Any
 import subprocess
 from threading import Thread
 from pathlib import Path
@@ -601,3 +601,21 @@ def safe_click(text, *args, **kwargs):
         # most common character error
         cleaned_text = "".join([ch if ord(ch) < 128 else "=" for ch in text])
         click.secho(cleaned_text, err=error_flag, *args, **kwargs)
+
+
+def count(obj: Any, singular: str, plural: str = None) -> str:
+    """Returns singular or plural based on the size of the object."""
+    # -- Figure out the size of the object
+    if isinstance(obj, int):
+        n = obj
+    else:
+        n = len(obj)
+
+    # -- For value of 1 return the signgular form.
+    if n == 1:
+        return f"{n} {singular}"
+
+    # -- For all other values, return the plural form.
+    if plural is None:
+        plural = singular + "s"
+    return f"{n} {plural}"

--- a/test/commands/test_packages.py
+++ b/test/commands/test_packages.py
@@ -6,7 +6,7 @@
 from apio.commands.packages import cli as cmd_packages
 
 
-def test_packages(clirunner, configenv, validate_cliresult):
+def test_packages(clirunner, configenv):
     """Test "apio packages" with different parameters"""
 
     with clirunner.isolated_filesystem():
@@ -18,13 +18,14 @@ def test_packages(clirunner, configenv, validate_cliresult):
         result = clirunner.invoke(cmd_packages)
         assert result.exit_code == 1, result.output
         assert (
-            "One of [--list, --install, --uninstall] "
+            "One of [--list, --install, --uninstall, --fix] "
             "must be specified" in result.output
         )
 
         # -- Execute "apio packages --list"
         result = clirunner.invoke(cmd_packages, ["--list"])
-        validate_cliresult(result)
+        assert result.exit_code == 0, result.output
+        assert "No errors" in result.output
 
         # -- Execute "apio packages --install missing_package"
         result = clirunner.invoke(

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -107,7 +107,8 @@ def test_end_to_end1(clirunner, validate_cliresult, configenv, offline):
 
         # -- Execute "apio packages --install --list"
         result = clirunner.invoke(cmd_packages, ["--list"])
-        validate_cliresult(result)
+        assert result.exit_code == 0, result.output
+        assert "No errors" in result.output
         assert "Installed packages:" in result.output
         assert "examples" in result.output
 
@@ -244,7 +245,7 @@ def test_end_to_end3(clirunner, validate_cliresult, configenv, offline):
         result = clirunner.invoke(
             cmd_packages, ["--uninstall", "examples"], input="n"
         )
-        validate_cliresult(result)
+        assert result.exit_code != 0, result.output
         assert "User said no" in result.output
 
         # -- Execute "apio packages --uninstall examples"


### PR DESCRIPTION
Added detection, reporting, and fixing of broken package installation.  The command ``apio packages --list`` now reports also package errors, and the command ``apio packages --fix`` fixes them.

There are 3 categories of package error
1. A package is registered in profile but has no directory, or vice versa.
2. An unknown package is listed in profile.
3. An unknown dir or file in exists in the packages dir.

This change doesn't change the behavior of the deprecated command ``apio install --list``.

Example:
<img width="471" alt="image" src="https://github.com/user-attachments/assets/01099bdd-4b5b-4bcb-823a-ed19fa2a75dc">


