### PR TITLE
Adapting to the new examples package.

### DIFF
--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -9,7 +9,7 @@
 import shutil
 from pathlib import Path, PosixPath
 from dataclasses import dataclass
-from typing import Optional, Tuple, List
+from typing import Optional, List
 import click
 from apio import util
 from apio import pkg_util
@@ -49,7 +49,7 @@ class Examples:
         self.apio_ctx = apio_ctx
 
         # -- Folder where the example packages was installed
-        self.examples_dir = apio_ctx.get_package_dir("examples")
+        self.examples_dir = apio_ctx.get_package_dir("examples") / "examples"
 
     def get_examples_infos(self) -> Optional[List[ExampleInfo]]:
         """Scans the examples and returns a list of ExampleInfos.
@@ -66,7 +66,7 @@ class Examples:
                 boards_dirs.append(board_dir)
 
         # -- Collect the examples of each boards.
-        examples: List[Tuple[str, PosixPath]] = []
+        examples: List[ExampleInfo] = []
         for board_dir in boards_dirs:
 
             # -- Iterate board's example subdirectories.

--- a/apio/resources/packages.json
+++ b/apio/resources/packages.json
@@ -2,7 +2,7 @@
   "examples": {
     "repository": {
       "name": "apio-examples",
-      "organization": "zapta"
+      "organization": "FPGAwars"
     },
     "release": {
       "tag_name": "%V",
@@ -10,7 +10,7 @@
       "uncompressed_name": "apio-examples-%V",
       "folder_name": "examples",
       "extension": "zip",
-      "url_version": "https://github.com/zapta/apio-examples/raw/master/VERSION"
+      "url_version": "https://github.com/FPGAwars/apio-examples/raw/master/VERSION"
     },
     "description": "Verilog examples",
     "env": {}

--- a/test/integration/test_examples.py
+++ b/test/integration/test_examples.py
@@ -31,20 +31,21 @@ def test_examples(apio_runner: ApioRunner):
         # -- Install the examples package.
         result = sb.invoke_apio_cmd(apio_packages, ["--install", "examples"])
         sb.assert_ok(result)
-        # assert "Installing package 'examples'" in result.output
-        # assert "Download" in result.output
         assert "Package 'examples' installed successfully" in result.output
-        assert getsize(sb.packages_dir / "examples/alhambra-ii/ledon/ledon.v")
+        assert getsize(
+            sb.packages_dir / "examples/examples/alhambra-ii/ledon/ledon.v"
+        )
 
-        # -- List the examples
+        # -- 'apio examples --list'
         result = sb.invoke_apio_cmd(
             apio_examples,
             ["--list"],
         )
         sb.assert_ok(result)
         assert "alhambra-ii/ledon" in result.output
+        assert "Hello world for the Alhambra-II board" in result.output
 
-        # -- Fetch example files to current directory
+        # -- 'apio examples --fetch-files alhambra-ii/ledon'
         result = sb.invoke_apio_cmd(
             apio_examples,
             ["--fetch-files", "alhambra-ii/ledon"],
@@ -54,7 +55,7 @@ def test_examples(apio_runner: ApioRunner):
         assert "have been successfully created!" in result.output
         assert getsize("ledon.v")
 
-        # -- Fetch example dir to current directory
+        # -- 'apio examples --fetch-dir alhambra-ii/ledon'
         result = sb.invoke_apio_cmd(
             apio_examples,
             ["--fetch-dir", "alhambra-ii/ledon"],
@@ -64,20 +65,20 @@ def test_examples(apio_runner: ApioRunner):
         assert "has been successfully created" in result.output
         assert getsize("alhambra-ii/ledon/ledon.v")
 
-        # -- Fetch example files to another project dir
+        # -- 'apio examples --fetch-files" alhambra-ii/ledon -p dir1'
         result = sb.invoke_apio_cmd(
             apio_examples,
-            ["--fetch-files", "alhambra-ii/ledon", "--project-dir=./dir1"],
+            ["--fetch-files", "alhambra-ii/ledon", "-p", "dir1"],
         )
         sb.assert_ok(result)
         assert "Copying alhambra-ii/ledon example files" in result.output
         assert "have been successfully created!" in result.output
         assert getsize("dir1/ledon.v")
 
-        # -- Fetch example dir to another project dir
+        # -- 'apio examples --fetch-dir alhambra-ii/ledon -p dir2
         result = sb.invoke_apio_cmd(
             apio_examples,
-            ["--fetch-dir", "alhambra-ii/ledon", "--project-dir=dir2"],
+            ["--fetch-dir", "alhambra-ii/ledon", "-p", "dir2"],
         )
         sb.assert_ok(result)
         assert "Creating alhambra-ii/ledon directory" in result.output

--- a/test/integration/test_packages.py
+++ b/test/integration/test_packages.py
@@ -43,7 +43,7 @@ def test_packages(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio_packages, ["--install", "examples"])
         sb.assert_ok(result)
         assert "Package 'examples' installed successfully" in result.output
-        assert listdir(sb.packages_dir / "examples/alhambra-ii")
+        assert listdir(sb.packages_dir / "examples/examples/alhambra-ii")
         assert "tools-oss-cad-suite" not in listdir(sb.packages_dir)
 
         # -- Install the reset of the packages.
@@ -55,12 +55,14 @@ def test_packages(apio_runner: ApioRunner):
         assert (
             "Package 'oss-cad-suite' installed successfully" in result.output
         )
-        assert listdir(sb.packages_dir / "examples/alhambra-ii")
+        assert listdir(sb.packages_dir / "examples/examples/alhambra-ii")
         assert listdir(sb.packages_dir / "tools-oss-cad-suite/bin")
 
         # -- Delete a file from the examples package, we will use it as an
         # -- indicator for the reinstallation of the package.
-        marker_file = sb.packages_dir / "examples/alhambra-ii/ledon/ledon.v"
+        marker_file = (
+            sb.packages_dir / "examples/examples/alhambra-ii/ledon/ledon.v"
+        )
         assert marker_file.is_file()
         marker_file.unlink()
         assert not marker_file.exists()


### PR DESCRIPTION
1. Redirecting the package back to FPGAWars (was zapta).

2. Adapting the examples command and test to the new packages structure (added a wrapper 'examples' directory).