### PR TITLE
Pointing the dev apio dev examples package to VERSION_DEV

### DIFF
--- a/apio/resources/distribution.json
+++ b/apio/resources/distribution.json
@@ -4,7 +4,7 @@
     "drivers": ">=1.1.0",
     "examples": ">=0.0.7",
     "graphviz": ">=12.1.2",
-    "oss-cad-suite": ">=0.2.0"
+    "oss-cad-suite": ">=0.2.1"
   },
   "pip_packages": {
     "blackiceprog": ">=2.0.0,<3.0.0",

--- a/apio/resources/packages.json
+++ b/apio/resources/packages.json
@@ -10,7 +10,7 @@
       "uncompressed_name": "apio-examples-%V",
       "folder_name": "examples",
       "extension": "zip",
-      "url_version": "https://github.com/FPGAwars/apio-examples/raw/master/VERSION"
+      "url_version": "https://github.com/FPGAwars/apio-examples/raw/master/VERSION_DEV"
     },
     "description": "Verilog examples",
     "env": {}

--- a/apio/resources/packages.json
+++ b/apio/resources/packages.json
@@ -10,9 +10,9 @@
       "uncompressed_name": "apio-examples-%V",
       "folder_name": "examples",
       "extension": "zip",
-      "url_version": "https://github.com/FPGAwars/apio-examples/raw/master/VERSION_DEV"
+      "url_version": "https://github.com/FPGAwars/apio-examples/raw/master/VERSION"
     },
-    "description": "Verilog examples",
+    "description": "Apio's project examples",
     "env": {}
   },
   "oss-cad-suite": {
@@ -28,7 +28,7 @@
       "extension": "tar.gz",
       "url_version": "https://github.com/FPGAwars/tools-oss-cad-suite/raw/main/VERSION_DEV"
     },
-    "description": "YosysHQ/oss-cad-suite",
+    "description": "YosysHQ's oss-cad-suite",
     "env": {
       "path": [
         "%p/bin",
@@ -60,6 +60,26 @@
       ]
     },
     "description": "Graphviz tool for Windows",
+    "env": {
+      "path": [
+        "%p/bin"
+      ]
+    }
+  },
+  "verible": {
+    "repository": {
+      "name": "tools-verible",
+      "organization": "FPGAwars"
+    },
+    "release": {
+      "tag_name": "v%V",
+      "compressed_name": "tools-verible-%P-%V",
+      "uncompressed_name": "",
+      "folder_name": "tools-verible",
+      "extension": "tar.gz",
+      "url_version": "https://github.com/FPGAwars/tools-verible/raw/main/VERSION_DEV"
+    },
+    "description": "Chips Aliance's Verible toolset",
     "env": {
       "path": [
         "%p/bin"


### PR DESCRIPTION
**IMPORTANT:  should be submitted shortly after https://github.com/FPGAwars/apio-examples/pull/32 and the creation of apio-examples 0.1.12.**

This PR redirects the examples packages of apio-dev to the new VERSION_DEV file.

Edit: also added a definition for the new tools-verible package.