### PR TITLE
Fixed the 'apio lint' error on windows. 

### DIFF
--- a/apio/scons/ecp5/SConstruct
+++ b/apio/scons/ecp5/SConstruct
@@ -70,6 +70,7 @@ from apio.scons.scons_util import (
     get_report_action,
     set_up_cleanup,
     get_source_file_issue_action,
+    vlt_path,
 )
 
 # # -- Uncomment for debugging of the scons subprocess using a remote debugger.
@@ -341,12 +342,12 @@ verilator_config_builder = make_verilator_config_builder(
     env,
     (
         "`verilator_config\n"
-        f'lint_off -rule COMBDLY      -file "{YOSYS_LIB_DIR}/*"\n'
-        f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_LIB_DIR}/*"\n'
-        f'lint_off -rule PINMISSING   -file "{YOSYS_LIB_DIR}/*"\n'
-        f'lint_off -rule ASSIGNIN     -file "{YOSYS_LIB_DIR}/*"\n'
-        f'lint_off -rule WIDTHTRUNC   -file "{YOSYS_LIB_DIR}/*"\n'
-        f'lint_off -rule INITIALDLY   -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule COMBDLY      -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
+        f'lint_off -rule WIDTHEXPAND  -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
+        f'lint_off -rule PINMISSING   -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
+        f'lint_off -rule ASSIGNIN     -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
+        f'lint_off -rule WIDTHTRUNC   -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
+        f'lint_off -rule INITIALDLY   -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
     ),
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})

--- a/apio/scons/gowin/SConstruct
+++ b/apio/scons/gowin/SConstruct
@@ -69,6 +69,7 @@ from apio.scons.scons_util import (
     get_report_action,
     set_up_cleanup,
     get_source_file_issue_action,
+    vlt_path,
 )
 
 # # -- Uncomment for debugging of the scons subprocess using a remote debugger.
@@ -334,8 +335,8 @@ verilator_config_builder = make_verilator_config_builder(
     env,
     (
         "`verilator_config\n"
-        f'lint_off -rule COMBDLY      -file "{YOSYS_LIB_DIR}/*"\n'
-        f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule COMBDLY      -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
+        f'lint_off -rule WIDTHEXPAND  -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
     ),
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})

--- a/apio/scons/ice40/SConstruct
+++ b/apio/scons/ice40/SConstruct
@@ -69,6 +69,7 @@ from apio.scons.scons_util import (
     get_report_action,
     set_up_cleanup,
     get_source_file_issue_action,
+    vlt_path,
 )
 
 # # -- Uncomment for debugging of the scons subprocess using a remote debugger.
@@ -337,8 +338,8 @@ verilator_config_builder = make_verilator_config_builder(
     env,
     (
         "`verilator_config\n"
-        f'lint_off -rule COMBDLY      -file "{YOSYS_LIB_DIR}/*"\n'
-        f'lint_off -rule WIDTHEXPAND  -file "{YOSYS_LIB_DIR}/*"\n'
+        f'lint_off -rule COMBDLY      -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
+        f'lint_off -rule WIDTHEXPAND  -file "{vlt_path(YOSYS_LIB_DIR)}/*"\n'
     ),
 )
 env.Append(BUILDERS={"VerilatorConfig": verilator_config_builder})

--- a/apio/scons/scons_util.py
+++ b/apio/scons/scons_util.py
@@ -417,6 +417,13 @@ def make_verilog_src_scanner(env: SConsEnvironment) -> Scanner.Base:
     return env.Scanner(function=verilog_src_scanner_func)
 
 
+def vlt_path(path: str) -> str:
+    """Normalize a path that is used in the verilator config file hardware.vlt.
+    On windows it replaces "\" with "/". Otherwise it leaves the path as is.
+    """
+    return path.replace("\\", "/")
+
+
 def make_verilator_config_builder(env: SConsEnvironment, config_text: str):
     """Create a scons Builder that writes a verilator config file
     (hardware.vlt) with the given text."""

--- a/test/commands/test_raw.py
+++ b/test/commands/test_raw.py
@@ -1,0 +1,34 @@
+"""
+  Test for the "apio raw" command
+"""
+
+from test.conftest import ApioRunner
+
+# -- apio system entry point
+from apio.commands.raw import cli as apio_raw
+
+
+def test_raw(apio_runner: ApioRunner):
+    """Test "apio raw" with different parameters"""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Execute "apio raw"
+        result = sb.invoke_apio_cmd(apio_raw)
+        assert result.exit_code != 0, result.output
+        assert "Error: Missing an option or a command" in result.output
+        # -- Since we run the raw command directly, the 'apio' prefix is
+        # -- missing from the output.
+        assert "Try 'raw --help' for help" in result.output
+
+        # -- Execute "apio raw --env"
+        result = sb.invoke_apio_cmd(apio_raw, ["--env"])
+        assert result.exit_code == 0, result.output
+        assert "Envirnment settings:" in result.output
+        assert "PATH" in result.output
+        assert "YOSYS_LIB" in result.output
+
+        # -- Execute "apio raw yosys --version"
+        result = sb.invoke_apio_cmd(apio_raw, ["yosys", "--version"])
+        assert result.exit_code != 0, result.output
+        assert "package 'oss-cad-suite' is not installed" in result.output

--- a/test/scons/test_scons_util.py
+++ b/test/scons/test_scons_util.py
@@ -37,6 +37,7 @@ from apio.scons.scons_util import (
     get_programmer_cmd,
     make_verilator_config_builder,
     get_source_files,
+    vlt_path
 )
 
 DEPENDECIES_TEST_TEXT = """
@@ -508,3 +509,11 @@ def test_get_source_files(apio_runner):
         # -- Verify results.
         assert srcs == ["aaa.v", "bbb.v"]
         assert testbenches == ["aaa_tb.v", "ccc_tb.v"]
+
+def test_vlt_path(apio_runner):
+    """Tests the vlt_path path string mapping."""
+
+    assert vlt_path("") == ""
+    assert vlt_path("/aa/bb/cc.xyz") == "/aa/bb/cc.xyz"
+    assert vlt_path("C:\\aa\\bb/cc.xyz") == "C:/aa/bb/cc.xyz"
+    


### PR DESCRIPTION
1. Fixed the 'apio lint' failures on windows.
2. Added a unit test for the 'apio raw' command.