### PR TITLE
'tinyprog' is now directoed to oss-cad-suite  (instead of to a pip packge). 

### DIFF
--- a/apio/resources/distribution.json
+++ b/apio/resources/distribution.json
@@ -5,7 +5,6 @@
     "blackiceprog": ">=2.0.0,<3.0.0",
     "litterbox": ">=0.2.1,<0.3.0",
     "tinyfpgab": ">=1.1.0,<1.2.0",
-    "tinyprog": ">=1.0.21,<1.1.0",
     "icefunprog": ">=2.0.3,<3.0.0",
     "apycula": ">=0.12",
     "apollo_fpga": ">=1.1.0"

--- a/apio/resources/programmers.json
+++ b/apio/resources/programmers.json
@@ -42,8 +42,7 @@
   },
   "tinyprog": {
     "command": "tinyprog",
-    "args": "--pyserial -c ${SERIAL_PORT} --program",
-    "pip_packages": [ "tinyprog" ]
+    "args": "--pyserial -c ${SERIAL_PORT} --program"
   },
   "ujprog": {
     "command": "ujprog",

--- a/apio/util.py
+++ b/apio/util.py
@@ -418,32 +418,33 @@ def get_tinyprog_meta() -> list:
      ]'
     """
 
-    # -- Get the Apio executable folder
-    apio_bin_dir = get_bin_dir()
-
-    # -- Construct the command to execute
-    _command = apio_bin_dir / "tinyprog"
-
-    # -- Check if the executable exist
-    # -- In it does not exist, try with just the
-    # -- name: "tinyprog"
-    if not _command.exists():
-        _command = "tinyprog"
+    # -- Construct the command to execute. Since we exectute tinyprog from
+    # -- the apio packages which add to the path, we can use a simple name.
+    command = ["tinyprog", "--pyserial", "--meta"]
+    command_str = " ".join(command)
 
     # -- Execute the command!
-    # -- It will return the meta information as a json string
-    result = exec_command([_command, "--pyserial", "--meta"])
+    # -- It should return the meta information as a json string
+    secho(command_str)
+    result = exec_command(command)
 
-    # pylint: disable=fixme
-    # TODO: Exit with an error if result.exit_code is not zero.
+    if result.exit_code != 0:
+        secho(
+            f"Warning: the command `{command_str}`failed with exit code "
+            f"{result.exit_code}",
+            color="yellow",
+        )
+        return []
 
     # -- Convert the json string to an object (list)
-
     try:
         meta = json.loads(result.out_text)
 
     except json.decoder.JSONDecodeError as exc:
-        secho(f"Invalid data provided by {_command}", fg="red")
+        secho(
+            f"Warning: invalid json dnvalid data provided by `{command_str}`",
+            fg="yellow",
+        )
         secho(f"{exc}", fg="red")
         return []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ exclude = ["test-examples/"]
 blackiceprog = ['blackiceprog==2.0.0']
 litterbox = ['litterbox==0.2.2']
 tinyfpgab = ['tinyfpgab==1.1.0']
-tinyprog = ['tinyprog==1.0.21']
 icefunprog = ['icefunprog==2.0.3']
 
 


### PR DESCRIPTION
Removed dependency on pip 'tinyprog' package. Now the tinyprog from oss-cad-tools is invoked. I don't have a tinyprog fpga board so was not able to test beyond that.

@cavearr, please review and accept.