### PR TITLE
Renamed the resources files from .json to .jsonc.  Removed the ecp5 12k/25k hack.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,11 @@
         "test"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "editor.rulers": [
+        79
+    ],
+    "black-formatter.args": [
+        "--line-length=79"
+    ]
 }

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -75,31 +75,31 @@ Options:
   -h, --help  Show this message and exit.
 
 Build commands:
-  apio [35mbuild      [0m  Synthesize the bitstream.
-  apio [35mupload     [0m  Upload the bitstream to the FPGA.
-  apio [35mclean      [0m  Delete the apio generated files.
+  apio build        Synthesize the bitstream.
+  apio upload       Upload the bitstream to the FPGA.
+  apio clean        Delete the apio generated files.
 
 Verification commands:
-  apio [35mlint       [0m  Lint the verilog code.
-  apio [35mformat     [0m  Format verilog source files.
-  apio [35msim        [0m  Simulate a testbench with graphic results.
-  apio [35mtest       [0m  Test all or a single verilog testbench module.
-  apio [35mreport     [0m  Report design utilization and timing.
-  apio [35mgraph      [0m  Generate a visual graph of the code.
+  apio lint         Lint the verilog code.
+  apio format       Format verilog source files.
+  apio sim          Simulate a testbench with graphic results.
+  apio test         Test all or a single verilog testbench module.
+  apio report       Report design utilization and timing.
+  apio graph        Generate a visual graph of the code.
 
 Setup commands:
-  apio [35mcreate     [0m  Create an apio.ini project file.
-  apio [35mpreferences[0m  Manage the apio user preferences.
-  apio [35mpackages   [0m  Manage the apio packages.
-  apio [35mdrivers    [0m  Manage the operating system drivers.
+  apio create       Create an apio.ini project file.
+  apio preferences  Manage the apio user preferences.
+  apio packages     Manage the apio packages.
+  apio drivers      Manage the operating system drivers.
 
 Utility commands:
-  apio [35mboards     [0m  List available board definitions.
-  apio [35mfpgas      [0m  List available FPGA definitions.
-  apio [35mexamples   [0m  List and fetch apio examples.
-  apio [35msystem     [0m  Provides system info.
-  apio [35mraw        [0m  Execute commands directly from the Apio packages.
-  apio [35mupgrade    [0m  Check the latest Apio version.
+  apio boards       List available board definitions.
+  apio fpgas        List available FPGA definitions.
+  apio examples     List and fetch apio examples.
+  apio system       Provides system info.
+  apio raw          Execute commands directly from the Apio packages.
+  apio upgrade      Check the latest Apio version.
 
 ```
 
@@ -111,8 +111,8 @@ Utility commands:
 Usage: apio boards [OPTIONS]
 
   The command 'apio boards' lists the FPGA boards recognized by Apio. Custom
-  boards can be defined by placing a custom 'boards.json' file in the project
-  directory, which will override Apio’s default 'boards.json' file.
+  boards can be defined by placing a custom 'boards.jsonc' file in the project
+  directory, which will override Apio’s default 'boards.jsonc' file.
 
   Examples:
     apio boards                   # List all boards.
@@ -208,9 +208,9 @@ Options:
   -h, --help  Show this message and exit.
 
 Subcommands:
-  apio drivers [35mftdi  [0m  Manage the ftdi drivers.
-  apio drivers [35mserial[0m  Manage the serial drivers.
-  apio drivers [35mlsusb [0m  List connected USB devices.
+  apio drivers ftdi    Manage the ftdi drivers.
+  apio drivers serial  Manage the serial drivers.
+  apio drivers lsusb   List connected USB devices.
 
 ```
 
@@ -228,9 +228,9 @@ Options:
   -h, --help  Show this message and exit.
 
 Subcommands:
-  apio drivers ftdi [35minstall  [0m  Install the ftdi drivers.
-  apio drivers ftdi [35muninstall[0m  Uninstall the ftdi drivers.
-  apio drivers ftdi [35mlist     [0m  List the connected ftdi devices.
+  apio drivers ftdi install    Install the ftdi drivers.
+  apio drivers ftdi uninstall  Uninstall the ftdi drivers.
+  apio drivers ftdi list       List the connected ftdi devices.
 
 ```
 
@@ -326,9 +326,9 @@ Options:
   -h, --help  Show this message and exit.
 
 Subcommands:
-  apio drivers serial [35minstall  [0m  Install the serial drivers.
-  apio drivers serial [35muninstall[0m  Uninstall the serial drivers.
-  apio drivers serial [35mlist     [0m  List the connected serial devices.
+  apio drivers serial install    Install the serial drivers.
+  apio drivers serial uninstall  Uninstall the serial drivers.
+  apio drivers serial list       List the connected serial devices.
 
 ```
 
@@ -403,9 +403,9 @@ Options:
   -h, --help  Show this message and exit.
 
 Subcommands:
-  apio examples [35mlist       [0m  List the available apio examples.
-  apio examples [35mfetch      [0m  Fetch the files of an example.
-  apio examples [35mfetch-board[0m  Fetch all examples of a board.
+  apio examples list         List the available apio examples.
+  apio examples fetch        Fetch the files of an example.
+  apio examples fetch-board  Fetch all examples of a board.
 
 ```
 
@@ -526,8 +526,8 @@ Usage: apio fpgas [OPTIONS]
 
   The command ‘apio fpgas’ lists the FPGAs recognized by Apio. Custom FPGAs
   supported by the underlying Yosys toolchain can be defined by placing a
-  custom fpgas.json file in the project directory, overriding Apio’s standard
-  fpgas.json file.
+  custom fpgas.jsonc file in the project directory, overriding Apio’s standard
+  fpgas.jsonc file.
 
   Examples:
     apio fpgas               # List all fpgas.
@@ -614,10 +614,10 @@ Options:
   -h, --help  Show this message and exit.
 
 Subcommands:
-  apio packages [35minstall  [0m  Install apio packages.
-  apio packages [35muninstall[0m  Uninstall apio packages.
-  apio packages [35mlist     [0m  List apio packages.
-  apio packages [35mfix      [0m  Fix broken apio packages.
+  apio packages install    Install apio packages.
+  apio packages uninstall  Uninstall apio packages.
+  apio packages list       List apio packages.
+  apio packages fix        Fix broken apio packages.
 
 ```
 
@@ -719,8 +719,8 @@ Options:
   -h, --help  Show this message and exit.
 
 Subcommands:
-  apio preferences [35mlist[0m  List the apio user preferences.
-  apio preferences [35mset [0m  Set the apio user preferences.
+  apio preferences list  List the apio user preferences.
+  apio preferences set   Set the apio user preferences.
 
 ```
 
@@ -872,8 +872,8 @@ Options:
   -h, --help  Show this message and exit.
 
 Subcommands:
-  apio system [35mplatforms[0m  List supported platforms ids.
-  apio system [35minfo     [0m  Show platform id and other info.
+  apio system platforms  List supported platforms ids.
+  apio system info       Show platform id and other info.
 
 ```
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -78,12 +78,12 @@ python apio/main.py build --project_dir test-examples/alhambra-ii/01-LEDs-button
 
 ## Running apio in the Visual Studio Code debugger.
 
-The ``apio`` repository contains at its root the file ``.vscode/launch.json`` with debug
+The ``apio`` repository contains at its root the file ``.vscode/launch.jsonc`` with debug
 target for most of the ``apio`` commands. Make sure to open the root folder of the repository for VSC to recognize the targets file. To select the debug target, click on the debug icon on the left sidebar and this will display above a pull down menu with the available debug target and a start icon.
 
 [NOTE] This method doesn't not work for debugging the SConstruct scripts since they are run as subprocesses of the apio process. For debugging SConstruct scripts see the next section.
 
-The debug target can be viewed here https://github.com/FPGAwars/apio/blob/develop/.vscode/launch.json
+The debug target can be viewed here https://github.com/FPGAwars/apio/blob/develop/.vscode/launch.jsonc
 
 
 ## Debugging SConstruct scripts (subprocesses) with Visual Studio Code.

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -29,45 +29,45 @@ from apio.managers.project import (
 RESOURCES_DIR = "resources"
 
 # ---------------------------------------
-# ---- File: resources/platforms.json
+# ---- File: resources/platforms.jsonc
 # --------------------------------------
 # -- This file contains  the information regarding the supported platforms
 # -- and their attributes.
-PLATFORMS_JSON = "platforms.json"
+PLATFORMS_JSONC = "platforms.jsonc"
 
 # ---------------------------------------
-# ---- File: resources/packages.json
+# ---- File: resources/packages.jsonc
 # --------------------------------------
 # -- This file contains all the information regarding the available apio
 # -- packages: Repository, version, name...
-PACKAGES_JSON = "packages.json"
+PACKAGES_JSONC = "packages.jsonc"
 
 # -----------------------------------------
-# ---- File: resources/boads.json
+# ---- File: resources/boads.jsonc
 # -----------------------------------------
 # -- Information about all the supported boards
 # -- names, fpga family, programmer, ftdi description, vendor id, product id
-BOARDS_JSON = "boards.json"
+BOARDS_JSONC = "boards.jsonc"
 
 # -----------------------------------------
-# ---- File: resources/fpgas.json
+# ---- File: resources/fpgas.jsonc
 # -----------------------------------------
 # -- Information about all the supported fpgas
 # -- arch, type, size, packaging
-FPGAS_JSON = "fpgas.json"
+FPGAS_JSONC = "fpgas.jsonc"
 
 # -----------------------------------------
-# ---- File: resources/programmers.json
+# ---- File: resources/programmers.jsonc
 # -----------------------------------------
 # -- Information about all the supported programmers
 # -- name, command to execute, arguments...
-PROGRAMMERS_JSON = "programmers.json"
+PROGRAMMERS_JSONC = "programmers.jsonc"
 
 # -----------------------------------------
-# ---- File: resources/distribution.json
+# ---- File: resources/distribution.jsonc
 # -----------------------------------------
 # -- Information about all the supported apio and pip packages
-DISTRIBUTION_JSON = "distribution.json"
+DISTRIBUTION_JSONC = "distribution.jsonc"
 
 
 class ApioContextScope(Enum):
@@ -147,23 +147,23 @@ class ApioContext:
         self.home_dir: Path = util.resolve_home_dir()
 
         # -- Read the distribution information
-        self.distribution = self._load_resource(DISTRIBUTION_JSON)
+        self.distribution = self._load_resource(DISTRIBUTION_JSONC)
 
         # -- Profile information, from ~/.apio/profile.json. We provide it with
-        # -- the remote config url template from disribution.json such that
+        # -- the remote config url template from disribution.jsonc such that
         # -- can it fetch the remote config on demand.
         self.profile = Profile(
             self.home_dir, self.distribution["remote-config"]
         )
 
         # -- Read the platforms information.
-        self.platforms = self._load_resource(PLATFORMS_JSON)
+        self.platforms = self._load_resource(PLATFORMS_JSONC)
 
         # -- Determine the platform_id for this APIO session.
         self.platform_id = self._determine_platform_id(self.platforms)
 
         # -- Read the apio packages information
-        self.all_packages = self._load_resource(PACKAGES_JSON)
+        self.all_packages = self._load_resource(PACKAGES_JSONC)
 
         # -- Expand in place the env templates in all_packages.
         ApioContext._resolve_package_envs(self.all_packages, self.packages_dir)
@@ -174,22 +174,22 @@ class ApioContext:
         )
 
         # -- Read the boards information. Allow override files in project dir.
-        self.boards = self._load_resource(BOARDS_JSON, allow_custom=True)
+        self.boards = self._load_resource(BOARDS_JSONC, allow_custom=True)
 
         # -- Read the FPGAs information. Allow override files in project dir.
-        self.fpgas = self._load_resource(FPGAS_JSON, allow_custom=True)
+        self.fpgas = self._load_resource(FPGAS_JSONC, allow_custom=True)
 
         # -- Read the programmers information. Allow override files in project
         # -- dir.
         self.programmers = self._load_resource(
-            PROGRAMMERS_JSON, allow_custom=True
+            PROGRAMMERS_JSONC, allow_custom=True
         )
 
         # -- Sort resources for consistency and intunitiveness.
         # --
         # -- We don't sort the all_packages and platform_packages dictionaries
         # -- because that will affect the order of the env path items.
-        # -- Instead we preserve the order from the packages.json file.
+        # -- Instead we preserve the order from the packages.jsonc file.
 
         self.boards = OrderedDict(
             sorted(self.boards.items(), key=lambda t: t[0])
@@ -212,8 +212,8 @@ class ApioContext:
         self, board: str, *, warn: bool = True, strict: bool = True
     ) -> str:
         """Lookup and return the board's canonical board name which is its key
-        in boards.json().  'board' can be the canonical name itself or a
-        legacy id of the board as defined in boards.json.  The method prints
+        in boards.jsonc.  'board' can be the canonical name itself or a
+        legacy id of the board as defined in boards.jsonc.  The method prints
         a warning if 'board' is a legacy board name that is mapped to its
         canonical name and 'warn' is True. If the  board is not found, the
         method returns None if 'strict' is False or exit the program with a
@@ -221,7 +221,7 @@ class ApioContext:
         # -- If this fails, it's a programming error.
         assert board is not None
 
-        # -- The result. The board's key in boards.json.
+        # -- The result. The board's key in boards.jsonc.
         canonical_name = None
 
         if board in self.boards:
@@ -282,18 +282,18 @@ class ApioContext:
         return self._project
 
     def _load_resource(self, name: str, allow_custom: bool = False) -> dict:
-        """Load the resources from a given json file
+        """Load the resources from a given jsonc file
         * INPUTS:
-          * Name: Name of the json file
+          * Name: Name of the jsonc file
             Use the following constants:
-              * PACKAGES_JSON
-              * BOARD_JSON
-              * FPGAS_JSON
-              * PROGRAMMERS_JSON
-              * DISTRIBUTION_JSON
+              * PACKAGES_JSONC
+              * BOARD_JSONC
+              * FPGAS_JSONC
+              * PROGRAMMERS_JSONC
+              * DISTRIBUTION_JSONC
             * Allow_custom: if true, look first in the project dir for
               a project specific resource file of same name.
-        * OUTPUT: A dictionary with the json file data
+        * OUTPUT: A dictionary with the jsonc file data
           In case of error it raises an exception and finish
         """
         # -- Try loading a custom resource file from the project directory.
@@ -312,26 +312,26 @@ class ApioContext:
 
     @staticmethod
     def _load_resource_file(filepath: Path) -> dict:
-        """Load the resources from a given json file path
-        * OUTPUT: A dictionary with the json file data
+        """Load the resources from a given jsonc file path
+        * OUTPUT: A dictionary with the jsons file data
           In case of error it raises an exception and finish
         """
 
-        # -- Read the json file
+        # -- Read the jsonc file
         try:
             with filepath.open(encoding="utf8") as file:
 
                 # -- Read the json with comments file
                 data_jsonc = file.read()
 
-        # -- json file NOT FOUND! This is an apio system error
+        # -- The jsonc file NOT FOUND! This is an apio system error
         # -- It should never ocurr unless there is a bug in the
         # -- apio system files, or a bug when calling this function
         # -- passing a wrong file
         except FileNotFoundError as exc:
 
             # -- Display Main error
-            secho("Apio System Error! JSON file not found", fg="red")
+            secho("Apio System Error! JSONC file not found", fg="red")
 
             # -- Display the affected file (in a different color)
             apio_file_msg = click.style("Apio file: ", fg="yellow")
@@ -357,7 +357,7 @@ class ApioContext:
         except json.decoder.JSONDecodeError as exc:
 
             # -- Display Main error
-            secho("Apio System Error! Invalid JSON file", fg="red")
+            secho("Apio System Error! Invalid JSONC file", fg="red")
 
             # -- Display the affected file (in a different color)
             apio_file_msg = click.style("Apio file: ", fg="yellow")
@@ -375,10 +375,10 @@ class ApioContext:
 
     @staticmethod
     def _expand_env_template(template: str, package_path: Path) -> str:
-        """Fills a packages env value template as they appear in packages.json.
-        Currently it recognizes only a single place holder '%p' representing
-        the package absolute path. The '%p" can appear only at the begigning
-        of the template.
+        """Fills a packages env value template as they appear in
+        packages.jsonc. Currently it recognizes only a single place holder
+        '%p' representing the package absolute path. The '%p" can appear only
+        at the begigning of the template.
 
         E.g. '%p/bin' -> '/users/user/.apio/packages/drivers/bin'
 
@@ -482,7 +482,7 @@ class ApioContext:
         platform_id: str,
         platforms: Dict[str, Dict],
     ):
-        """Given a dictionary with the packages.json packages configurations,
+        """Given a dictionary with the packages.jsonc packages configurations,
         returns subset dictionary with packages that are applicable to the
         this platform.
         """

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -64,10 +64,10 @@ FPGAS_JSONC = "fpgas.jsonc"
 PROGRAMMERS_JSONC = "programmers.jsonc"
 
 # -----------------------------------------
-# ---- File: resources/distribution.jsonc
+# ---- File: resources/config.jsonc
 # -----------------------------------------
-# -- Information about all the supported apio and pip packages
-DISTRIBUTION_JSONC = "distribution.jsonc"
+# -- General config information.
+CONFIG_JSONC = "config.jsonc"
 
 
 class ApioContextScope(Enum):
@@ -146,15 +146,13 @@ class ApioContext:
         # -- Determine apio home dir.
         self.home_dir: Path = util.resolve_home_dir()
 
-        # -- Read the distribution information
-        self.distribution = self._load_resource(DISTRIBUTION_JSONC)
+        # -- Read the config information
+        self.config = self._load_resource(CONFIG_JSONC)
 
         # -- Profile information, from ~/.apio/profile.json. We provide it with
         # -- the remote config url template from disribution.jsonc such that
         # -- can it fetch the remote config on demand.
-        self.profile = Profile(
-            self.home_dir, self.distribution["remote-config"]
-        )
+        self.profile = Profile(self.home_dir, self.config["remote-config"])
 
         # -- Read the platforms information.
         self.platforms = self._load_resource(PLATFORMS_JSONC)
@@ -290,7 +288,7 @@ class ApioContext:
               * BOARD_JSONC
               * FPGAS_JSONC
               * PROGRAMMERS_JSONC
-              * DISTRIBUTION_JSONC
+              * CONFIG_JSONC
             * Allow_custom: if true, look first in the project dir for
               a project specific resource file of same name.
         * OUTPUT: A dictionary with the jsonc file data

--- a/apio/commands/apio_boards.py
+++ b/apio/commands/apio_boards.py
@@ -127,7 +127,7 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
     parts.append(f"{'ARCH':<{fpga_arch_len}}")
     parts.append(f"{'SIZE':<{fpga_size_len}}")
     if verbose:
-        parts.append(f"{'FPGA':<{fpga_len}}")
+        parts.append(f"{'FPGA-ID':<{fpga_len}}")
     parts.append(f"{'PART-NUMBER':<{fpga_part_num_len}}")
     if verbose:
         parts.append(f"{'TYPE':<{fpga_type_len}}")
@@ -142,7 +142,7 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
     last_arch = None
     for entry in entries:
         # -- If not piping, add architecture groups seperations.
-        if last_arch != entry.fpga_arch and output_config.terminal_mode():
+        if last_arch != entry.fpga_arch and output_config.terminal_mode:
             echo("")
             secho(f"{entry.fpga_arch.upper()}", fg="magenta", bold=True)
         last_arch = entry.fpga_arch
@@ -169,7 +169,7 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
 
     # -- Show the summary.
 
-    if output_config.terminal_mode():
+    if output_config.terminal_mode:
         secho(f"Total of {util.plurality(entries, 'board')}")
         if not verbose:
             secho("Run 'apio boards -v' for additional columns.", fg="yellow")

--- a/apio/commands/apio_boards.py
+++ b/apio/commands/apio_boards.py
@@ -165,8 +165,8 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
 # pylint: disable = R0801
 APIO_BOARDS_HELP = """
 The command 'apio boards' lists the FPGA boards recognized by Apio.
-Custom boards can be defined by placing a custom 'boards.json' file in the
-project directory, which will override Apio’s default 'boards.json' file.
+Custom boards can be defined by placing a custom 'boards.jsonc' file in the
+project directory, which will override Apio’s default 'boards.jsonc' file.
 
 \b
 Examples:
@@ -193,7 +193,7 @@ def cli(
     definitions."""
 
     # -- Create the apio context. If the project exists, it's custom
-    # -- boards.json is also loaded.
+    # -- boards.jsonc is also loaded.
     apio_ctx = ApioContext(
         scope=ApioContextScope.PROJECT_OPTIONAL,
         project_dir_arg=project_dir,

--- a/apio/commands/apio_boards.py
+++ b/apio/commands/apio_boards.py
@@ -27,15 +27,16 @@ class Entry:
     """Holds the values of a single board report line."""
 
     board: str
-    board_description: str
     examples_count: str
-    fpga: str
-    programmer: str
+    board_description: str
     fpga_arch: str
-    fpga_part_num: str
     fpga_size: str
+    fpga: str
+    fpga_part_num: str
     fpga_type: str
     fpga_pack: str
+    fpga_speed: str
+    programmer: str
 
     def sort_key(self):
         """Returns a key for sorting entiries. Primary key is the architecture
@@ -65,28 +66,32 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
     # -- Collect the boards info into a list of entires, one per board.
     entries: List[Entry] = []
     for board, board_info in apio_ctx.boards.items():
-        board_description = board_info.get("description", "")
-        examples_count = "   " + str(examples_counts.get(board, ""))
-        programmer = board_info.get("programmer", {}).get("type", "")
         fpga = board_info.get("fpga", "")
         fpga_info = apio_ctx.fpgas.get(fpga, {})
+
+        examples_count = "   " + str(examples_counts.get(board, ""))
+        board_description = board_info.get("description", "")
         fpga_arch = fpga_info.get("arch", "")
-        fpga_part_num = fpga_info.get("part_num", "")
         fpga_size = fpga_info.get("size", "")
+        fpga_part_num = fpga_info.get("part_num", "")
         fpga_type = fpga_info.get("type", "")
         fpga_pack = fpga_info.get("pack", "")
+        fpga_speed = fpga_info.get("speed", "")
+        programmer = board_info.get("programmer", {}).get("type", "")
+
         entries.append(
             Entry(
-                board,
-                board_description,
-                examples_count,
-                fpga,
-                programmer,
-                fpga_arch,
-                fpga_part_num,
-                fpga_size,
-                fpga_type,
-                fpga_pack,
+                board=board,
+                examples_count=examples_count,
+                board_description=board_description,
+                fpga_arch=fpga_arch,
+                fpga_size=fpga_size,
+                fpga=fpga,
+                fpga_part_num=fpga_part_num,
+                fpga_type=fpga_type,
+                fpga_pack=fpga_pack,
+                fpga_speed=fpga_speed,
+                programmer=programmer,
             )
         )
 
@@ -94,19 +99,21 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
     entries.sort(key=lambda x: x.sort_key())
 
     # -- Compute the columns widths.
+
     margin = 2 if verbose else 4
     board_len = max(len(x.board) for x in entries) + margin - 2
+    examples_count_len = 7 + margin
     board_description_len = (
         max(len(x.board_description) for x in entries) + margin
     )
-    examples_count_len = 7 + margin
-    fpga_len = max(len(x.fpga) for x in entries) + margin
-    programmer_len = max(len(x.programmer) for x in entries) + margin
     fpga_arch_len = max(len(x.fpga_arch) for x in entries) + margin
+    fpga_size_len = max(len(x.fpga_size) for x in entries) + margin
+    fpga_len = max(len(x.fpga) for x in entries) + margin
     fpga_part_num_len = max(len(x.fpga_part_num) for x in entries) + margin
     fpga_type_len = max(len(x.fpga_type) for x in entries) + margin
-    fpga_size_len = max(len(x.fpga_size) for x in entries) + margin
     fpga_pack_len = max(len(x.fpga_pack) for x in entries) + margin
+    fpga_speed_len = 5 + margin
+    programmer_len = max(len(x.programmer) for x in entries) + margin
 
     # -- Construct the title fields.
     parts = []
@@ -115,14 +122,14 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
     if verbose:
         parts.append(f"{'DESCRIPTION':<{board_description_len}}")
     parts.append(f"{'ARCH':<{fpga_arch_len}}")
-    if verbose:
-        parts.append(f"{'FPGA':<{fpga_len}}")
-    parts.append(f"{'PART NUMBER':<{fpga_part_num_len}}")
-    if verbose:
-        parts.append(f"{'TYPE':<{fpga_type_len}}")
     parts.append(f"{'SIZE':<{fpga_size_len}}")
     if verbose:
+        parts.append(f"{'FPGA':<{fpga_len}}")
+    parts.append(f"{'PART-NUMBER':<{fpga_part_num_len}}")
+    if verbose:
+        parts.append(f"{'TYPE':<{fpga_type_len}}")
         parts.append(f"{'PACK':<{fpga_pack_len}}")
+        parts.append(f"{'SPEED':<{fpga_speed_len}}")
     parts.append(f"{'PROGRAMMER':<{programmer_len}}")
 
     # -- Show the title line.
@@ -138,14 +145,14 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
         if verbose:
             parts.append(f"{x.board_description:<{board_description_len}}")
         parts.append(f"{x.fpga_arch:<{fpga_arch_len}}")
+        parts.append(f"{x.fpga_size:<{fpga_size_len}}")
         if verbose:
             parts.append(f"{x.fpga:<{fpga_len}}")
         parts.append(f"{x.fpga_part_num:<{fpga_part_num_len}}")
         if verbose:
             parts.append(f"{x.fpga_type:<{fpga_type_len}}")
-        parts.append(f"{x.fpga_size:<{fpga_size_len}}")
-        if verbose:
             parts.append(f"{x.fpga_pack:<{fpga_pack_len}}")
+            parts.append(f"{x.fpga_speed:<{fpga_speed_len}}")
         parts.append(f"{x.programmer:<{programmer_len}}")
 
         # -- Print the line

--- a/apio/commands/apio_fpgas.py
+++ b/apio/commands/apio_fpgas.py
@@ -99,12 +99,12 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
     parts = []
     parts.append(f"{'FPGA ID':<{fpga_len}}")
     parts.append(f"{'BOARDS':<{board_count_len}}")
-    parts.append(f"{'AECH':<{fpga_arch_len}}")
+    parts.append(f"{'ARCH':<{fpga_arch_len}}")
     parts.append(f"{'PART NUMBER':<{fpga_part_num_len}}")
     parts.append(f"{'SIZE':<{fpga_size_len}}")
     if verbose:
         parts.append(f"{'TYPE':<{fpga_type_len}}")
-        parts.append(f"{'PACKAGE':<{fpga_pack_len}}")
+        parts.append(f"{'PACK':<{fpga_pack_len}}")
 
     # -- Print the title
     secho("".join(parts), fg="cyan", bold="True")

--- a/apio/commands/apio_fpgas.py
+++ b/apio/commands/apio_fpgas.py
@@ -141,8 +141,8 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
 APIO_FPGAS_HELP = """
 The command ‘apio fpgas’ lists the FPGAs recognized by Apio. Custom FPGAs
 supported by the underlying Yosys toolchain can be defined by placing a
-custom fpgas.json file in the project directory, overriding Apio’s standard
-fpgas.json file.
+custom fpgas.jsonc file in the project directory, overriding Apio’s standard
+fpgas.jsonc file.
 
 \b
 Examples:
@@ -169,7 +169,7 @@ def cli(
     definitions.
     """
 
-    # -- Create the apio context. If project dir has a fpgas.json file,
+    # -- Create the apio context. If project dir has a fpgas.jsonc file,
     # -- it will be loaded instead of the apio's standard file.
     apio_ctx = ApioContext(
         scope=ApioContextScope.PROJECT_OPTIONAL, project_dir_arg=project_dir

--- a/apio/commands/apio_fpgas.py
+++ b/apio/commands/apio_fpgas.py
@@ -106,7 +106,7 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
 
     # -- Construct the title fields.
     parts = []
-    parts.append(f"{'FPGA ID':<{fpga_len}}")
+    parts.append(f"{'FPGA-ID':<{fpga_len}}")
     parts.append(f"{'BOARDS':<{board_count_len}}")
     parts.append(f"{'ARCH':<{fpga_arch_len}}")
     parts.append(f"{'PART-NUMBER':<{fpga_part_num_len}}")
@@ -123,7 +123,7 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
     last_arch = None
     for entries in entries:
         # -- Seperation before each archictecture group, unless piped out.
-        if last_arch != entries.fpga_arch and output_config.terminal_mode():
+        if last_arch != entries.fpga_arch and output_config.terminal_mode:
             echo("")
             secho(f"{entries.fpga_arch.upper()}", fg="magenta", bold=True)
         last_arch = entries.fpga_arch
@@ -147,7 +147,7 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
         echo("".join(parts))
 
     # -- Show summary.
-    if output_config.terminal_mode():
+    if output_config.terminal_mode:
         secho(f"Total of {util.plurality(apio_ctx.fpgas, 'fpga')}")
         if not verbose:
             secho("Run 'apio fpgas -v' for additional columns.", fg="yellow")

--- a/apio/commands/apio_fpgas.py
+++ b/apio/commands/apio_fpgas.py
@@ -20,6 +20,7 @@ from apio.commands import options
 
 # R0801: Similar lines in 2 files
 # pylint: disable=R0801
+# pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class Entry:
     """A class to hold the field of a single line of the report."""
@@ -31,6 +32,7 @@ class Entry:
     fpga_size: str
     fpga_type: str
     fpga_pack: str
+    fpga_speed: str
 
     def sort_key(self):
         """A kery for sorting entries. Primary key is architecture, by
@@ -48,6 +50,7 @@ class Entry:
 
 
 # pylint: disable=too-many-locals
+# pylint: disable=too-many-statements
 def list_fpgas(apio_ctx: ApioContext, verbose: bool):
     """Prints all the available FPGA definitions."""
 
@@ -69,16 +72,18 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
         fpga_size = fpga_info.get("size", "")
         fpga_type = fpga_info.get("type", "")
         fpga_pack = fpga_info.get("pack", "")
+        fpga_speed = fpga_info.get("speed", "")
         # -- Append to the list
         entries.append(
             Entry(
-                fpga,
-                board_count,
-                fpga_arch,
-                fpga_part_num,
-                fpga_size,
-                fpga_type,
-                fpga_pack,
+                fpga=fpga,
+                board_count=board_count,
+                fpga_arch=fpga_arch,
+                fpga_part_num=fpga_part_num,
+                fpga_size=fpga_size,
+                fpga_type=fpga_type,
+                fpga_pack=fpga_pack,
+                fpga_speed=fpga_speed,
             )
         )
 
@@ -94,17 +99,19 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
     fpga_size_len = max(len(x.fpga_size) for x in entries) + margin
     fpga_type_len = max(len(x.fpga_type) for x in entries) + margin
     fpga_pack_len = max(len(x.fpga_pack) for x in entries) + margin
+    fpga_speed_len = 5 + margin
 
     # -- Construct the title fields.
     parts = []
     parts.append(f"{'FPGA ID':<{fpga_len}}")
     parts.append(f"{'BOARDS':<{board_count_len}}")
     parts.append(f"{'ARCH':<{fpga_arch_len}}")
-    parts.append(f"{'PART NUMBER':<{fpga_part_num_len}}")
+    parts.append(f"{'PART-NUMBER':<{fpga_part_num_len}}")
     parts.append(f"{'SIZE':<{fpga_size_len}}")
     if verbose:
         parts.append(f"{'TYPE':<{fpga_type_len}}")
         parts.append(f"{'PACK':<{fpga_pack_len}}")
+        parts.append(f"{'SPEED':<{fpga_speed_len}}")
 
     # -- Print the title
     secho("".join(parts), fg="cyan", bold="True")
@@ -123,6 +130,7 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
         if verbose:
             parts.append(f"{x.fpga_type:<{fpga_type_len}}")
             parts.append(f"{x.fpga_pack:<{fpga_pack_len}}")
+            parts.append(f"{x.fpga_speed:<{fpga_speed_len}}")
 
         # -- Print the fpga line.
         echo("".join(parts))

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -12,7 +12,7 @@ import os
 from pathlib import Path, PosixPath
 from dataclasses import dataclass
 from typing import Optional, List, Dict
-from click import secho
+from click import secho, style, echo
 from apio.utils import util
 from apio.apio_context import ApioContext
 from apio.managers import installer
@@ -227,13 +227,13 @@ class Examples:
             # -- Copy the file unless it's 'info' which we ignore.
             if file.name != "info":
                 shutil.copy(file, dst_dir_path)
+                styled_name = style(
+                    os.path.basename(file), fg="cyan", bold=True
+                )
+                echo(f"Fetched file {styled_name}")
 
         # -- Inform the user.
-        secho(
-            f"Fetched successfully the files of example '{example_name}'.",
-            fg="green",
-            bold=True,
-        )
+        secho("Example fetched successfully.", fg="green", bold=True)
 
     def get_board_examples(self, board_name) -> List[ExampleInfo]:
         """Returns the list of examples with given board name."""
@@ -305,10 +305,10 @@ class Examples:
         # -- Copy the directory tree.
         shutil.copytree(src_board_dir, dst_board_dir, dirs_exist_ok=True)
 
-        secho(
-            "Board '"
-            + board_name
-            + "' examples has been fetched successfully.",
-            fg="green",
-            bold=True,
-        )
+        for example_name in os.listdir(dst_board_dir):
+            styled_name = style(
+                f"{board_name}/{example_name}", fg="cyan", bold=True
+            )
+            echo(f"Fetched example {styled_name}")
+
+        secho("Board examples fetched successfully.", fg="green", bold=True)

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -123,7 +123,7 @@ class Examples:
 
         # -- For terminal, print a header with an horizontal line across the
         # -- terminal.
-        if output_config.terminal_mode():
+        if output_config.terminal_mode:
             terminal_seperator_line = "─" * output_config.terminal_width
             secho()
             secho(terminal_seperator_line)
@@ -133,7 +133,7 @@ class Examples:
 
         # -- Emit the examples
         for example in examples:
-            if output_config.terminal_mode():
+            if output_config.terminal_mode:
                 # -- For a terminal. Multi lines and colors.
                 secho(f"{example.name}", fg="cyan", bold=True)
                 secho(f"{example.description}")
@@ -146,7 +146,7 @@ class Examples:
                 )
 
         # -- For a terminal, emit additional summary.
-        if output_config.terminal_mode():
+        if output_config.terminal_mode:
             secho(f"Total: {len(examples)}")
 
         return 0

--- a/apio/managers/installer.py
+++ b/apio/managers/installer.py
@@ -403,7 +403,7 @@ def fix_packages(
         apio_ctx.profile.remove_package(package_name)
 
     for dir_name in scan.orphan_dir_names:
-        print(f"Deleting unknown dir '{dir_name}'")
+        print(f"Deleting unknown package dir '{dir_name}'")
         # -- Sanity check. Since apio_ctx.packages_dir is guarranted to include
         # -- the word packages, this can fail only due to programming error.
         dir_path = apio_ctx.packages_dir / dir_name
@@ -412,7 +412,7 @@ def fix_packages(
         shutil.rmtree(dir_path)
 
     for file_name in scan.orphan_file_names:
-        print(f"Deleting unknown file '{file_name}'")
+        print(f"Deleting unknown package file '{file_name}'")
         # -- Sanity check. Since apio_ctx.packages_dir is guarranted to
         # -- include the word packages, this can fail only due to programming
         # -- error.

--- a/apio/managers/installer.py
+++ b/apio/managers/installer.py
@@ -28,11 +28,11 @@ def _construct_package_download_url(
                        v0.0.9/tools-oss-cad-suite-darwin_arm64-0.0.9.tar.gz'
     """
 
-    # -- Get the package info (originated from packages.json)
+    # -- Get the package info (originated from packages.jsonc)
     package_info = apio_ctx.get_package_info(package_name)
 
     # -- Get the package selector of this platform (the package selectors
-    # -- are specified in platforms.json). E.g. 'darwin_arm64'
+    # -- are specified in platforms.jsonc). E.g. 'darwin_arm64'
     platform_id = apio_ctx.platform_id
     package_selector = apio_ctx.platforms[platform_id]["package_selector"]
 

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -266,7 +266,7 @@ class SCons:
         board_info = self.apio_ctx.boards[board]
 
         # -- pylint: disable=fixme
-        # -- TODO: abstract this better in boards.json. For example, add a
+        # -- TODO: abstract this better in boards.jsonc. For example, add a
         # -- property "darwin-no-detection".
         # --
         # -- Special case for the TinyFPGA on MACOS platforms
@@ -366,7 +366,7 @@ class SCons:
     #     current platform. There are some boards, like icoboard,
     #     that only runs in the platform linux/arm7
     #     * INPUT:
-    #       * board_info: Dictionary with board info from boards.json.
+    #       * board_info: Dictionary with board info from boards.jsonc.
 
     #     Only in case the platform is not compatible with the board,
     #     and exception is raised
@@ -393,7 +393,7 @@ class SCons:
     ) -> str:
         """
         * INPUT:
-          * board_info: Dictionary with board info from boards.json.
+          * board_info: Dictionary with board info from boards.jsonc.
         * OUTPUT: It returns a template string with the command line
            to execute for uploading the circuit. It has the following
            parameters (in the string):
@@ -463,7 +463,7 @@ class SCons:
 
         * INPUT:
           * board: Board name (string)
-          * board_info: Dictionary with board info from boards.json.
+          * board_info: Dictionary with board info from boards.jsonc.
         """
 
         # -- The board is connected by USB
@@ -517,7 +517,7 @@ class SCons:
         """Get the serial port of the connected board
         * INPUT:
           * board: Board name (string)
-          * board_info: Dictionary with board info from boards.json.
+          * board_info: Dictionary with board info from boards.jsonc.
           * ext_serial_port: serial port name given by the user (optional)
 
         * OUTPUT: (string) The serial port name
@@ -543,7 +543,7 @@ class SCons:
 
         * INPUT:
           * board: Board name (string)
-          * board_info: Dictionary with board info from boards.json.
+          * board_info: Dictionary with board info from boards.jsonc.
           * ext_serial_port: serial port name given by the user (optional)
 
         * OUTPUT: (string) The serial port name
@@ -606,7 +606,7 @@ class SCons:
     def _check_tinyprog(board_info: dict, port: str) -> bool:
         """Check if the correct TinyFPGA board is connected
         * INPUT:
-          * board_info: Dictionary with board info from boards.json.
+          * board_info: Dictionary with board info from boards.jsonc.
           * port: Serial port name
 
         * OUTPUT:
@@ -657,7 +657,7 @@ class SCons:
 
         * INPUT:
           * board: Board name (string)
-          * board_info: Dictionary with board info from boards.json.
+          * board_info: Dictionary with board info from boards.jsonc.
           * ext_ftdi_id: FTDI index given by the user (optional)
 
         * OUTPUT: It return the FTDI index (as a string)
@@ -685,7 +685,7 @@ class SCons:
 
         * INPUT:
           * board: Board name (string)
-          * board_info: Dictionary with board info from boards.json.
+          * board_info: Dictionary with board info from boards.jsonc.
           * ext_ftdi_id: FTDI index given by the user (optional)
 
         * OUTPUT: It return the FTDI index (as a string)

--- a/apio/managers/scons_args.py
+++ b/apio/managers/scons_args.py
@@ -18,7 +18,6 @@ from apio.utils import util
 ARG_FPGA_PART_NUM = "part_num"
 ARG_FPGA_ARCH = "arch"
 ARG_FPGA_TYPE = "type"
-ARG_FPGA_SIZE = "size"
 ARG_FPGA_PACK = "pack"
 ARG_VERBOSE_ALL = "verbose_all"  # Bool.
 ARG_VERBOSE_YOSYS = "verbose_yosys"  # Bool
@@ -104,7 +103,7 @@ def process_arguments(
       * Return a tuple (board, variables)
         - board: Board name ('alhambra-ii', 'icezum'...)
         - variables: A list of strings scons variables. For example
-          ['fpga_arch=ice40', 'fpga_size=8k', 'fpga_type=hx',
+          ['fpga_arch=ice40', 'fpga_type=hx',
           fpga_pack='tq144:4k']...
     """
 
@@ -114,7 +113,6 @@ def process_arguments(
         ARG_FPGA_PART_NUM: Arg(ARG_FPGA_PART_NUM, "fpga_part_num"),
         ARG_FPGA_ARCH: Arg(ARG_FPGA_ARCH, "fpga_arch"),
         ARG_FPGA_TYPE: Arg(ARG_FPGA_TYPE, "fpga_type"),
-        ARG_FPGA_SIZE: Arg(ARG_FPGA_SIZE, "fpga_size"),
         ARG_FPGA_PACK: Arg(ARG_FPGA_PACK, "fpga_pack"),
         ARG_VERBOSE_ALL: Arg(ARG_VERBOSE_ALL, "verbose_all"),
         ARG_VERBOSE_YOSYS: Arg(ARG_VERBOSE_YOSYS, "verbose_yosys"),
@@ -165,7 +163,6 @@ def process_arguments(
         [args[ARG_FPGA_PART_NUM], "part_num"],
         [args[ARG_FPGA_ARCH], "arch"],
         [args[ARG_FPGA_TYPE], "type"],
-        [args[ARG_FPGA_SIZE], "size"],
         [args[ARG_FPGA_PACK], "pack"],
     ]:
         # -- Get the fpga property, if exits.
@@ -175,13 +172,9 @@ def process_arguments(
         if fpga_property:
             arg.set(fpga_property)
 
-    # -- We already have a final configuration
-    # -- Check that this configuration is ok
-    # -- At least it should have fpga, type, size and pack
-    # -- Exit if it is not correct
-    for arg in [args[ARG_FPGA_TYPE], args[ARG_FPGA_SIZE], args[ARG_FPGA_PACK]]:
-
-        # -- Config item not defined!! it is mandatory!
+    # -- Check that the required fpga args exists.
+    for arg_name in [ARG_FPGA_PART_NUM, ARG_FPGA_TYPE, ARG_FPGA_PACK]:
+        arg = args[arg_name]
         if not arg.has_value:
             perror_insuficient_arguments()
             raise ValueError(f"Missing FPGA {arg.arg_name.upper()}")

--- a/apio/managers/scons_args.py
+++ b/apio/managers/scons_args.py
@@ -20,7 +20,6 @@ ARG_FPGA_ARCH = "arch"
 ARG_FPGA_TYPE = "type"
 ARG_FPGA_SIZE = "size"
 ARG_FPGA_PACK = "pack"
-ARG_FPGA_IDCODE = "idcode"
 ARG_VERBOSE_ALL = "verbose_all"  # Bool.
 ARG_VERBOSE_YOSYS = "verbose_yosys"  # Bool
 ARG_VERBOSE_PNR = "verbose_pnr"  # Bool
@@ -117,7 +116,6 @@ def process_arguments(
         ARG_FPGA_TYPE: Arg(ARG_FPGA_TYPE, "fpga_type"),
         ARG_FPGA_SIZE: Arg(ARG_FPGA_SIZE, "fpga_size"),
         ARG_FPGA_PACK: Arg(ARG_FPGA_PACK, "fpga_pack"),
-        ARG_FPGA_IDCODE: Arg(ARG_FPGA_IDCODE, "fpga_idcode"),
         ARG_VERBOSE_ALL: Arg(ARG_VERBOSE_ALL, "verbose_all"),
         ARG_VERBOSE_YOSYS: Arg(ARG_VERBOSE_YOSYS, "verbose_yosys"),
         ARG_VERBOSE_PNR: Arg(ARG_VERBOSE_PNR, "verbose_pnr"),
@@ -169,7 +167,6 @@ def process_arguments(
         [args[ARG_FPGA_TYPE], "type"],
         [args[ARG_FPGA_SIZE], "size"],
         [args[ARG_FPGA_PACK], "pack"],
-        [args[ARG_FPGA_IDCODE], "idcode"],
     ]:
         # -- Get the fpga property, if exits.
         fpga_config = apio_ctx.fpgas.get(fpga_id)

--- a/apio/managers/scons_args.py
+++ b/apio/managers/scons_args.py
@@ -18,6 +18,7 @@ ARG_FPGA_PART_NUM = "part_num"
 ARG_FPGA_ARCH = "arch"
 ARG_FPGA_TYPE = "type"
 ARG_FPGA_PACK = "pack"
+ARG_FPGA_SPEED = "speed"
 ARG_VERBOSE_ALL = "verbose_all"  # Bool.
 ARG_VERBOSE_YOSYS = "verbose_yosys"  # Bool
 ARG_VERBOSE_PNR = "verbose_pnr"  # Bool
@@ -113,6 +114,7 @@ def process_arguments(
         ARG_FPGA_ARCH: Arg(ARG_FPGA_ARCH, "fpga_arch"),
         ARG_FPGA_TYPE: Arg(ARG_FPGA_TYPE, "fpga_type"),
         ARG_FPGA_PACK: Arg(ARG_FPGA_PACK, "fpga_pack"),
+        ARG_FPGA_SPEED: Arg(ARG_FPGA_SPEED, "fpga_speed"),
         ARG_VERBOSE_ALL: Arg(ARG_VERBOSE_ALL, "verbose_all"),
         ARG_VERBOSE_YOSYS: Arg(ARG_VERBOSE_YOSYS, "verbose_yosys"),
         ARG_VERBOSE_PNR: Arg(ARG_VERBOSE_PNR, "verbose_pnr"),
@@ -161,6 +163,7 @@ def process_arguments(
         [args[ARG_FPGA_ARCH], "arch"],
         [args[ARG_FPGA_TYPE], "type"],
         [args[ARG_FPGA_PACK], "pack"],
+        [args[ARG_FPGA_SPEED], "speed"],
     ]:
         # -- Get the fpga property, if exits.
         fpga_config = apio_ctx.fpgas.get(fpga_id)

--- a/apio/resources/boards.json
+++ b/apio/resources/boards.json
@@ -138,6 +138,7 @@
       "pid": "5740"
     }
   },
+  // https://github.com/mystorm-org/BlackIce-II/wiki/BlackIce-II-Overview
   "blackice-ii": {
     "description": "BlackIce II",
     "fpga": "ice40-hx4k-tq144",
@@ -149,6 +150,7 @@
       "pid": "5740"
     }
   },
+  // https://github.com/folknology/BlackIceMx
   "blackice-mx": {
     "description": "BlackIce MX",
     "fpga": "ice40-hx4k-tq144",
@@ -160,6 +162,7 @@
       "pid": "5740"
     }
   },
+  // https://www.robot-electronics.co.uk/products/fpga/icefun.html
   "icefun": {
     "description": "iceFUN",
     "fpga": "ice40-hx8k-cb132",
@@ -171,6 +174,7 @@
       "pid": "ffee"
     }
   },
+  // https://www.robotshop.com/products/devantech-icewerx-kit-ice40-hx8k-fpga-module
   "icewerx": {
     "legacy_name": "iceWerx",
     "description": "iceWerx",
@@ -183,6 +187,7 @@
       "pid": "ffee"
     }
   },
+  // https://github.com/tinyfpga/TinyFPGA-B-Series
   "tinyfpga-b2": {
     "legacy_name": "TinyFPGA-B2",
     "description": "TinyFPGA B2",
@@ -195,6 +200,7 @@
       "pid": "2100"
     }
   },
+  // https://github.com/tinyfpga/TinyFPGA-BX
   "tinyfpga-bx": {
     "legacy_name": "TinyFPGA-BX",
     "description": "TinyFPGA BX",
@@ -225,6 +231,7 @@
       "desc": "Alhambra II.*"
     }
   },
+  // TBD
   "upduino": {
     "description": "UPDuino v1.0",
     "fpga": "ice40-up5k-sg48",
@@ -239,6 +246,7 @@
       "desc": "Single RS232-HS"
     }
   },
+  // TBD
   "upduino2": {
     "description": "UPDuino v2.0",
     "fpga": "ice40-up5k-sg48",
@@ -253,6 +261,7 @@
       "desc": "Single RS232-HS"
     }
   },
+  // https://github.com/tinyvision-ai-inc/UPduino-v2.1
   "upduino21": {
     "description": "UPduino v2.1",
     "fpga": "ice40-up5k-sg48",
@@ -267,6 +276,7 @@
       "desc": "(?:Single RS232-HS)|(?:UPduino v2.*)"
     }
   },
+  // https://github.com/tinyvision-ai-inc/UPduino-v3.0
   "upduino3": {
     "description": "UPduino v3.0",
     "fpga": "ice40-up5k-sg48",
@@ -281,6 +291,7 @@
       "desc": "UPduino v3\\.0"
     }
   },
+  // https://github.com/tinyvision-ai-inc/UPduino-v3.0
   "upduino31": {
     "description": "UPduino v3.1",
     "fpga": "ice40-up5k-sg48",

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -652,6 +652,9 @@
       "pid": "602b"
     }
   },
+  // FPGA part number need to be resolved.
+  // See https://github.com/FPGAwars/apio/issues/545
+  // See https://github.com/FPGAwars/apio/issues/535 
   "odt-icyblue-feather": {
     "legacy_name": "ODT_IcyBlue_Feather",
     "description": "ODT_IcyBlue_Feather",
@@ -664,6 +667,9 @@
       "pid": "6014"
     }
   },
+  // Candidate for removal.
+  // See https://github.com/FPGAwars/apio/issues/545
+  // See https://github.com/FPGAwars/apio/issues/535 
   "odt-rpga-feather": {
     "legacy_name": "ODT_RPGA_Feather",
     "description": "ODT_RPGA_Feather",

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -4,7 +4,7 @@
   // https://embedded-tek.com/?product=development-fpga-board-pi-sicle
   "pi-sicle": {
     "description": "Pi-sicle",
-    "fpga": "ice40-hx4k-tq144",
+    "fpga": "ice40hx4k-tq144-8k",
     "programmer": {
       "type": "pi-sicle-loader"
     }
@@ -12,7 +12,7 @@
   // https://github.com/FPGAwars/icezum/wiki
   "icezum": {
     "description": "Icezum Alhambra",
-    "fpga": "ice40-hx1k-tq144",
+    "fpga": "ice40hx1k-tq144",
     "programmer": {
       "type": "iceprog"
     },
@@ -27,7 +27,7 @@
   // https://www.latticesemi.com/icestick
   "icestick": {
     "description": "iCEstick Eval Kit",
-    "fpga": "ice40-hx1k-tq144",
+    "fpga": "ice40hx1k-tq144",
     "programmer": {
       "type": "iceprog"
     },
@@ -42,7 +42,7 @@
   // https://www.latticesemi.com/iCEblink40-HX1K
   "iceblink40-hx1k": {
     "description": "iCEblink40-HX1K Eval Kit",
-    "fpga": "ice40-hx1k-vq100",
+    "fpga": "ice40hx1k-vq100",
     "programmer": {
       "type": "iceburn"
     },
@@ -54,7 +54,7 @@
   // https://nandland.com/the-go-board/
   "go-board": {
     "description": "The Go Board",
-    "fpga": "ice40-hx1k-vq100",
+    "fpga": "ice40hx1k-vq100",
     "programmer": {
       "type": "iceprog"
     },
@@ -70,7 +70,7 @@
   "ice40-hx8k": {
     "legacy_name": "iCE40-HX8K",
     "description": "iCE40-HX8K Breakout Board",
-    "fpga": "ice40-hx8k-ct256",
+    "fpga": "ice40hx8k-ct256",
     "programmer": {
       "type": "iceprog"
     },
@@ -86,7 +86,7 @@
   "ice40-hx8k-evb": {
     "legacy_name": "iCE40-HX8K-EVB",
     "description": "iCE40HX8K-EVB",
-    "fpga": "ice40-hx8k-ct256",
+    "fpga": "ice40hx8k-ct256",
     "programmer": {
       "type": "iceprogduino"
     },
@@ -99,7 +99,7 @@
   "ice40-hx1k-evb": {
     "legacy_name": "iCE40-HX1K-EVB",
     "description": "ICE40HX1K-EVB",
-    "fpga": "ice40-hx1k-vq100",
+    "fpga": "ice40hx1k-vq100",
     "programmer": {
       "type": "iceprogduino"
     },
@@ -111,7 +111,7 @@
   // https://fpgalibre.sourceforge.net/Kefir/
   "kefir": {
     "description": "Kéfir I iCE40-HX4K",
-    "fpga": "ice40-hx4k-tq144",
+    "fpga": "ice40hx4k-tq144-8k",
     "programmer": {
       "type": "iceprog",
       "extra_args": "-I B"
@@ -127,7 +127,7 @@
   // URL: TBD
   "blackice": {
     "description": "BlackIce",
-    "fpga": "ice40-hx4k-tq144",
+    "fpga": "ice40hx4k-tq144-8k",
     "programmer": {
       "type": "blackiceprog"
     },
@@ -139,7 +139,7 @@
   // https://github.com/mystorm-org/BlackIce-II/wiki/BlackIce-II-Overview
   "blackice-ii": {
     "description": "BlackIce II",
-    "fpga": "ice40-hx4k-tq144",
+    "fpga": "ice40hx4k-tq144-8k",
     "programmer": {
       "type": "blackiceprog"
     },
@@ -151,7 +151,7 @@
   // https://github.com/folknology/BlackIceMx
   "blackice-mx": {
     "description": "BlackIce MX",
-    "fpga": "ice40-hx4k-tq144",
+    "fpga": "ice40hx4k-tq144-8k",
     "programmer": {
       "type": "blackiceprog"
     },
@@ -163,7 +163,7 @@
   // https://www.robot-electronics.co.uk/products/fpga/icefun.html
   "icefun": {
     "description": "iceFUN",
-    "fpga": "ice40-hx8k-cb132",
+    "fpga": "ice40hx8k-cb132",
     "programmer": {
       "type": "icefunprog"
     },
@@ -176,7 +176,7 @@
   "icewerx": {
     "legacy_name": "iceWerx",
     "description": "iceWerx",
-    "fpga": "ice40-hx8k-cb132",
+    "fpga": "ice40hx8k-cb132",
     "programmer": {
       "type": "icefunprog"
     },
@@ -189,7 +189,7 @@
   "tinyfpga-b2": {
     "legacy_name": "TinyFPGA-B2",
     "description": "TinyFPGA B2",
-    "fpga": "ice40-lp8k-cm81",
+    "fpga": "ice40lp8k-cm81",
     "programmer": {
       "type": "tinyfpgab"
     },
@@ -202,7 +202,7 @@
   "tinyfpga-bx": {
     "legacy_name": "TinyFPGA-BX",
     "description": "TinyFPGA BX",
-    "fpga": "ice40-lp8k-cm81",
+    "fpga": "ice40lp8k-cm81",
     "programmer": {
       "type": "tinyprog"
     },
@@ -217,7 +217,7 @@
   // https://github.com/FPGAwars/Alhambra-II-FPGA
   "alhambra-ii": {
     "description": "Alhambra II",
-    "fpga": "ice40-hx4k-tq144",
+    "fpga": "ice40hx4k-tq144-8k",
     "programmer": {
       "type": "iceprog"
     },
@@ -232,7 +232,7 @@
   // TBD
   "upduino": {
     "description": "UPDuino v1.0",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -247,7 +247,7 @@
   // TBD
   "upduino2": {
     "description": "UPDuino v2.0",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -262,7 +262,7 @@
   // https://github.com/tinyvision-ai-inc/UPduino-v2.1
   "upduino21": {
     "description": "UPduino v2.1",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -277,7 +277,7 @@
   // https://github.com/tinyvision-ai-inc/UPduino-v3.0
   "upduino3": {
     "description": "UPduino v3.0",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -292,7 +292,7 @@
   // https://github.com/tinyvision-ai-inc/UPduino-v3.0
   "upduino31": {
     "description": "UPduino v3.1",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -307,7 +307,7 @@
   "icebreaker": {
     "legacy_name": "iCEBreaker",
     "description": "iCEBreaker",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -322,7 +322,7 @@
   "icebreaker-bitsy0": {
     "legacy_name": "iCEBreaker-bitsy0",
     "description": "iCEBreaker bitsy",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "dfu"
     },
@@ -337,7 +337,7 @@
   "icebreaker-bitsy1": {
     "legacy_name": "iCEBreaker-bitsy1",
     "description": "iCEBreaker bitsy",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "dfu"
     },
@@ -351,7 +351,7 @@
   },
   "fpga101": {
     "description": "FPGA 101 - Workshop Badge",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -366,7 +366,7 @@
   "ice40-up5k": {
     "legacy_name": "iCE40-UP5K",
     "description": "iCE40 UltraPlus Breakout Board",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -381,7 +381,7 @@
   "ice40-ul1k-breakout": {
     "legacy_name": "iCE40-UL1K-Breakout",
     "description": "iCE40-UL1K UltraLite Breakout Board",
-    "fpga": "ice40-ul1k-cm36a",
+    "fpga": "ice40ul1k-cm36a",
     "programmer": {
       "type": "iceprog"
     },
@@ -396,7 +396,7 @@
   "tinyfpga-ex-rev1": {
     "legacy_name": "TinyFPGA-EX-rev1",
     "description": "TinyFPGA EX rev 1",
-    "fpga": "ecp5-lfe5u-85f-csfbga285",
+    "fpga": "lfe5u-85f-6mg285c",
     "programmer": {
       "type": "tinyprog"
     },
@@ -411,7 +411,7 @@
   "tinyfpga-ex-rev2": {
     "legacy_name": "TinyFPGA-EX-rev2",
     "description": "TinyFPGA EX rev 2",
-    "fpga": "ecp5-lfe5um5g-85f-csfbga285",
+    "fpga": "lfe5um5g-85f-8mg285c",
     "programmer": {
       "type": "tinyprog"
     },
@@ -425,7 +425,7 @@
   },
   "ulx3s-12f": {
     "description": "ULX3S",
-    "fpga": "ecp5-lfe5u-12f-cabga381",
+    "fpga": "lfe5u-12f-6bg381c",
     "programmer": {
       "type": "fujprog"
     },
@@ -436,7 +436,7 @@
   },
   "ulx3s-25f": {
     "description": "ULX3S",
-    "fpga": "ecp5-lfe5u-25f-cabga381",
+    "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
       "type": "fujprog"
     },
@@ -447,7 +447,7 @@
   },
   "ulx3s-45f": {
     "description": "ULX3S",
-    "fpga": "ecp5-lfe5u-45f-cabga381",
+    "fpga": "lfe5u-45f-6bg381c",
     "programmer": {
       "type": "fujprog"
     },
@@ -458,7 +458,7 @@
   },
   "ulx3s-85f": {
     "description": "ULX3S",
-    "fpga": "ecp5-lfe5u-85f-cabga381",
+    "fpga": "lfe5u-85f-6bg381c",
     "programmer": {
       "type": "fujprog"
     },
@@ -469,7 +469,7 @@
   },
   "orangecrab-r02-25f": {
     "description": "OrangeCrab r0.2",
-    "fpga": "ecp5-lfe5u-25f-csfbga285",
+    "fpga": "lfe5u-25f-6mg285c",
     "programmer": {
       "type": "dfu"
     },
@@ -483,7 +483,7 @@
   },
   "orangecrab-r02-85f": {
     "description": "OrangeCrab r0.2",
-    "fpga": "ecp5-lfe5u-85f-csfbga285",
+    "fpga": "lfe5u-85f-6mg285c",
     "programmer": {
       "type": "dfu"
     },
@@ -498,7 +498,7 @@
   "butterstick-r10-2g-85k": {
     "legacy_name": "Butterstick-r10-2g-85k",
     "description": "butterstick r1.0",
-    "fpga": "ecp5-lfe5um5g-85f-cabga381",
+    "fpga": "lfe5um5g-85f-8bg381c",
     "programmer": {
       "type": "dfu",
       "extra_args": "--reset"
@@ -514,7 +514,7 @@
   "butterstick-r10-2g-85k-ft2232h": {
     "legacy_name": "Butterstick-r10-2g-85k_(FT2232H)",
     "description": "butterstick r1.0",
-    "fpga": "ecp5-lfe5um5g-85f-cabga381",
+    "fpga": "lfe5um5g-85f-8bg381c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -522,14 +522,14 @@
   "butterstick-r10-2g-85k-ft232h": {
     "legacy_name": "Butterstick-r10-2g-85k_(FT232H)",
     "description": "butterstick r1.0",
-    "fpga": "ecp5-lfe5um5g-85f-cabga381",
+    "fpga": "lfe5um5g-85f-8bg381c",
     "programmer": {
       "type": "openfpgaloader-ft232"
     }
   },
   "versa": {
     "description": "ECP5 Versa",
-    "fpga": "ecp5-lfe5um-45f-cabga381",
+    "fpga": "lfe5um-45f-6bg381c",
     "programmer": {
       "type": "iceprog"
     },
@@ -544,7 +544,7 @@
   "alchitry-cu": {
     "legacy_name": "Alchitry-Cu",
     "description": "Alchitry Cu Development Board",
-    "fpga": "ice40-hx8k-cb132",
+    "fpga": "ice40hx8k-cb132",
     "programmer": {
       "type": "iceprog"
     },
@@ -558,7 +558,7 @@
   },
   "fomu": {
     "description": "Fomu",
-    "fpga": "ice40-up5k-uwg30",
+    "fpga": "ice40up5k-uwg30",
     "programmer": {
       "type": "dfu"
     },
@@ -572,7 +572,7 @@
   },
   "arice1": {
     "description": "ARiCE v1",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -586,7 +586,7 @@
   },
   "edu-ciaa-fpga": {
     "description": "EDU-CIAA-FPGA",
-    "fpga": "ice40-hx4k-tq144",
+    "fpga": "ice40hx4k-tq144-8k",
     "programmer": {
       "type": "iceprog"
     },
@@ -601,7 +601,7 @@
   "icesugar-nano": {
     "legacy_name": "iCESugar-nano",
     "description": "iCESugar-nano",
-    "fpga": "ice40-lp1k-cm36",
+    "fpga": "ice40lp1k-cm36",
     "programmer": {
       "type": "icesprog"
     },
@@ -613,7 +613,7 @@
   "ok-ice40pro": {
     "legacy_name": "OK-iCE40Pro",
     "description": "OK-iCE40Pro",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },
@@ -627,7 +627,7 @@
   },
   "pico-ice": {
     "description": "pico-ice",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "dfu",
       "extra_args": "--reset"
@@ -643,7 +643,7 @@
   "icesugar-1-5": {
     "legacy_name": "iCESugar_1_5",
     "description": "iCESugar v1.5",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "icesprog"
     },
@@ -660,7 +660,7 @@
   "odt-icyblue-feather": {
     "legacy_name": "ODT_IcyBlue_Feather",
     "description": "ODT_IcyBlue_Feather",
-    "fpga": "ice40-u4k-sg48",
+    "fpga": "ice40u4k-sg48",
     "programmer": {
       "type": "icesprog"
     },
@@ -672,7 +672,7 @@
   "colorlight-5a-75b-v61": {
     "legacy_name": "ColorLight-5A-75B-V61",
     "description": "ColorLight-5A-75B-V61",
-    "fpga": "ecp5-lfe5u-25f-cabga381",
+    "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -680,7 +680,7 @@
   "colorlight-5a-75b-v7": {
     "legacy_name": "ColorLight-5A-75B-V7",
     "description": "ColorLight-5A-75B-V7",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -688,7 +688,7 @@
   "colorlight-5a-75b-v8": {
     "legacy_name": "ColorLight-5A-75B-V8",
     "description": "ColorLight-5A-75B-V8",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -696,7 +696,7 @@
   "colorlight-5a-75e-v6": {
     "legacy_name": "ColorLight-5A-75E-V6",
     "description": "ColorLight-5A-75E-V6",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -704,7 +704,7 @@
   "colorlight-5a-75e-v71-ft2232h": {
     "legacy_name": "ColorLight-5A-75E-V71_(FT2232H)",
     "description": "ColorLight-5A-75E-V71",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -712,7 +712,7 @@
   "colorlight-5a-75e-v71-ft232h": {
     "legacy_name": "ColorLight-5A-75E-V71_(FT232H)",
     "description": "ColorLight-5A-75E-V71",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft232"
     }
@@ -720,7 +720,7 @@
   "colorlight-5a-75e-v71-usb-blaster": {
     "legacy_name": "ColorLight-5A-75E-V71_(USB-Blaster)",
     "description": "ColorLight-5A-75E-V71",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-usb-blaster"
     }
@@ -728,7 +728,7 @@
   "colorlight-i5-v7-0-ft2232h": {
     "legacy_name": "ColorLight-i5-v7.0_(FT2232H)",
     "description": "ColorLight-i5",
-    "fpga": "ecp5-lfe5u-25f-cabga381",
+    "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -736,7 +736,7 @@
   "colorlight-i5-v7-0-ft232h": {
     "legacy_name": "ColorLight-i5-v7.0_(FT232H)",
     "description": "ColorLight-i5",
-    "fpga": "ecp5-lfe5u-25f-cabga381",
+    "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-ft232"
     }
@@ -744,7 +744,7 @@
   "colorlight-i5-v7-0-usb-blaster": {
     "legacy_name": "ColorLight-i5-v7.0_(USB-Blaster)",
     "description": "ColorLight-i5",
-    "fpga": "ecp5-lfe5u-25f-cabga381",
+    "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-usb-blaster"
     }
@@ -752,7 +752,7 @@
   "icesugar-pro-ft2232h": {
     "legacy_name": "iCESugar-Pro_(FT2232H)",
     "description": "ColorLight-i5",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -760,7 +760,7 @@
   "icesugar-pro-ft232h": {
     "legacy_name": "iCESugar-Pro_(FT232H)",
     "description": "ColorLight-i5",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft232"
     }
@@ -768,7 +768,7 @@
   "icesugar-pro-usb-blaster": {
     "legacy_name": "iCESugar-Pro_(USB-Blaster)",
     "description": "ColorLight-i5",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-usb-blaster"
     }
@@ -776,7 +776,7 @@
   "fleafpga-ohm-ft2232h": {
     "legacy_name": "FleaFPGA-Ohm_(FT2232H)",
     "description": "FleaFPGA-Ohm_(FT2232H)",
-    "fpga": "ecp5-lfe5u-25f-cabga381",
+    "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -784,7 +784,7 @@
   "fleafpga-ohm-ft232h": {
     "legacy_name": "FleaFPGA-Ohm_(FT232H)",
     "description": "FleaFPGA-Ohm_(FT232H)",
-    "fpga": "ecp5-lfe5u-25f-cabga381",
+    "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-ft232"
     }
@@ -792,7 +792,7 @@
   "fleafpga-ohm-usb-blaster": {
     "legacy_name": "FleaFPGA-Ohm_(USB-Blaster)",
     "description": "FleaFPGA-Ohm_(USB-Blaster)",
-    "fpga": "ecp5-lfe5u-25f-cabga381",
+    "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-usb-blaster"
     }
@@ -800,7 +800,7 @@
   "ecp5-mini-12": {
     "legacy_name": "ECP5-Mini-12",
     "description": "ECP5-Mini-12",
-    "fpga": "ecp5-lfe5u-12f-cabga256",
+    "fpga": "lfe5u-12f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -808,7 +808,7 @@
   "ecp5-mini-25": {
     "legacy_name": "ECP5-Mini-25",
     "description": "ECP5-Mini-12",
-    "fpga": "ecp5-lfe5u-25f-cabga256",
+    "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -816,7 +816,7 @@
   "ecp5-evaluation-board": {
     "legacy_name": "ECP5-Evaluation-Board",
     "description": "ECP5-Evaluation-Board",
-    "fpga": "ecp5-lfe5um5g-85f-cabga381",
+    "fpga": "lfe5um5g-85f-8bg381c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -824,7 +824,7 @@
   "colorlight-i9-v7-2-ft2232h": {
     "legacy_name": "ColorLight-i9-v7.2_(FT2232H)",
     "description": "ColorLight-i9",
-    "fpga": "ecp5-lfe5u-45f-cabga381",
+    "fpga": "lfe5u-45f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }
@@ -832,7 +832,7 @@
   "colorlight-i9-v7-2-ft232h": {
     "legacy_name": "ColorLight-i9-v7.2_(FT232H)",
     "description": "ColorLight-i9",
-    "fpga": "ecp5-lfe5u-45f-cabga381",
+    "fpga": "lfe5u-45f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-ft232"
     }
@@ -840,7 +840,7 @@
   "colorlight-i9-v7-2-usb-blaster": {
     "legacy_name": "ColorLight-i9-v7.2_(USB-Blaster)",
     "description": "ColorLight-i9",
-    "fpga": "ecp5-lfe5u-45f-cabga381",
+    "fpga": "lfe5u-45f-6bg381c",
     "programmer": {
       "type": "openfpgaloader-usb-blaster"
     }
@@ -848,7 +848,7 @@
   "thetamachines-eth4k": {
     "legacy_name": "ThetaMachines-ETH4K",
     "description": "Theta Machines ETH4K",
-    "fpga": "ice40-hx4k-tq144",
+    "fpga": "ice40hx4k-tq144-8k",
     "programmer": {
       "type": "iceprog"
     },
@@ -923,14 +923,14 @@
   "cynthion-r1-4": {
     "legacy_name": "Cynthion-r1.4",
     "description": "Cynthion r1.4",
-    "fpga": "ecp5-lfe5u-12f-cabga256",
+    "fpga": "lfe5u-12f-6bg256c",
     "programmer": {
       "type": "apollo"
     }
   },
   "mimas-ecp5-mini": {
     "description": "Mimas ECP5 Mini",
-    "fpga": "ecp5-lfe5u-45f-cabga256",
+    "fpga": "lfe5u-45f-6bg256c",
     "programmer": {
       "type": "openfpgaloader-ft2232"
     }

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -1,7 +1,5 @@
 // Apio boards definitions.
 //
-// Visual Studio Code note: set language model to 'jsonc' to avoid flagging 
-// comments as errors.
 {
   // https://embedded-tek.com/?product=development-fpga-board-pi-sicle
   "pi-sicle": {

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -304,6 +304,7 @@
       "desc": "UPduino v3\\.1"
     }
   },
+  // https://github.com/icebreaker-fpga/icebreaker
   "icebreaker": {
     "legacy_name": "iCEBreaker",
     "description": "iCEBreaker",
@@ -319,6 +320,7 @@
       "desc": "(?:Dual RS232-HS)|(?:iCEBreaker.*)"
     }
   },
+  // https://github.com/icebreaker-fpga/icebreaker
   "icebreaker-bitsy0": {
     "legacy_name": "iCEBreaker-bitsy0",
     "description": "iCEBreaker bitsy",
@@ -334,6 +336,7 @@
       "desc": "iCEBreaker bitsy v0.*"
     }
   },
+  // https://github.com/icebreaker-fpga/icebreaker
   "icebreaker-bitsy1": {
     "legacy_name": "iCEBreaker-bitsy1",
     "description": "iCEBreaker bitsy",
@@ -349,6 +352,7 @@
       "desc": "iCEBreaker bitsy1.*"
     }
   },
+  // TBD
   "fpga101": {
     "description": "FPGA 101 - Workshop Badge",
     "fpga": "ice40up5k-sg48",
@@ -363,6 +367,7 @@
       "desc": "Single RS232-HS"
     }
   },
+  // https://www.latticesemi.com/Products/DevelopmentBoardsAndKits/iCE40UltraPlusBreakoutBoard
   "ice40-up5k": {
     "legacy_name": "iCE40-UP5K",
     "description": "iCE40 UltraPlus Breakout Board",
@@ -378,6 +383,7 @@
       "desc": "(?:USB <-> Serial Converter)|(?:Lattice iCE40UP5K Breakout)"
     }
   },
+  // https://www.latticesemi.com/products/developmentboardsandkits/ice40ultralitebreakoutboard
   "ice40-ul1k-breakout": {
     "legacy_name": "iCE40-UL1K-Breakout",
     "description": "iCE40-UL1K UltraLite Breakout Board",

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -667,17 +667,6 @@
       "pid": "6014"
     }
   },
-  // Candidate for removal.
-  // See https://github.com/FPGAwars/apio/issues/545
-  // See https://github.com/FPGAwars/apio/issues/535 
-  "odt-rpga-feather": {
-    "legacy_name": "ODT_RPGA_Feather",
-    "description": "ODT_RPGA_Feather",
-    "fpga": "ice40-u4k-sg48",
-    "programmer": {
-      "type": "mcu"
-    }
-  },
   "colorlight-5a-75b-v61": {
     "legacy_name": "ColorLight-5A-75B-V61",
     "description": "ColorLight-5A-75B-V61",

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -655,6 +655,8 @@
   // FPGA part number need to be resolved.
   // See https://github.com/FPGAwars/apio/issues/545
   // See https://github.com/FPGAwars/apio/issues/535 
+  //
+  // https://github.com/Oak-Development-Technologies/IcyBlue
   "odt-icyblue-feather": {
     "legacy_name": "ODT_IcyBlue_Feather",
     "description": "ODT_IcyBlue_Feather",

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -522,7 +522,8 @@
     "description": "butterstick r1.0",
     "fpga": "lfe5um5g-85f-8bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "butterstick-r10-2g-85k-ft232h": {
@@ -530,7 +531,8 @@
     "description": "butterstick r1.0",
     "fpga": "lfe5um5g-85f-8bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft232 -v --file-type bin"
     }
   },
   "versa": {
@@ -676,7 +678,8 @@
     "description": "ColorLight-5A-75B-V61",
     "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "colorlight-5a-75b-v7": {
@@ -684,7 +687,8 @@
     "description": "ColorLight-5A-75B-V7",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "colorlight-5a-75b-v8": {
@@ -692,7 +696,8 @@
     "description": "ColorLight-5A-75B-V8",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "colorlight-5a-75e-v6": {
@@ -700,7 +705,8 @@
     "description": "ColorLight-5A-75E-V6",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "colorlight-5a-75e-v71-ft2232h": {
@@ -708,7 +714,8 @@
     "description": "ColorLight-5A-75E-V71",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "colorlight-5a-75e-v71-ft232h": {
@@ -716,7 +723,8 @@
     "description": "ColorLight-5A-75E-V71",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft232 -v --file-type bin"
     }
   },
   "colorlight-5a-75e-v71-usb-blaster": {
@@ -724,7 +732,8 @@
     "description": "ColorLight-5A-75E-V71",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-usb-blaster"
+      "type": "openfpgaloader",
+      "args": "-c usb-blaster -v --file-type bin"
     }
   },
   "colorlight-i5-v7-0-ft2232h": {
@@ -732,7 +741,8 @@
     "description": "ColorLight-i5",
     "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "colorlight-i5-v7-0-ft232h": {
@@ -740,7 +750,8 @@
     "description": "ColorLight-i5",
     "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft232 -v --file-type bin"
     }
   },
   "colorlight-i5-v7-0-usb-blaster": {
@@ -748,7 +759,8 @@
     "description": "ColorLight-i5",
     "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-usb-blaster"
+      "type": "openfpgaloader",
+      "args": "-c usb-blaster -v --file-type bin"
     }
   },
   "icesugar-pro-ft2232h": {
@@ -756,7 +768,8 @@
     "description": "ColorLight-i5",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "icesugar-pro-ft232h": {
@@ -764,7 +777,8 @@
     "description": "ColorLight-i5",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft232 -v --file-type bin"
     }
   },
   "icesugar-pro-usb-blaster": {
@@ -772,7 +786,8 @@
     "description": "ColorLight-i5",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-usb-blaster"
+      "type": "openfpgaloader",
+      "args": "-c usb-blaster -v --file-type bin"
     }
   },
   "fleafpga-ohm-ft2232h": {
@@ -780,7 +795,8 @@
     "description": "FleaFPGA-Ohm_(FT2232H)",
     "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "fleafpga-ohm-ft232h": {
@@ -788,7 +804,8 @@
     "description": "FleaFPGA-Ohm_(FT232H)",
     "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft232 -v --file-type bin"
     }
   },
   "fleafpga-ohm-usb-blaster": {
@@ -796,7 +813,8 @@
     "description": "FleaFPGA-Ohm_(USB-Blaster)",
     "fpga": "lfe5u-25f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-usb-blaster"
+      "type": "openfpgaloader",
+      "args": "-c usb-blaster -v --file-type bin"
     }
   },
   "ecp5-mini-12": {
@@ -804,7 +822,8 @@
     "description": "ECP5-Mini-12",
     "fpga": "lfe5u-12f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "ecp5-mini-25": {
@@ -812,7 +831,8 @@
     "description": "ECP5-Mini-12",
     "fpga": "lfe5u-25f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "ecp5-evaluation-board": {
@@ -820,7 +840,8 @@
     "description": "ECP5-Evaluation-Board",
     "fpga": "lfe5um5g-85f-8bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "colorlight-i9-v7-2-ft2232h": {
@@ -828,7 +849,8 @@
     "description": "ColorLight-i9",
     "fpga": "lfe5u-45f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   },
   "colorlight-i9-v7-2-ft232h": {
@@ -836,7 +858,8 @@
     "description": "ColorLight-i9",
     "fpga": "lfe5u-45f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-ft232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft232 -v --file-type bin"
     }
   },
   "colorlight-i9-v7-2-usb-blaster": {
@@ -844,7 +867,8 @@
     "description": "ColorLight-i9",
     "fpga": "lfe5u-45f-6bg381c",
     "programmer": {
-      "type": "openfpgaloader-usb-blaster"
+      "type": "openfpgaloader",
+      "args": "-c usb-blaster -v --file-type bin"
     }
   },
   "thetamachines-eth4k": {
@@ -934,7 +958,8 @@
     "description": "Mimas ECP5 Mini",
     "fpga": "lfe5u-45f-6bg256c",
     "programmer": {
-      "type": "openfpgaloader-ft2232"
+      "type": "openfpgaloader",
+      "extra_args": "-c ft2232 -v --file-type bin"
     }
   }
 }

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -652,15 +652,11 @@
       "pid": "602b"
     }
   },
-  // FPGA part number need to be resolved.
-  // See https://github.com/FPGAwars/apio/issues/545
-  // See https://github.com/FPGAwars/apio/issues/535 
-  //
   // https://github.com/Oak-Development-Technologies/IcyBlue
   "odt-icyblue-feather": {
     "legacy_name": "ODT_IcyBlue_Feather",
     "description": "ODT_IcyBlue_Feather",
-    "fpga": "ice40u4k-sg48",
+    "fpga": "ice5lp4k-sg48",
     "programmer": {
       "type": "icesprog"
     },

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -1,7 +1,5 @@
-// General definitions regarding remote config.
+// General config parameters.
 //
-// TODO: Find a better place or file name for this data.
-
 {
   // URL of the apio remote config file. The placeholder %v is replaced with
   // apio's version.

--- a/apio/resources/distribution.jsonc
+++ b/apio/resources/distribution.jsonc
@@ -1,5 +1,6 @@
-// Visual Studio Code note: set language model to 'jsonc' to avoid flagging 
-// comments as errors.
+// General definitions regarding remote config.
+//
+// TODO: Find a better place or file name for this data.
 
 {
   // URL of the apio remote config file. The placeholder %v is replaced with

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -288,17 +288,6 @@
     "pack": "uwg30"
   },
   // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
-  // This fpga is currently not used.
-  // See https://github.com/FPGAwars/apio/issues/545
-  // See https://github.com/FPGAwars/apio/issues/535 
-  "ice40u4k-uwg30": {
-    "part_num": "ICE40U4K-UWG30",
-    "arch": "ice40",
-    "size": "4k",
-    "type": "u4k",
-    "pack": "uwg30"
-  },
-  // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
   // This fpga is used by the boards 'odt-icyblue-feather'.
   // See https://github.com/FPGAwars/apio/issues/545
   // See https://github.com/FPGAwars/apio/issues/535 

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -530,41 +530,34 @@
   //        FPGA_TYPE arg that is passed to nextpnr-himbaechel and to 
   //        gowin_pack. See plugin_gowin.py for details.
   //
-  //    'pack': Unused.
-  //
   "gw1n-lv1qn48c6-i5": {
     "part_num": "GW1N-LV1QN48C6/I5",
     "arch": "gowin",
     "size": "1k",
-    "type": "GW1N-1",
-    "pack": "QN48"
+    "type": "GW1N-1"
   },
   "gw1nz-lv1qn48c6-i5": {
     "part_num": "GW1NZ-LV1QN48C6/I5",
     "arch": "gowin",
     "size": "1k",
-    "type": "GW1NZ-1",
-    "pack": "QN48"
+    "type": "GW1NZ-1"
   },
   "gw1nsr-lv4cqn48pc7-i6": {
     "part_num": "GW1NSR-LV4CQN48PC7/I6",
     "arch": "gowin",
     "size": "4k",
-    "type": "GW1NS-4",
-    "pack": "QN48P"
+    "type": "GW1NS-4"
   },
   "gw1nr-lv9qn88pc6-i5": {
     "part_num": "GW1NR-LV9QN88PC6/I5",
     "arch": "gowin",
     "size": "9k",
-    "type": "GW1N-9C",
-    "pack": "QN88P"
+    "type": "GW1N-9C"
   },
   "gw2ar-lv18qn88c8-i7": {
     "part_num": "GW2AR-LV18QN88C8/I7",
     "arch": "gowin",
     "size": "20k",
-    "type": "GW2A-18C",
-    "pack": "QN88"
+    "type": "GW2A-18C"
   }
 }

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -266,260 +266,297 @@
   // ============= ECP5
   //
   // ARCHITECTURE-SPECIFIC-FIELDS: 
-  //    'type': TBD
-  //    'pack': TBD
+  //    'type':  TBD
+  //    'pack':  TBD
+  //    'speed': TBD
   //
   "ecp5-lfe5u-12f-cabga256": {
     "part_num": "LFE5U-12F-6BG256C",
     "arch": "ecp5",
     "size": "12k",
     "type": "12k",
-    "pack": "CABGA256"
+    "pack": "CABGA256",
+    "speed": "6"
   },
   "ecp5-lfe5u-12f-cabga381": {
     "part_num": "LFE5U-12F-6BG381C",
     "arch": "ecp5",
     "size": "12k",
     "type": "12k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "6"
   },
   "ecp5-lfe5u-12f-csfbga285": {
     "part_num": "LFE5U-12F-6MG285C",
     "arch": "ecp5",
     "size": "12k",
     "type": "12k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "6"
   },
   "ecp5-lfe5u-25f-cabga256": {
     "part_num": "LFE5U-25F-6BG256C",
     "arch": "ecp5",
     "size": "25k",
     "type": "25k",
-    "pack": "CABGA256"
+    "pack": "CABGA256",
+    "speed": "6"
   },
   "ecp5-lfe5u-25f-cabga381": {
     "part_num": "LFE5U-25F-6BG381C",
     "arch": "ecp5",
     "size": "25k",
     "type": "25k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "6"
   },
   "ecp5-lfe5u-25f-csfbga285": {
     "part_num": "LFE5U-25F-6MG285C",
     "arch": "ecp5",
     "size": "25k",
     "type": "25k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "6"
   },
   "ecp5-lfe5u-45f-cabga256": {
     "part_num": "LFE5U-45F-6BG256C",
     "arch": "ecp5",
     "size": "45k",
     "type": "45k",
-    "pack": "CABGA256"
+    "pack": "CABGA256",
+    "speed": "6"
   },
   "ecp5-lfe5u-45f-cabga381": {
     "part_num": "LFE5U-45F-6BG381C",
     "arch": "ecp5",
     "size": "45k",
     "type": "45k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "6"
   },
   "ecp5-lfe5u-45f-cabga554": {
     "part_num": "LFE5U-45F-6BG554C",
     "arch": "ecp5",
     "size": "45k",
     "type": "45k",
-    "pack": "CABGA554"
+    "pack": "CABGA554",
+    "speed": "6"
   },
   "ecp5-lfe5u-45f-csfbga285": {
     "part_num": "LFE5U-45F-6MG285C",
     "arch": "ecp5",
     "size": "45k",
     "type": "45k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "6"
   },
   "ecp5-lfe5u-85f-cabga381": {
     "part_num": "LFE5U-85F-6BG381C",
     "arch": "ecp5",
     "size": "85k",
     "type": "85k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "6"
   },
   "ecp5-lfe5u-85f-cabga554": {
     "part_num": "LFE5U-85F-6BG554C",
     "arch": "ecp5",
     "size": "85k",
     "type": "85k",
-    "pack": "CABGA554"
+    "pack": "CABGA554",
+    "speed": "6"
   },
   "ecp5-lfe5u-85f-cabga756": {
     "part_num": "LFE5U-85F-6BG756C",
     "arch": "ecp5",
     "size": "85k",
     "type": "85k",
-    "pack": "CABGA756"
+    "pack": "CABGA756",
+    "speed": "6"
   },
   "ecp5-lfe5u-85f-csfbga285": {
     "part_num": "LFE5U-85F-6MG285C",
     "arch": "ecp5",
     "size": "85k",
     "type": "85k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "6"
   },
   "ecp5-lfe5um-25f-cabga256": {
     "part_num": "LFE5UM-25F-6BG256C",
     "arch": "ecp5",
     "size": "25k",
     "type": "um-25k",
-    "pack": "CABGA256"
+    "pack": "CABGA256",
+    "speed": "6"
   },
   "ecp5-lfe5um-25f-cabga381": {
     "part_num": "LFE5UM-25F-6BG381C",
     "arch": "ecp5",
     "size": "25k",
     "type": "um-25k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "6"
   },
   "ecp5-lfe5um-25f-csfbga285": {
     "part_num": "LFE5UM-25F-6MG285C",
     "arch": "ecp5",
     "size": "25k",
     "type": "um-25k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "6"
   },
   "ecp5-lfe5um-45f-cabga256": {
     "part_num": "LFE5UM-45F-6BG256C",
     "arch": "ecp5",
     "size": "45k",
     "type": "um-45k",
-    "pack": "CABGA256"
+    "pack": "CABGA256",
+    "speed": "6"
   },
   "ecp5-lfe5um-45f-cabga381": {
     "part_num": "LFE5UM-45F-6BG381C",
     "arch": "ecp5",
     "size": "45k",
     "type": "um-45k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "6"
   },
   "ecp5-lfe5um-45f-cabga554": {
     "part_num": "LFE5UM-45F-6BG554C",
     "arch": "ecp5",
     "size": "45k",
     "type": "um-45k",
-    "pack": "CABGA554"
+    "pack": "CABGA554",
+    "speed": "6"
   },
   "ecp5-lfe5um-45f-csfbga285": {
     "part_num": "LFE5UM-45F-6MG285C",
     "arch": "ecp5",
     "size": "45k",
     "type": "um-45k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "6"
   },
   "ecp5-lfe5um-85f-cabga381": {
     "part_num": "LFE5UM-85F-6BG381C",
     "arch": "ecp5",
     "size": "85k",
     "type": "um-85k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "6"
   },
   "ecp5-lfe5um-85f-cabga554": {
     "part_num": "LFE5UM-85F-6BG554C",
     "arch": "ecp5",
     "size": "85k",
     "type": "um-85k",
-    "pack": "CABGA554"
+    "pack": "CABGA554",
+    "speed": "6"
   },
   "ecp5-lfe5um-85f-cabga756": {
     "part_num": "LFE5UM-85F-6BG756C",
     "arch": "ecp5",
     "size": "85k",
     "type": "um-85k",
-    "pack": "CABGA756"
+    "pack": "CABGA756",
+    "speed": "6"
   },
   "ecp5-lfe5um-85f-csfbga285": {
     "part_num": "LFE5UM-85F-6MG285C",
     "arch": "ecp5",
     "size": "85k",
     "type": "um-85k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "6"
   },
   "ecp5-lfe5um5g-25f-cabga256": {
     "part_num": "LFE5UM5G-25F-8BG256C",
     "arch": "ecp5",
     "size": "25k",
     "type": "um5g-25k",
-    "pack": "CABGA256"
+    "pack": "CABGA256",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-25f-cabga381": {
     "part_num": "LFE5UM5G-25F-8BG381C",
     "arch": "ecp5",
     "size": "25k",
     "type": "um5g-25k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-25f-csfbga285": {
     "part_num": "LFE5UM5G-25F-8MG285C",
     "arch": "ecp5",
     "size": "25k",
     "type": "um5g-25k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-45f-cabga256": {
     "part_num": "LFE5UM5G-45F-8BG256C",
     "arch": "ecp5",
     "size": "45k",
     "type": "um5g-45k",
-    "pack": "CABGA256"
+    "pack": "CABGA256",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-45f-cabga381": {
     "part_num": "LFE5UM5G-45F-8BG381C",
     "arch": "ecp5",
     "size": "45k",
     "type": "um5g-45k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-45f-cabga554": {
     "part_num": "LFE5UM5G-45F-8BG554C",
     "arch": "ecp5",
     "size": "45k",
     "type": "um5g-45k",
-    "pack": "CABGA554"
+    "pack": "CABGA554",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-45f-csfbga285": {
     "part_num": "LFE5UM5G-45F-8MG285C",
     "arch": "ecp5",
     "size": "45k",
     "type": "um5g-45k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-85f-cabga381": {
     "part_num": "LFE5UM5G-85F-8BG381C",
     "arch": "ecp5",
     "size": "85k",
     "type": "um5g-85k",
-    "pack": "CABGA381"
+    "pack": "CABGA381",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-85f-cabga554": {
     "part_num": "LFE5UM5G-85F-8BG554C",
     "arch": "ecp5",
     "size": "85k",
     "type": "um5g-85k",
-    "pack": "CABGA554"
+    "pack": "CABGA554",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-85f-cabga756": {
     "part_num": "LFE5UM5G-85F-8BG756C",
     "arch": "ecp5",
     "size": "85k",
     "type": "um5g-85k",
-    "pack": "CABGA756"
+    "pack": "CABGA756",
+    "speed": "8"
   },
   "ecp5-lfe5um5g-85f-csfbga285": {
     "part_num": "LFE5UM5G-85F-8MG285C",
     "arch": "ecp5",
     "size": "85k",
     "type": "um5g-85k",
-    "pack": "CSFBGA285"
+    "pack": "CSFBGA285",
+    "speed": "8"
   },
   //
   //

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -526,10 +526,11 @@
   // ============= GOWIN
   //
   // ARCHITECTURE-SPECIFIC-FIELDS: 
-  //    'type': TBD
+  //    'type': Represents the device family, This is the scons arg 
+  //        FPGA_TYPE arg that is passed to nextpnr-himbaechel and to 
+  //        gowin_pack. See plugin_gowin.py for details.
   //
-  //    'pack': As of Jan 2024, this fields is used for information only
-  //        and doesn't not affect the toolchain commands. We set it to the 
+  //    'pack': Unused.
   //
   "gw1n-lv1qn48c6-i5": {
     "part_num": "GW1N-LV1QN48C6/I5",

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -239,7 +239,7 @@
     "pack": "uwg30"
   },
   // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
-  // This fpga is used by the boards 'odt-icyblue-feather' and 'odt-rpga-feather'.
+  // This fpga is used by the boards 'odt-icyblue-feather'.
   // See https://github.com/FPGAwars/apio/issues/545
   // See https://github.com/FPGAwars/apio/issues/535 
   "ice40-u4k-sg48": {

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -229,6 +229,9 @@
     "pack": "uwg30"
   },
   // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
+  // This fpga is currently not used.
+  // See https://github.com/FPGAwars/apio/issues/545
+  // See https://github.com/FPGAwars/apio/issues/535 
   "ice40-u4k-uwg30": {
     "part_num": "ICE40U4K-UWG30",
     "arch": "ice40",
@@ -237,6 +240,9 @@
     "pack": "uwg30"
   },
   // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
+  // This fpga is used by the boards 'odt-icyblue-feather' and 'odt-rpga-feather'.
+  // See https://github.com/FPGAwars/apio/issues/545
+  // See https://github.com/FPGAwars/apio/issues/535 
   "ice40-u4k-sg48": {
     "part_num": "ICE40U4K-SG48",
     "arch": "ice40",

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -1,20 +1,32 @@
 // Apio boards definitions.
 // These FPGAs are referred to from bords.jsonc.
 //
-// FIELDS
-// part_num: The exact and complete part number, but without the delivery
-//           information such as tape vs tray. If an variant is unknown,
-//           err on the safe side and select the least demanding option (e.g.
-//           if multiple speeds are available and the actual speed option is
-//           unknown, use the slowest option.) 
-// arch:     The architecture, in term of apio's impelemntation which has
-//           per architecture plugin implementation.
-// size:     TBD
-// type:     TBD
-// pack:     TBD
+// COMMON-FIELDS:
+//    'part_num': The exact and complete part number, but without the delivery
+//        information such as tape vs tray. If an variant is unknown,
+//        err on the safe side and select the least demanding option (e.g.
+//        if multiple speeds are available and the actual speed option is
+//        unknown, use the slowest option.) 
+//
+//    'arch': The architecture group of the FPGA, This determines the saemantic
+//        of its fields and the toolchain commands that are used to process it.
+//
+//    'size': The device size class. As of Jan 2024, this field is for
+//        information only and doesn't affect the oeration of the 
+//        toochain. 
+//
+// ARCHITECTURE-SPECIFIC-FIELDS: 
+//    'type':
+//    'pack': 
+//        These fields are documented at the begining of each architecture
+//        group below.
 //
 //
 // ============= ICE40
+//
+// ARCHITECTURE-SPECIFIC-FIELDS: 
+//    'type': TBD
+//    'pack': TBD
 //
 {
   "ice40-lp1k-swg16tr": {
@@ -252,6 +264,10 @@
   //
   //
   // ============= ECP5
+  //
+  // ARCHITECTURE-SPECIFIC-FIELDS: 
+  //    'type': TBD
+  //    'pack': TBD
   //
   "ecp5-lfe5u-12f-cabga256": {
     "part_num": "LFE5U-12F-6BG256C",
@@ -509,8 +525,11 @@
   //
   // ============= GOWIN
   //
-  // arch: "gowin"
-  // type: 
+  // ARCHITECTURE-SPECIFIC-FIELDS: 
+  //    'type': TBD
+  //
+  //    'pack': As of Jan 2024, this fields is used for information only
+  //        and doesn't not affect the toolchain commands. We set it to the 
   //
   "gw1n-lv1qn48c6-i5": {
     "part_num": "GW1N-LV1QN48C6/I5",

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -2,11 +2,13 @@
 // These FPGAs are referred to from bords.jsonc.
 //
 // COMMON-FIELDS:
-//    'part_num': The exact and complete part number, but without the delivery
-//        information such as tape vs tray. If an variant is unknown,
-//        err on the safe side and select the least demanding option (e.g.
-//        if multiple speeds are available and the actual speed option is
-//        unknown, use the slowest option.) 
+//    'fpga_id': These are the entries keys. They equal to the part number
+//        converted to lower-case-0-9 with an optional suffix denoting a
+//        variant, e.g. '-8k' when oversizing a 4k device to act as a 8k 
+//        device.
+//
+//    'part_num': The exact and complete part number, without the delivery
+//        information such as tape vs tray. 
 //
 //    'arch': The architecture group of the FPGA, This determines the saemantic
 //        of its fields and the toolchain commands that are used to process it.
@@ -15,224 +17,270 @@
 //        information only and doesn't affect the oeration of the 
 //        toochain. 
 //
-// ARCHITECTURE-SPECIFIC-FIELDS: 
-//    'type':
-//    'pack': 
-//        These fields are documented at the begining of each architecture
-//        group below.
+// The reset of the fields are architecture specific and are described in each
+// architecture section below.
+//    
 //
 //
-// ============= ICE40
+// ============= ICE40 ARCHITECTURE
 //
 // ARCHITECTURE-SPECIFIC-FIELDS: 
 //    'type': TBD
 //    'pack': TBD
 //
 {
-  "ice40-lp1k-swg16tr": {
+  "ice40lp1k-swg16tr": {
     "part_num": "ICE40LP1K-SWG16TR",
     "arch": "ice40",
     "size": "1k",
     "type": "lp1k",
     "pack": "swg16tr"
   },
-  "ice40-lp384-cm36": {
+  "ice40lp384-cm36": {
     "part_num": "ICE40LP384-CM36",
     "arch": "ice40",
     "size": "384",
     "type": "lp384",
     "pack": "cm36"
   },
-  "ice40-lp1k-cm36": {
+  "ice40lp1k-cm36": {
     "part_num": "ICE40LP1K-CM36",
     "arch": "ice40",
     "size": "1k",
     "type": "lp1k",
     "pack": "cm36"
   },
-  "ice40-ul1k-cm36a": {
+  "ice40ul1k-cm36a": {
     "part_num": "ICE40UL1K-CM36A",
     "arch": "ice40",
     "size": "1k",
     "type": "ul1k",
     "pack": "cm36a"
   },
-  "ice40-lp384-cm49": {
+  "ice40lp384-cm49": {
     "part_num": "ICE40LP384-CM49",
     "arch": "ice40",
     "size": "384",
     "type": "lp384",
     "pack": "cm49"
   },
-  "ice40-lp1k-cm49": {
+  "ice40lp1k-cm49": {
     "part_num": "ICE40LP1K-CM49",
     "arch": "ice40",
     "size": "1k",
     "type": "lp1k",
     "pack": "cm49"
   },
-  "ice40-lp1k-cm81": {
+  "ice40lp1k-cm81": {
     "part_num": "ICE40LP1K-CM81",
     "arch": "ice40",
     "size": "1k",
     "type": "lp1k",
     "pack": "cm81"
   },
-  "ice40-lp4k-cm81": {
+  "ice40lp4k-cm81": {
+    "part_num": "ICE40LP4K-CM81",
+    "arch": "ice40",
+    "size": "4k",
+    "type": "lp4k",
+    "pack": "cm81"
+  },
+  // This is a 4k fpga that is oversized to 8k.
+  "ice40lp4k-cm81-8k": {
     "part_num": "ICE40LP4K-CM81",
     "arch": "ice40",
     "size": "8k",
     "type": "lp8k",
     "pack": "cm81:4k"
   },
-  "ice40-lp8k-cm81": {
+  "ice40lp8k-cm81": {
     "part_num": "ICE40LP8K-CM81",
     "arch": "ice40",
     "size": "8k",
     "type": "lp8k",
     "pack": "cm81"
   },
-  "ice40-lp1k-cm121": {
+  "ice40lp1k-cm121": {
     "part_num": "ICE40LP1K-CM121",
     "arch": "ice40",
     "size": "1k",
     "type": "lp1k",
     "pack": "cm121"
   },
-  "ice40-lp4k-cm121": {
+  "ice40lp4k-cm121": {
+    "part_num": "ICE40LP4K-CM121",
+    "arch": "ice40",
+    "size": "4k",
+    "type": "lp4k",
+    "pack": "cm121"
+  },
+  // This is a 4k fpga that is oversized to 8k.
+  "ice40lp4k-cm121-8k": {
     "part_num": "ICE40LP4K-CM121",
     "arch": "ice40",
     "size": "8k",
     "type": "lp8k",
     "pack": "cm121:4k"
   },
-  "ice40-lp8k-cm121": {
+  "ice40lp8k-cm121": {
     "part_num": "ICE40LP8K-CM121",
     "arch": "ice40",
     "size": "8k",
     "type": "lp8k",
     "pack": "cm121"
   },
-  "ice40-lp4k-cm225": {
+  "ice40lp4k-cm225": {
+    "part_num": "ICE40LP4K-CM225",
+    "arch": "ice40",
+    "size": "4k",
+    "type": "lp4k",
+    "pack": "cm225"
+  },
+  // This is a 4k fpga that is oversized to 8k.
+  "ice40lp4k-cm225-8k": {
     "part_num": "ICE40LP4K-CM225",
     "arch": "ice40",
     "size": "8k",
     "type": "lp8k",
     "pack": "cm225:4k"
   },
-  "ice40-lp8k-cm225": {
+  "ice40lp8k-cm225": {
     "part_num": "ICE40LP8K-CM225",
     "arch": "ice40",
     "size": "8k",
     "type": "lp8k",
     "pack": "cm225"
   },
-  "ice40-hx8k-cm225": {
+  "ice40hx8k-cm225": {
     "part_num": "ICE40HX8K-CM225",
     "arch": "ice40",
     "size": "8k",
     "type": "hx8k",
     "pack": "cm225"
   },
-  "ice40-lp384-qn32": {
+  "ice40lp384-qn32": {
     "part_num": "ICE40LP384-QN32",
     "arch": "ice40",
     "size": "384",
     "type": "lp384",
     "pack": "qn32"
   },
-  "ice40-lp1k-qn84": {
+  "ice40lp1k-qn84": {
     "part_num": "ICE40LP1K-QN84",
     "arch": "ice40",
     "size": "1k",
     "type": "lp1k",
     "pack": "qn84"
   },
-  "ice40-lp1k-cb81": {
+  "ice40lp1k-cb81": {
     "part_num": "ICE40LP1K-CB81",
     "arch": "ice40",
     "size": "1k",
     "type": "lp1k",
     "pack": "cb81"
   },
-  "ice40-lp1k-cb121": {
+  "ice40lp1k-cb121": {
     "part_num": "ICE40LP1K-CB121",
     "arch": "ice40",
     "size": "1k",
     "type": "lp1k",
     "pack": "cb121"
   },
-  "ice40-hx1k-cb132": {
+  "ice40hx1k-cb132": {
     "part_num": "ICE40HX1K-CB132",
     "arch": "ice40",
     "size": "1k",
     "type": "hx1k",
     "pack": "cb132"
   },
-  "ice40-hx4k-cb132": {
+  "ice40hx4k-cb132": {
+    "part_num": "ICE40HX4K-CB132",
+    "arch": "ice40",
+    "size": "4k",
+    "type": "hx4k",
+    "pack": "cb132"
+  },
+  // This is a 4k fpga that is oversized to 8k.
+  "ice40hx4k-cb132-8k": {
     "part_num": "ICE40HX4K-CB132",
     "arch": "ice40",
     "size": "8k",
     "type": "hx8k",
     "pack": "cb132:4k"
   },
-  "ice40-hx8k-cb132": {
+  "ice40hx8k-cb132": {
     "part_num": "ICE40HX8K-CB132",
     "arch": "ice40",
     "size": "8k",
     "type": "hx8k",
     "pack": "cb132"
   },
-  "ice40-hx1k-vq100": {
+  "ice40hx1k-vq100": {
     "part_num": "ICE40HX1K-VQ100",
     "arch": "ice40",
     "size": "1k",
     "type": "hx1k",
     "pack": "vq100"
   },
-  "ice40-hx1k-tq144": {
+  "ice40hx1k-tq144": {
     "part_num": "ICE40HX1K-TQ144",
     "arch": "ice40",
     "size": "1k",
     "type": "hx1k",
     "pack": "tq144"
   },
-  "ice40-hx4k-tq144": {
+  "ice40hx4k-tq144": {
+    "part_num": "ICE40HX4K-TQ144",
+    "arch": "ice40",
+    "size": "4k",
+    "type": "hx4k",
+    "pack": "tq144"
+  },
+  // This is a 4k fpga that is oversized to 8k.
+  "ice40hx4k-tq144-8k": {
     "part_num": "ICE40HX4K-TQ144",
     "arch": "ice40",
     "size": "8k",
     "type": "hx8k",
     "pack": "tq144:4k"
   },
-  "ice40-hx4k-bg121": {
+  "ice40hx4k-bg121": {
+    "part_num": "ICE40HX4K-BG121",
+    "arch": "ice40",
+    "size": "4k",
+    "type": "hx4k",
+    "pack": "bg121"
+  },
+  // This is a 4k fpga that is oversized to 8k.
+  "ice40hx4k-bg121-8k": {
     "part_num": "ICE40HX4K-BG121",
     "arch": "ice40",
     "size": "8k",
     "type": "hx8k",
     "pack": "bg121:4k"
   },
-  "ice40-hx8k-ct256": {
+  "ice40hx8k-ct256": {
     "part_num": "ICE40HX8K-CT256",
     "arch": "ice40",
     "size": "8k",
     "type": "hx8k",
     "pack": "ct256"
   },
-  "ice40-hx8k-bg121": {
+  "ice40hx8k-bg121": {
     "part_num": "ICE40HX8K-BG121",
     "arch": "ice40",
     "size": "8k",
     "type": "hx8k",
     "pack": "bg121"
   },
-  "ice40-up5k-sg48": {
+  "ice40up5k-sg48": {
     "part_num": "ICE40UP5K-SG48",
     "arch": "ice40",
     "size": "5k",
     "type": "up5k",
     "pack": "sg48"
   },
-  "ice40-up5k-uwg30": {
+  "ice40up5k-uwg30": {
     "part_num": "ICE40UP5K-UWG30",
     "arch": "ice40",
     "size": "5k",
@@ -243,7 +291,7 @@
   // This fpga is currently not used.
   // See https://github.com/FPGAwars/apio/issues/545
   // See https://github.com/FPGAwars/apio/issues/535 
-  "ice40-u4k-uwg30": {
+  "ice40u4k-uwg30": {
     "part_num": "ICE40U4K-UWG30",
     "arch": "ice40",
     "size": "4k",
@@ -254,7 +302,7 @@
   // This fpga is used by the boards 'odt-icyblue-feather'.
   // See https://github.com/FPGAwars/apio/issues/545
   // See https://github.com/FPGAwars/apio/issues/535 
-  "ice40-u4k-sg48": {
+  "ice40u4k-sg48": {
     "part_num": "ICE40U4K-SG48",
     "arch": "ice40",
     "size": "4k",
@@ -263,14 +311,14 @@
   },
   //
   //
-  // ============= ECP5
+  // ============= ECP5 ARCHITECTURE
   //
   // ARCHITECTURE-SPECIFIC-FIELDS: 
   //    'type':  TBD
   //    'pack':  TBD
   //    'speed': TBD
   //
-  "ecp5-lfe5u-12f-cabga256": {
+  "lfe5u-12f-6bg256c": {
     "part_num": "LFE5U-12F-6BG256C",
     "arch": "ecp5",
     "size": "12k",
@@ -278,7 +326,7 @@
     "pack": "CABGA256",
     "speed": "6"
   },
-  "ecp5-lfe5u-12f-cabga381": {
+  "lfe5u-12f-6bg381c": {
     "part_num": "LFE5U-12F-6BG381C",
     "arch": "ecp5",
     "size": "12k",
@@ -286,7 +334,7 @@
     "pack": "CABGA381",
     "speed": "6"
   },
-  "ecp5-lfe5u-12f-csfbga285": {
+  "lfe5u-12f-6mg285c": {
     "part_num": "LFE5U-12F-6MG285C",
     "arch": "ecp5",
     "size": "12k",
@@ -294,7 +342,7 @@
     "pack": "CSFBGA285",
     "speed": "6"
   },
-  "ecp5-lfe5u-25f-cabga256": {
+  "lfe5u-25f-6bg256c": {
     "part_num": "LFE5U-25F-6BG256C",
     "arch": "ecp5",
     "size": "25k",
@@ -302,7 +350,7 @@
     "pack": "CABGA256",
     "speed": "6"
   },
-  "ecp5-lfe5u-25f-cabga381": {
+  "lfe5u-25f-6bg381c": {
     "part_num": "LFE5U-25F-6BG381C",
     "arch": "ecp5",
     "size": "25k",
@@ -310,7 +358,7 @@
     "pack": "CABGA381",
     "speed": "6"
   },
-  "ecp5-lfe5u-25f-csfbga285": {
+  "lfe5u-25f-6mg285c": {
     "part_num": "LFE5U-25F-6MG285C",
     "arch": "ecp5",
     "size": "25k",
@@ -318,7 +366,7 @@
     "pack": "CSFBGA285",
     "speed": "6"
   },
-  "ecp5-lfe5u-45f-cabga256": {
+  "lfe5u-45f-6bg256c": {
     "part_num": "LFE5U-45F-6BG256C",
     "arch": "ecp5",
     "size": "45k",
@@ -326,7 +374,7 @@
     "pack": "CABGA256",
     "speed": "6"
   },
-  "ecp5-lfe5u-45f-cabga381": {
+  "lfe5u-45f-6bg381c": {
     "part_num": "LFE5U-45F-6BG381C",
     "arch": "ecp5",
     "size": "45k",
@@ -334,7 +382,7 @@
     "pack": "CABGA381",
     "speed": "6"
   },
-  "ecp5-lfe5u-45f-cabga554": {
+  "lfe5u-45f-6bg554c": {
     "part_num": "LFE5U-45F-6BG554C",
     "arch": "ecp5",
     "size": "45k",
@@ -342,7 +390,7 @@
     "pack": "CABGA554",
     "speed": "6"
   },
-  "ecp5-lfe5u-45f-csfbga285": {
+  "lfe5u-45f-6mg285c": {
     "part_num": "LFE5U-45F-6MG285C",
     "arch": "ecp5",
     "size": "45k",
@@ -350,7 +398,7 @@
     "pack": "CSFBGA285",
     "speed": "6"
   },
-  "ecp5-lfe5u-85f-cabga381": {
+  "lfe5u-85f-6bg381c": {
     "part_num": "LFE5U-85F-6BG381C",
     "arch": "ecp5",
     "size": "85k",
@@ -358,7 +406,7 @@
     "pack": "CABGA381",
     "speed": "6"
   },
-  "ecp5-lfe5u-85f-cabga554": {
+  "lfe5u-85f-6bg554c": {
     "part_num": "LFE5U-85F-6BG554C",
     "arch": "ecp5",
     "size": "85k",
@@ -366,7 +414,7 @@
     "pack": "CABGA554",
     "speed": "6"
   },
-  "ecp5-lfe5u-85f-cabga756": {
+  "lfe5u-85f-6bg756c": {
     "part_num": "LFE5U-85F-6BG756C",
     "arch": "ecp5",
     "size": "85k",
@@ -374,7 +422,7 @@
     "pack": "CABGA756",
     "speed": "6"
   },
-  "ecp5-lfe5u-85f-csfbga285": {
+  "lfe5u-85f-6mg285c": {
     "part_num": "LFE5U-85F-6MG285C",
     "arch": "ecp5",
     "size": "85k",
@@ -382,7 +430,7 @@
     "pack": "CSFBGA285",
     "speed": "6"
   },
-  "ecp5-lfe5um-25f-cabga256": {
+  "lfe5um-25f-6bg256c": {
     "part_num": "LFE5UM-25F-6BG256C",
     "arch": "ecp5",
     "size": "25k",
@@ -390,7 +438,7 @@
     "pack": "CABGA256",
     "speed": "6"
   },
-  "ecp5-lfe5um-25f-cabga381": {
+  "lfe5um-25f-6bg381c": {
     "part_num": "LFE5UM-25F-6BG381C",
     "arch": "ecp5",
     "size": "25k",
@@ -398,7 +446,7 @@
     "pack": "CABGA381",
     "speed": "6"
   },
-  "ecp5-lfe5um-25f-csfbga285": {
+  "lfe5um-25f-6mg285c": {
     "part_num": "LFE5UM-25F-6MG285C",
     "arch": "ecp5",
     "size": "25k",
@@ -406,7 +454,7 @@
     "pack": "CSFBGA285",
     "speed": "6"
   },
-  "ecp5-lfe5um-45f-cabga256": {
+  "lfe5um-45f-6bg256c": {
     "part_num": "LFE5UM-45F-6BG256C",
     "arch": "ecp5",
     "size": "45k",
@@ -414,7 +462,7 @@
     "pack": "CABGA256",
     "speed": "6"
   },
-  "ecp5-lfe5um-45f-cabga381": {
+  "lfe5um-45f-6bg381c": {
     "part_num": "LFE5UM-45F-6BG381C",
     "arch": "ecp5",
     "size": "45k",
@@ -422,7 +470,7 @@
     "pack": "CABGA381",
     "speed": "6"
   },
-  "ecp5-lfe5um-45f-cabga554": {
+  "lfe5um-45f-6bg554c": {
     "part_num": "LFE5UM-45F-6BG554C",
     "arch": "ecp5",
     "size": "45k",
@@ -430,7 +478,7 @@
     "pack": "CABGA554",
     "speed": "6"
   },
-  "ecp5-lfe5um-45f-csfbga285": {
+  "lfe5um-45f-6mg285c": {
     "part_num": "LFE5UM-45F-6MG285C",
     "arch": "ecp5",
     "size": "45k",
@@ -438,7 +486,7 @@
     "pack": "CSFBGA285",
     "speed": "6"
   },
-  "ecp5-lfe5um-85f-cabga381": {
+  "lfe5um-85f-6bg381c": {
     "part_num": "LFE5UM-85F-6BG381C",
     "arch": "ecp5",
     "size": "85k",
@@ -446,7 +494,7 @@
     "pack": "CABGA381",
     "speed": "6"
   },
-  "ecp5-lfe5um-85f-cabga554": {
+  "lfe5um-85f-6bg554c": {
     "part_num": "LFE5UM-85F-6BG554C",
     "arch": "ecp5",
     "size": "85k",
@@ -454,7 +502,7 @@
     "pack": "CABGA554",
     "speed": "6"
   },
-  "ecp5-lfe5um-85f-cabga756": {
+  "lfe5um-85f-6bg756c": {
     "part_num": "LFE5UM-85F-6BG756C",
     "arch": "ecp5",
     "size": "85k",
@@ -462,7 +510,7 @@
     "pack": "CABGA756",
     "speed": "6"
   },
-  "ecp5-lfe5um-85f-csfbga285": {
+  "lfe5um-85f-6mg285c": {
     "part_num": "LFE5UM-85F-6MG285C",
     "arch": "ecp5",
     "size": "85k",
@@ -470,7 +518,7 @@
     "pack": "CSFBGA285",
     "speed": "6"
   },
-  "ecp5-lfe5um5g-25f-cabga256": {
+  "lfe5um5g-25f-8bg256c": {
     "part_num": "LFE5UM5G-25F-8BG256C",
     "arch": "ecp5",
     "size": "25k",
@@ -478,7 +526,7 @@
     "pack": "CABGA256",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-25f-cabga381": {
+  "lfe5um5g-25f-8bg381c": {
     "part_num": "LFE5UM5G-25F-8BG381C",
     "arch": "ecp5",
     "size": "25k",
@@ -486,7 +534,7 @@
     "pack": "CABGA381",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-25f-csfbga285": {
+  "lfe5um5g-25f-8mg285c": {
     "part_num": "LFE5UM5G-25F-8MG285C",
     "arch": "ecp5",
     "size": "25k",
@@ -494,7 +542,7 @@
     "pack": "CSFBGA285",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-45f-cabga256": {
+  "lfe5um5g-45f-8bg256c": {
     "part_num": "LFE5UM5G-45F-8BG256C",
     "arch": "ecp5",
     "size": "45k",
@@ -502,7 +550,7 @@
     "pack": "CABGA256",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-45f-cabga381": {
+  "lfe5um5g-45f-8bg381c": {
     "part_num": "LFE5UM5G-45F-8BG381C",
     "arch": "ecp5",
     "size": "45k",
@@ -510,7 +558,7 @@
     "pack": "CABGA381",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-45f-cabga554": {
+  "lfe5um5g-45f-8bg554c": {
     "part_num": "LFE5UM5G-45F-8BG554C",
     "arch": "ecp5",
     "size": "45k",
@@ -518,7 +566,7 @@
     "pack": "CABGA554",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-45f-csfbga285": {
+  "lfe5um5g-45f-8mg285c": {
     "part_num": "LFE5UM5G-45F-8MG285C",
     "arch": "ecp5",
     "size": "45k",
@@ -526,7 +574,7 @@
     "pack": "CSFBGA285",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-85f-cabga381": {
+  "lfe5um5g-85f-8bg381c": {
     "part_num": "LFE5UM5G-85F-8BG381C",
     "arch": "ecp5",
     "size": "85k",
@@ -534,7 +582,7 @@
     "pack": "CABGA381",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-85f-cabga554": {
+  "lfe5um5g-85f-8bg554c": {
     "part_num": "LFE5UM5G-85F-8BG554C",
     "arch": "ecp5",
     "size": "85k",
@@ -542,7 +590,7 @@
     "pack": "CABGA554",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-85f-cabga756": {
+  "lfe5um5g-85f-8bg756c": {
     "part_num": "LFE5UM5G-85F-8BG756C",
     "arch": "ecp5",
     "size": "85k",
@@ -550,7 +598,7 @@
     "pack": "CABGA756",
     "speed": "8"
   },
-  "ecp5-lfe5um5g-85f-csfbga285": {
+  "lfe5um5g-85f-8mg285c": {
     "part_num": "LFE5UM5G-85F-8MG285C",
     "arch": "ecp5",
     "size": "85k",
@@ -560,7 +608,7 @@
   },
   //
   //
-  // ============= GOWIN
+  // ============= GOWIN ARCHITECTURE
   //
   // ARCHITECTURE-SPECIFIC-FIELDS: 
   //    'type': Represents the device family, This is the scons arg 

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -14,6 +14,9 @@
 // pack:     TBD
 // idcode:   TBD
 //
+//
+// ============= ICE40
+//
 {
   "ice40-lp1k-swg16tr": {
     "part_num": "ICE40LP1K-SWG16TR",
@@ -239,6 +242,10 @@
     "size": "4k",
     "pack": "sg48"
   },
+  //
+  //
+  // ============= ECP5
+  //
   "ecp5-lfe5u-12f-cabga256": {
     "part_num": "LFE5U-12F-6BG256C",
     "arch": "ecp5",
@@ -494,38 +501,45 @@
     "size": "85k",
     "pack": "CSFBGA285"
   },
+  //
+  //
+  // ============= GOWIN
+  //
+  // arch: "gowin"
+  // type: 
+  //
   "gw1n-lv1qn48c6-i5": {
     "part_num": "GW1N-LV1QN48C6/I5",
     "arch": "gowin",
-    "type": "gw1n-1",
+    "type": "GW1N-1",
     "size": "1k",
     "pack": "QN48"
   },
   "gw1nz-lv1qn48c6-i5": {
     "part_num": "GW1NZ-LV1QN48C6/I5",
     "arch": "gowin",
-    "type": "gw1nz-1",
+    "type": "GW1NZ-1",
     "size": "1k",
     "pack": "QN48"
   },
   "gw1nsr-lv4cqn48pc7-i6": {
     "part_num": "GW1NSR-LV4CQN48PC7/I6",
     "arch": "gowin",
-    "type": "gw1ns-4",
+    "type": "GW1NS-4",
     "size": "4k",
     "pack": "QN48P"
   },
   "gw1nr-lv9qn88pc6-i5": {
     "part_num": "GW1NR-LV9QN88PC6/I5",
     "arch": "gowin",
-    "type": "gw1n-9c",
+    "type": "GW1N-9C",
     "size": "9k",
     "pack": "QN88P"
   },
   "gw2ar-lv18qn88c8-i7": {
     "part_num": "GW2AR-LV18QN88C8/I7",
     "arch": "gowin",
-    "type": "gw2a-18c",
+    "type": "GW2A-18C",
     "size": "20k",
     "pack": "QN88"
   }

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -1,8 +1,5 @@
 // Apio boards definitions.
-// These FPGAs are referred to from bords.json.
-//
-// Visual Studio Code note: set language model to 'jsonc' to avoid flagging 
-// comments as errors.
+// These FPGAs are referred to from bords.jsonc.
 //
 // FIELDS
 // part_num: The exact and complete part number, but without the delivery

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -9,8 +9,8 @@
 //           unknown, use the slowest option.) 
 // arch:     The architecture, in term of apio's impelemntation which has
 //           per architecture plugin implementation.
-// type:     TBD
 // size:     TBD
+// type:     TBD
 // pack:     TBD
 // idcode:   TBD
 //
@@ -21,211 +21,211 @@
   "ice40-lp1k-swg16tr": {
     "part_num": "ICE40LP1K-SWG16TR",
     "arch": "ice40",
-    "type": "lp1k",
     "size": "1k",
+    "type": "lp1k",
     "pack": "swg16tr"
   },
   "ice40-lp384-cm36": {
     "part_num": "ICE40LP384-CM36",
     "arch": "ice40",
-    "type": "lp384",
     "size": "384",
+    "type": "lp384",
     "pack": "cm36"
   },
   "ice40-lp1k-cm36": {
     "part_num": "ICE40LP1K-CM36",
     "arch": "ice40",
-    "type": "lp1k",
     "size": "1k",
+    "type": "lp1k",
     "pack": "cm36"
   },
   "ice40-ul1k-cm36a": {
     "part_num": "ICE40UL1K-CM36A",
     "arch": "ice40",
-    "type": "ul1k",
     "size": "1k",
+    "type": "ul1k",
     "pack": "cm36a"
   },
   "ice40-lp384-cm49": {
     "part_num": "ICE40LP384-CM49",
     "arch": "ice40",
-    "type": "lp384",
     "size": "384",
+    "type": "lp384",
     "pack": "cm49"
   },
   "ice40-lp1k-cm49": {
     "part_num": "ICE40LP1K-CM49",
     "arch": "ice40",
-    "type": "lp1k",
     "size": "1k",
+    "type": "lp1k",
     "pack": "cm49"
   },
   "ice40-lp1k-cm81": {
     "part_num": "ICE40LP1K-CM81",
     "arch": "ice40",
-    "type": "lp1k",
     "size": "1k",
+    "type": "lp1k",
     "pack": "cm81"
   },
   "ice40-lp4k-cm81": {
     "part_num": "ICE40LP4K-CM81",
     "arch": "ice40",
-    "type": "lp8k",
     "size": "8k",
+    "type": "lp8k",
     "pack": "cm81:4k"
   },
   "ice40-lp8k-cm81": {
     "part_num": "ICE40LP8K-CM81",
     "arch": "ice40",
-    "type": "lp8k",
     "size": "8k",
+    "type": "lp8k",
     "pack": "cm81"
   },
   "ice40-lp1k-cm121": {
     "part_num": "ICE40LP1K-CM121",
     "arch": "ice40",
-    "type": "lp1k",
     "size": "1k",
+    "type": "lp1k",
     "pack": "cm121"
   },
   "ice40-lp4k-cm121": {
     "part_num": "ICE40LP4K-CM121",
     "arch": "ice40",
-    "type": "lp8k",
     "size": "8k",
+    "type": "lp8k",
     "pack": "cm121:4k"
   },
   "ice40-lp8k-cm121": {
     "part_num": "ICE40LP8K-CM121",
     "arch": "ice40",
-    "type": "lp8k",
     "size": "8k",
+    "type": "lp8k",
     "pack": "cm121"
   },
   "ice40-lp4k-cm225": {
     "part_num": "ICE40LP4K-CM225",
     "arch": "ice40",
-    "type": "lp8k",
     "size": "8k",
+    "type": "lp8k",
     "pack": "cm225:4k"
   },
   "ice40-lp8k-cm225": {
     "part_num": "ICE40LP8K-CM225",
     "arch": "ice40",
-    "type": "lp8k",
     "size": "8k",
+    "type": "lp8k",
     "pack": "cm225"
   },
   "ice40-hx8k-cm225": {
     "part_num": "ICE40HX8K-CM225",
     "arch": "ice40",
-    "type": "hx8k",
     "size": "8k",
+    "type": "hx8k",
     "pack": "cm225"
   },
   "ice40-lp384-qn32": {
     "part_num": "ICE40LP384-QN32",
     "arch": "ice40",
-    "type": "lp384",
     "size": "384",
+    "type": "lp384",
     "pack": "qn32"
   },
   "ice40-lp1k-qn84": {
     "part_num": "ICE40LP1K-QN84",
     "arch": "ice40",
-    "type": "lp1k",
     "size": "1k",
+    "type": "lp1k",
     "pack": "qn84"
   },
   "ice40-lp1k-cb81": {
     "part_num": "ICE40LP1K-CB81",
     "arch": "ice40",
-    "type": "lp1k",
     "size": "1k",
+    "type": "lp1k",
     "pack": "cb81"
   },
   "ice40-lp1k-cb121": {
     "part_num": "ICE40LP1K-CB121",
     "arch": "ice40",
-    "type": "lp1k",
     "size": "1k",
+    "type": "lp1k",
     "pack": "cb121"
   },
   "ice40-hx1k-cb132": {
     "part_num": "ICE40HX1K-CB132",
     "arch": "ice40",
-    "type": "hx1k",
     "size": "1k",
+    "type": "hx1k",
     "pack": "cb132"
   },
   "ice40-hx4k-cb132": {
     "part_num": "ICE40HX4K-CB132",
     "arch": "ice40",
-    "type": "hx8k",
     "size": "8k",
+    "type": "hx8k",
     "pack": "cb132:4k"
   },
   "ice40-hx8k-cb132": {
     "part_num": "ICE40HX8K-CB132",
     "arch": "ice40",
-    "type": "hx8k",
     "size": "8k",
+    "type": "hx8k",
     "pack": "cb132"
   },
   "ice40-hx1k-vq100": {
     "part_num": "ICE40HX1K-VQ100",
     "arch": "ice40",
-    "type": "hx1k",
     "size": "1k",
+    "type": "hx1k",
     "pack": "vq100"
   },
   "ice40-hx1k-tq144": {
     "part_num": "ICE40HX1K-TQ144",
     "arch": "ice40",
-    "type": "hx1k",
     "size": "1k",
+    "type": "hx1k",
     "pack": "tq144"
   },
   "ice40-hx4k-tq144": {
     "part_num": "ICE40HX4K-TQ144",
     "arch": "ice40",
-    "type": "hx8k",
     "size": "8k",
+    "type": "hx8k",
     "pack": "tq144:4k"
   },
   "ice40-hx4k-bg121": {
     "part_num": "ICE40HX4K-BG121",
     "arch": "ice40",
-    "type": "hx8k",
     "size": "8k",
+    "type": "hx8k",
     "pack": "bg121:4k"
   },
   "ice40-hx8k-ct256": {
     "part_num": "ICE40HX8K-CT256",
     "arch": "ice40",
-    "type": "hx8k",
     "size": "8k",
+    "type": "hx8k",
     "pack": "ct256"
   },
   "ice40-hx8k-bg121": {
     "part_num": "ICE40HX8K-BG121",
     "arch": "ice40",
-    "type": "hx8k",
     "size": "8k",
+    "type": "hx8k",
     "pack": "bg121"
   },
   "ice40-up5k-sg48": {
     "part_num": "ICE40UP5K-SG48",
     "arch": "ice40",
-    "type": "up5k",
     "size": "5k",
+    "type": "up5k",
     "pack": "sg48"
   },
   "ice40-up5k-uwg30": {
     "part_num": "ICE40UP5K-UWG30",
     "arch": "ice40",
-    "type": "up5k",
     "size": "5k",
+    "type": "up5k",
     "pack": "uwg30"
   },
   // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
@@ -235,8 +235,8 @@
   "ice40-u4k-uwg30": {
     "part_num": "ICE40U4K-UWG30",
     "arch": "ice40",
-    "type": "u4k",
     "size": "4k",
+    "type": "u4k",
     "pack": "uwg30"
   },
   // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
@@ -246,8 +246,8 @@
   "ice40-u4k-sg48": {
     "part_num": "ICE40U4K-SG48",
     "arch": "ice40",
-    "type": "u4k",
     "size": "4k",
+    "type": "u4k",
     "pack": "sg48"
   },
   //
@@ -257,256 +257,256 @@
   "ecp5-lfe5u-12f-cabga256": {
     "part_num": "LFE5U-12F-6BG256C",
     "arch": "ecp5",
-    "type": "12k",
     "size": "12k",
+    "type": "12k",
     "pack": "CABGA256",
     "idcode": "0x21111043"
   },
   "ecp5-lfe5u-12f-cabga381": {
     "part_num": "LFE5U-12F-6BG381C",
     "arch": "ecp5",
-    "type": "12k",
     "size": "12k",
+    "type": "12k",
     "pack": "CABGA381",
     "idcode": "0x21111043"
   },
   "ecp5-lfe5u-12f-csfbga285": {
     "part_num": "LFE5U-12F-6MG285C",
     "arch": "ecp5",
-    "type": "12k",
     "size": "12k",
+    "type": "12k",
     "pack": "CSFBGA285",
     "idcode": "0x21111043"
   },
   "ecp5-lfe5u-25f-cabga256": {
     "part_num": "LFE5U-25F-6BG256C",
     "arch": "ecp5",
-    "type": "25k",
     "size": "25k",
+    "type": "25k",
     "pack": "CABGA256"
   },
   "ecp5-lfe5u-25f-cabga381": {
     "part_num": "LFE5U-25F-6BG381C",
     "arch": "ecp5",
-    "type": "25k",
     "size": "25k",
+    "type": "25k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5u-25f-csfbga285": {
     "part_num": "LFE5U-25F-6MG285C",
     "arch": "ecp5",
-    "type": "25k",
     "size": "25k",
+    "type": "25k",
     "pack": "CSFBGA285"
   },
   "ecp5-lfe5u-45f-cabga256": {
     "part_num": "LFE5U-45F-6BG256C",
     "arch": "ecp5",
-    "type": "45k",
     "size": "45k",
+    "type": "45k",
     "pack": "CABGA256"
   },
   "ecp5-lfe5u-45f-cabga381": {
     "part_num": "LFE5U-45F-6BG381C",
     "arch": "ecp5",
-    "type": "45k",
     "size": "45k",
+    "type": "45k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5u-45f-cabga554": {
     "part_num": "LFE5U-45F-6BG554C",
     "arch": "ecp5",
-    "type": "45k",
     "size": "45k",
+    "type": "45k",
     "pack": "CABGA554"
   },
   "ecp5-lfe5u-45f-csfbga285": {
     "part_num": "LFE5U-45F-6MG285C",
     "arch": "ecp5",
-    "type": "45k",
     "size": "45k",
+    "type": "45k",
     "pack": "CSFBGA285"
   },
   "ecp5-lfe5u-85f-cabga381": {
     "part_num": "LFE5U-85F-6BG381C",
     "arch": "ecp5",
-    "type": "85k",
     "size": "85k",
+    "type": "85k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5u-85f-cabga554": {
     "part_num": "LFE5U-85F-6BG554C",
     "arch": "ecp5",
-    "type": "85k",
     "size": "85k",
+    "type": "85k",
     "pack": "CABGA554"
   },
   "ecp5-lfe5u-85f-cabga756": {
     "part_num": "LFE5U-85F-6BG756C",
     "arch": "ecp5",
-    "type": "85k",
     "size": "85k",
+    "type": "85k",
     "pack": "CABGA756"
   },
   "ecp5-lfe5u-85f-csfbga285": {
     "part_num": "LFE5U-85F-6MG285C",
     "arch": "ecp5",
-    "type": "85k",
     "size": "85k",
+    "type": "85k",
     "pack": "CSFBGA285"
   },
   "ecp5-lfe5um-25f-cabga256": {
     "part_num": "LFE5UM-25F-6BG256C",
     "arch": "ecp5",
-    "type": "um-25k",
     "size": "25k",
+    "type": "um-25k",
     "pack": "CABGA256"
   },
   "ecp5-lfe5um-25f-cabga381": {
     "part_num": "LFE5UM-25F-6BG381C",
     "arch": "ecp5",
-    "type": "um-25k",
     "size": "25k",
+    "type": "um-25k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5um-25f-csfbga285": {
     "part_num": "LFE5UM-25F-6MG285C",
     "arch": "ecp5",
-    "type": "um-25k",
     "size": "25k",
+    "type": "um-25k",
     "pack": "CSFBGA285"
   },
   "ecp5-lfe5um-45f-cabga256": {
     "part_num": "LFE5UM-45F-6BG256C",
     "arch": "ecp5",
-    "type": "um-45k",
     "size": "45k",
+    "type": "um-45k",
     "pack": "CABGA256"
   },
   "ecp5-lfe5um-45f-cabga381": {
     "part_num": "LFE5UM-45F-6BG381C",
     "arch": "ecp5",
-    "type": "um-45k",
     "size": "45k",
+    "type": "um-45k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5um-45f-cabga554": {
     "part_num": "LFE5UM-45F-6BG554C",
     "arch": "ecp5",
-    "type": "um-45k",
     "size": "45k",
+    "type": "um-45k",
     "pack": "CABGA554"
   },
   "ecp5-lfe5um-45f-csfbga285": {
     "part_num": "LFE5UM-45F-6MG285C",
     "arch": "ecp5",
-    "type": "um-45k",
     "size": "45k",
+    "type": "um-45k",
     "pack": "CSFBGA285"
   },
   "ecp5-lfe5um-85f-cabga381": {
     "part_num": "LFE5UM-85F-6BG381C",
     "arch": "ecp5",
-    "type": "um-85k",
     "size": "85k",
+    "type": "um-85k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5um-85f-cabga554": {
     "part_num": "LFE5UM-85F-6BG554C",
     "arch": "ecp5",
-    "type": "um-85k",
     "size": "85k",
+    "type": "um-85k",
     "pack": "CABGA554"
   },
   "ecp5-lfe5um-85f-cabga756": {
     "part_num": "LFE5UM-85F-6BG756C",
     "arch": "ecp5",
-    "type": "um-85k",
     "size": "85k",
+    "type": "um-85k",
     "pack": "CABGA756"
   },
   "ecp5-lfe5um-85f-csfbga285": {
     "part_num": "LFE5UM-85F-6MG285C",
     "arch": "ecp5",
-    "type": "um-85k",
     "size": "85k",
+    "type": "um-85k",
     "pack": "CSFBGA285"
   },
   "ecp5-lfe5um5g-25f-cabga256": {
     "part_num": "LFE5UM5G-25F-8BG256C",
     "arch": "ecp5",
-    "type": "um5g-25k",
     "size": "25k",
+    "type": "um5g-25k",
     "pack": "CABGA256"
   },
   "ecp5-lfe5um5g-25f-cabga381": {
     "part_num": "LFE5UM5G-25F-8BG381C",
     "arch": "ecp5",
-    "type": "um5g-25k",
     "size": "25k",
+    "type": "um5g-25k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5um5g-25f-csfbga285": {
     "part_num": "LFE5UM5G-25F-8MG285C",
     "arch": "ecp5",
-    "type": "um5g-25k",
     "size": "25k",
+    "type": "um5g-25k",
     "pack": "CSFBGA285"
   },
   "ecp5-lfe5um5g-45f-cabga256": {
     "part_num": "LFE5UM5G-45F-8BG256C",
     "arch": "ecp5",
-    "type": "um5g-45k",
     "size": "45k",
+    "type": "um5g-45k",
     "pack": "CABGA256"
   },
   "ecp5-lfe5um5g-45f-cabga381": {
     "part_num": "LFE5UM5G-45F-8BG381C",
     "arch": "ecp5",
-    "type": "um5g-45k",
     "size": "45k",
+    "type": "um5g-45k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5um5g-45f-cabga554": {
     "part_num": "LFE5UM5G-45F-8BG554C",
     "arch": "ecp5",
-    "type": "um5g-45k",
     "size": "45k",
+    "type": "um5g-45k",
     "pack": "CABGA554"
   },
   "ecp5-lfe5um5g-45f-csfbga285": {
     "part_num": "LFE5UM5G-45F-8MG285C",
     "arch": "ecp5",
-    "type": "um5g-45k",
     "size": "45k",
+    "type": "um5g-45k",
     "pack": "CSFBGA285"
   },
   "ecp5-lfe5um5g-85f-cabga381": {
     "part_num": "LFE5UM5G-85F-8BG381C",
     "arch": "ecp5",
-    "type": "um5g-85k",
     "size": "85k",
+    "type": "um5g-85k",
     "pack": "CABGA381"
   },
   "ecp5-lfe5um5g-85f-cabga554": {
     "part_num": "LFE5UM5G-85F-8BG554C",
     "arch": "ecp5",
-    "type": "um5g-85k",
     "size": "85k",
+    "type": "um5g-85k",
     "pack": "CABGA554"
   },
   "ecp5-lfe5um5g-85f-cabga756": {
     "part_num": "LFE5UM5G-85F-8BG756C",
     "arch": "ecp5",
-    "type": "um5g-85k",
     "size": "85k",
+    "type": "um5g-85k",
     "pack": "CABGA756"
   },
   "ecp5-lfe5um5g-85f-csfbga285": {
     "part_num": "LFE5UM5G-85F-8MG285C",
     "arch": "ecp5",
-    "type": "um5g-85k",
     "size": "85k",
+    "type": "um5g-85k",
     "pack": "CSFBGA285"
   },
   //
@@ -519,36 +519,36 @@
   "gw1n-lv1qn48c6-i5": {
     "part_num": "GW1N-LV1QN48C6/I5",
     "arch": "gowin",
-    "type": "GW1N-1",
     "size": "1k",
+    "type": "GW1N-1",
     "pack": "QN48"
   },
   "gw1nz-lv1qn48c6-i5": {
     "part_num": "GW1NZ-LV1QN48C6/I5",
     "arch": "gowin",
-    "type": "GW1NZ-1",
     "size": "1k",
+    "type": "GW1NZ-1",
     "pack": "QN48"
   },
   "gw1nsr-lv4cqn48pc7-i6": {
     "part_num": "GW1NSR-LV4CQN48PC7/I6",
     "arch": "gowin",
-    "type": "GW1NS-4",
     "size": "4k",
+    "type": "GW1NS-4",
     "pack": "QN48P"
   },
   "gw1nr-lv9qn88pc6-i5": {
     "part_num": "GW1NR-LV9QN88PC6/I5",
     "arch": "gowin",
-    "type": "GW1N-9C",
     "size": "9k",
+    "type": "GW1N-9C",
     "pack": "QN88P"
   },
   "gw2ar-lv18qn88c8-i7": {
     "part_num": "GW2AR-LV18QN88C8/I7",
     "arch": "gowin",
-    "type": "GW2A-18C",
     "size": "20k",
+    "type": "GW2A-18C",
     "pack": "QN88"
   }
 }

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -12,7 +12,6 @@
 // size:     TBD
 // type:     TBD
 // pack:     TBD
-// idcode:   TBD
 //
 //
 // ============= ICE40
@@ -259,24 +258,21 @@
     "arch": "ecp5",
     "size": "12k",
     "type": "12k",
-    "pack": "CABGA256",
-    "idcode": "0x21111043"
+    "pack": "CABGA256"
   },
   "ecp5-lfe5u-12f-cabga381": {
     "part_num": "LFE5U-12F-6BG381C",
     "arch": "ecp5",
     "size": "12k",
     "type": "12k",
-    "pack": "CABGA381",
-    "idcode": "0x21111043"
+    "pack": "CABGA381"
   },
   "ecp5-lfe5u-12f-csfbga285": {
     "part_num": "LFE5U-12F-6MG285C",
     "arch": "ecp5",
     "size": "12k",
     "type": "12k",
-    "pack": "CSFBGA285",
-    "idcode": "0x21111043"
+    "pack": "CSFBGA285"
   },
   "ecp5-lfe5u-25f-cabga256": {
     "part_num": "LFE5U-25F-6BG256C",

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -21,224 +21,226 @@
   "ice40-lp1k-swg16tr": {
     "part_num": "ICE40LP1K-SWG16TR",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "swg16tr"
   },
   "ice40-lp384-cm36": {
     "part_num": "ICE40LP384-CM36",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp384",
     "size": "384",
     "pack": "cm36"
   },
   "ice40-lp1k-cm36": {
     "part_num": "ICE40LP1K-CM36",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "cm36"
   },
   "ice40-ul1k-cm36a": {
     "part_num": "ICE40UL1K-CM36A",
     "arch": "ice40",
-    "type": "ul",
+    "type": "ul1k",
     "size": "1k",
     "pack": "cm36a"
   },
   "ice40-lp384-cm49": {
     "part_num": "ICE40LP384-CM49",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp384",
     "size": "384",
     "pack": "cm49"
   },
   "ice40-lp1k-cm49": {
     "part_num": "ICE40LP1K-CM49",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "cm49"
   },
   "ice40-lp1k-cm81": {
     "part_num": "ICE40LP1K-CM81",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "cm81"
   },
   "ice40-lp4k-cm81": {
     "part_num": "ICE40LP4K-CM81",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp8k",
     "size": "8k",
     "pack": "cm81:4k"
   },
   "ice40-lp8k-cm81": {
     "part_num": "ICE40LP8K-CM81",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp8k",
     "size": "8k",
     "pack": "cm81"
   },
   "ice40-lp1k-cm121": {
     "part_num": "ICE40LP1K-CM121",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "cm121"
   },
   "ice40-lp4k-cm121": {
     "part_num": "ICE40LP4K-CM121",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp8k",
     "size": "8k",
     "pack": "cm121:4k"
   },
   "ice40-lp8k-cm121": {
     "part_num": "ICE40LP8K-CM121",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp8k",
     "size": "8k",
     "pack": "cm121"
   },
   "ice40-lp4k-cm225": {
     "part_num": "ICE40LP4K-CM225",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp8k",
     "size": "8k",
     "pack": "cm225:4k"
   },
   "ice40-lp8k-cm225": {
     "part_num": "ICE40LP8K-CM225",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp8k",
     "size": "8k",
     "pack": "cm225"
   },
   "ice40-hx8k-cm225": {
     "part_num": "ICE40HX8K-CM225",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx8k",
     "size": "8k",
     "pack": "cm225"
   },
   "ice40-lp384-qn32": {
     "part_num": "ICE40LP384-QN32",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp384",
     "size": "384",
     "pack": "qn32"
   },
   "ice40-lp1k-qn84": {
     "part_num": "ICE40LP1K-QN84",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "qn84"
   },
   "ice40-lp1k-cb81": {
     "part_num": "ICE40LP1K-CB81",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "cb81"
   },
   "ice40-lp1k-cb121": {
     "part_num": "ICE40LP1K-CB121",
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "cb121"
   },
   "ice40-hx1k-cb132": {
     "part_num": "ICE40HX1K-CB132",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx1k",
     "size": "1k",
     "pack": "cb132"
   },
   "ice40-hx4k-cb132": {
     "part_num": "ICE40HX4K-CB132",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx8k",
     "size": "8k",
     "pack": "cb132:4k"
   },
   "ice40-hx8k-cb132": {
     "part_num": "ICE40HX8K-CB132",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx8k",
     "size": "8k",
     "pack": "cb132"
   },
   "ice40-hx1k-vq100": {
     "part_num": "ICE40HX1K-VQ100",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx1k",
     "size": "1k",
     "pack": "vq100"
   },
   "ice40-hx1k-tq144": {
     "part_num": "ICE40HX1K-TQ144",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx1k",
     "size": "1k",
     "pack": "tq144"
   },
   "ice40-hx4k-tq144": {
     "part_num": "ICE40HX4K-TQ144",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx8k",
     "size": "8k",
     "pack": "tq144:4k"
   },
   "ice40-hx4k-bg121": {
     "part_num": "ICE40HX4K-BG121",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx8k",
     "size": "8k",
     "pack": "bg121:4k"
   },
   "ice40-hx8k-ct256": {
     "part_num": "ICE40HX8K-CT256",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx8k",
     "size": "8k",
     "pack": "ct256"
   },
   "ice40-hx8k-bg121": {
     "part_num": "ICE40HX8K-BG121",
     "arch": "ice40",
-    "type": "hx",
+    "type": "hx8k",
     "size": "8k",
     "pack": "bg121"
   },
   "ice40-up5k-sg48": {
     "part_num": "ICE40UP5K-SG48",
     "arch": "ice40",
-    "type": "up",
+    "type": "up5k",
     "size": "5k",
     "pack": "sg48"
   },
   "ice40-up5k-uwg30": {
     "part_num": "ICE40UP5K-UWG30",
     "arch": "ice40",
-    "type": "up",
+    "type": "up5k",
     "size": "5k",
     "pack": "uwg30"
   },
+  // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
   "ice40-u4k-uwg30": {
     "part_num": "ICE40U4K-UWG30",
     "arch": "ice40",
-    "type": "u",
+    "type": "u4k",
     "size": "4k",
     "pack": "uwg30"
   },
+  // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
   "ice40-u4k-sg48": {
     "part_num": "ICE40U4K-SG48",
     "arch": "ice40",
-    "type": "u",
+    "type": "u4k",
     "size": "4k",
     "pack": "sg48"
   },

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -287,12 +287,10 @@
     "type": "up5k",
     "pack": "uwg30"
   },
-  // TODO: Should the part numbrer and type should have 'up' instead of just 'u'?
-  // This fpga is used by the boards 'odt-icyblue-feather'.
-  // See https://github.com/FPGAwars/apio/issues/545
-  // See https://github.com/FPGAwars/apio/issues/535 
-  "ice40u4k-sg48": {
-    "part_num": "ICE40U4K-SG48",
+  // TODO: The part number of this fpga definition changed from ICE40U4K-SG48
+  // to ICE5LP4K-SG48. Verify that the type and pack are correct.
+  "ice5lp4k-sg48": {
+    "part_num": "ICE5LP4K-SG48",
     "arch": "ice40",
     "size": "4k",
     "type": "u4k",

--- a/apio/resources/fpgas.jsonc
+++ b/apio/resources/fpgas.jsonc
@@ -287,8 +287,6 @@
     "type": "up5k",
     "pack": "uwg30"
   },
-  // TODO: The part number of this fpga definition changed from ICE40U4K-SG48
-  // to ICE5LP4K-SG48. Verify that the type and pack are correct.
   "ice5lp4k-sg48": {
     "part_num": "ICE5LP4K-SG48",
     "arch": "ice40",

--- a/apio/resources/packages.jsonc
+++ b/apio/resources/packages.jsonc
@@ -1,9 +1,6 @@
 // Definition of apio software packages. These are packages with various
 // data and utilities that are installed by apio. 
 //
-// Visual Studio Code note: set language model to 'jsonc' to avoid flagging 
-// comments as errors.
-
 {
   "examples": {
     "repository": {

--- a/apio/resources/platforms.jsonc
+++ b/apio/resources/platforms.jsonc
@@ -1,8 +1,5 @@
 // List of computer plaforms that are supported by apio.
 //
-// Visual Studio Code note: set language model to 'jsonc' to avoid flagging 
-// comments as errors.
-
 {
   "darwin": {
     "description": "Mac OSX, x86 64 bit",

--- a/apio/resources/programmers.jsonc
+++ b/apio/resources/programmers.jsonc
@@ -2,6 +2,9 @@
 // The programmers are reffers to by the boards in boards.jsonc which can
 // add additional arguments to the programmers' command lines.
 //
+// The programmer command is constructed as follows:
+// <programmer.args> $SOURCE <board.extra_args>
+
 {
   "iceprog": {
     "command": "iceprog",
@@ -54,18 +57,6 @@
   "openfpgaloader": {
     "command": "openFPGALoader",
     "args": ""
-  },
-  "openfpgaloader-ft2232": {
-    "command": "openFPGALoader",
-    "args": "-c ft2232 -v --file-type bin"
-  },
-  "openfpgaloader-ft232": {
-    "command": "openFPGALoader",
-    "args": "-c ft232 -v --file-type bin"
-  },
-  "openfpgaloader-usb-blaster": {
-    "command": "openFPGALoader",
-    "args": "-c usb-blaster -v --file-type bin"
   },
   "apollo": {
     "command": "apollo",

--- a/apio/resources/programmers.jsonc
+++ b/apio/resources/programmers.jsonc
@@ -1,10 +1,7 @@
 // List of FPGA boards programmers definition that are used by apio. 
-// The programmers are reffers to by the boards in boards.json which can
+// The programmers are reffers to by the boards in boards.jsonc which can
 // add additional arguments to the programmers' command lines.
 //
-// Visual Studio Code note: set language model to 'jsonc' to avoid flagging
-// comments as errors.
-
 {
   "iceprog": {
     "command": "iceprog",

--- a/apio/scons/apio_args.py
+++ b/apio/scons/apio_args.py
@@ -110,7 +110,6 @@ class ApioArgs:
     PLATFORM_ID: str
     FPGA_ARCH: str
     FPGA_PART_NUM: str
-    FPGA_SIZE: str
     FPGA_TYPE: str
     FPGA_PACK: str
     TOP_MODULE: str
@@ -155,7 +154,6 @@ class ApioArgs:
             PLATFORM_ID=parser.arg_str("platform_id"),
             FPGA_ARCH=parser.arg_str("fpga_arch"),
             FPGA_PART_NUM=parser.arg_str("fpga_part_num"),
-            FPGA_SIZE=parser.arg_str("fpga_size"),
             FPGA_TYPE=parser.arg_str("fpga_type"),
             FPGA_PACK=parser.arg_str("fpga_pack"),
             TOP_MODULE=parser.arg_str("top_module"),

--- a/apio/scons/apio_args.py
+++ b/apio/scons/apio_args.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import Dict, List
 import os
 import sys
+from varname import argname
 from click import secho
 
 
@@ -105,6 +106,8 @@ class ApioArgsParser:
 class ApioArgs:
     """Apio scons args values. Contains values from scons args and os env."""
 
+    is_debug: bool
+
     # -- Scons str args.
     PROG: str
     PLATFORM_ID: str
@@ -137,6 +140,35 @@ class ApioArgs:
         assert self.YOSYS_PATH, "YOSYS_PATH env var is required."
         assert self.TRELLIS_PATH, "TRELLIS_PATH env var is required."
 
+    def check_required_str_args(self, *_args):
+        """Check that the specified required str args has a non default/empty
+        value and exit with an error if not. The args are in the forma
+        args.FPGA_ARCH, args.FPGA_TYPE, and so on.
+        """
+
+        # -- Use the magic of argname to get the name of the arg names
+        # -- that the caller want to check.
+        args_names = argname(
+            "self", "*_args", func=ApioArgs.check_required_str_args
+        )
+
+        for arg_name in args_names:
+            # -- Get the arg value.
+            arg_val = getattr(self, arg_name)
+            if self.is_debug:
+                print(f"Checking required scons arg: {arg_name} [{arg_val}]")
+
+            # -- We restrict this check to string args.
+            assert isinstance(
+                arg_val, str
+            ), f"Arg: {arg_name}, type: {type(arg_val)}"
+
+            # -- If the value is empty, print an error message and dexit.
+            if not arg_val:
+                # -- Arg is empty
+                secho(f"Error: missing required value: {arg_name}.")
+                sys.exit(1)
+
     @classmethod
     def make(cls, scons_args: Dict[str, str], is_debug: bool) -> ApioArgs:
         """Return a ApioArgs object with the parsed args."""
@@ -149,6 +181,7 @@ class ApioArgs:
 
         # -- Parse the args and populate an ApioArgs instance.
         result = ApioArgs(
+            is_debug=is_debug,
             # Scons tring args.
             PROG=parser.arg_str("prog"),
             PLATFORM_ID=parser.arg_str("platform_id"),

--- a/apio/scons/apio_args.py
+++ b/apio/scons/apio_args.py
@@ -114,7 +114,6 @@ class ApioArgs:
     FPGA_TYPE: str
     FPGA_PACK: str
     TOP_MODULE: str
-    FPGA_IDCODE: str
     TESTBENCH: str
     VERILATOR_NOWARNS: List[str]
     VERILATOR_WARNS: List[str]
@@ -160,7 +159,6 @@ class ApioArgs:
             FPGA_TYPE=parser.arg_str("fpga_type"),
             FPGA_PACK=parser.arg_str("fpga_pack"),
             TOP_MODULE=parser.arg_str("top_module"),
-            FPGA_IDCODE=parser.arg_str("fpga_idcode"),
             TESTBENCH=parser.arg_str("testbench"),
             VERILATOR_NOWARNS=parser.env_str_list(
                 "nowarn", ",", strip=True, keep_empty=False

--- a/apio/scons/apio_args.py
+++ b/apio/scons/apio_args.py
@@ -115,6 +115,7 @@ class ApioArgs:
     FPGA_PART_NUM: str
     FPGA_TYPE: str
     FPGA_PACK: str
+    FPGA_SPEED: str
     TOP_MODULE: str
     TESTBENCH: str
     VERILATOR_NOWARNS: List[str]
@@ -189,6 +190,7 @@ class ApioArgs:
             FPGA_PART_NUM=parser.arg_str("fpga_part_num"),
             FPGA_TYPE=parser.arg_str("fpga_type"),
             FPGA_PACK=parser.arg_str("fpga_pack"),
+            FPGA_SPEED=parser.arg_str("fpga_speed"),
             TOP_MODULE=parser.arg_str("top_module"),
             TESTBENCH=parser.arg_str("testbench"),
             VERILATOR_NOWARNS=parser.env_str_list(

--- a/apio/scons/apio_env.py
+++ b/apio/scons/apio_env.py
@@ -57,6 +57,10 @@ class ApioEnv:
 
         self.args = ApioArgs.make(scons_args, is_debug)
 
+        # -- Check that the required args for this class exist.
+        args = self.args
+        args.check_required_str_args(args.PLATFORM_ID)
+
         # -- Since we ae not using the default environment, make sure it was
         # -- not used unintentionally, e.v. in tests that run create multiple
         # -- scons env in the same session.

--- a/apio/scons/plugin_base.py
+++ b/apio/scons/plugin_base.py
@@ -114,7 +114,6 @@ class PluginBase:
         """Creates and returns the graphviz renderer builder."""
         apio_env = self.apio_env
         args = apio_env.args
-        # return apio_env.graphviz_builder(args.GRAPH_SPEC)
 
         # --Decode the graphic spec. Currently it's trivial since it
         # -- contains a single value.

--- a/apio/scons/plugin_ecp5.py
+++ b/apio/scons/plugin_ecp5.py
@@ -46,6 +46,7 @@ class PluginEcp5(PluginBase):
             args.FPGA_PART_NUM,
             args.FPGA_TYPE,
             args.FPGA_PACK,
+            args.FPGA_SPEED,
         )
 
         # -- Cache values.
@@ -97,12 +98,13 @@ class PluginEcp5(PluginBase):
         # -- Create the builder.
         return Builder(
             action=(
-                "nextpnr-ecp5 --{0} --package {1} "
+                "nextpnr-ecp5 --{0} --package {1} --speed {2} "
                 "--json $SOURCE --textcfg $TARGET "
-                "--report {2} --lpf {3} {4} --timing-allow-fail --force"
+                "--report {3} --lpf {4} {5} --timing-allow-fail --force"
             ).format(
                 args.FPGA_TYPE,
                 args.FPGA_PACK,
+                args.FPGA_SPEED,
                 TARGET + ".pnr",
                 self.constrain_file(),
                 "" if args.VERBOSE_ALL or args.VERBOSE_PNR else "-q",

--- a/apio/scons/plugin_ecp5.py
+++ b/apio/scons/plugin_ecp5.py
@@ -105,13 +105,10 @@ class PluginEcp5(PluginBase):
     # @overrides
     def bitstream_builder(self) -> BuilderBase:
         """Creates and returns the bitstream builder."""
-        apio_env = self.apio_env
-        args = apio_env.args
         return Builder(
-            action="ecppack --compress --db {0} {1} $SOURCE "
-            "{2}/hardware.bit".format(
+            action="ecppack --compress --db {0} $SOURCE "
+            "{1}/hardware.bit".format(
                 self.database_path,
-                "" if not args.FPGA_IDCODE else f"--idcode {args.FPGA_IDCODE}",
                 BUILD_DIR,
             ),
             suffix=".bit",

--- a/apio/scons/plugin_ecp5.py
+++ b/apio/scons/plugin_ecp5.py
@@ -91,8 +91,7 @@ class PluginEcp5(PluginBase):
                 "--json $SOURCE --textcfg $TARGET "
                 "--report {2} --lpf {3} {4} --timing-allow-fail --force"
             ).format(
-                # -- See details here: https://tinyurl.com/apio-ecp5-25k-12k
-                "25k" if (args.FPGA_TYPE == "12k") else args.FPGA_TYPE,
+                args.FPGA_TYPE,
                 args.FPGA_PACK,
                 TARGET + ".pnr",
                 self.constrain_file(),

--- a/apio/scons/plugin_ecp5.py
+++ b/apio/scons/plugin_ecp5.py
@@ -38,6 +38,16 @@ class PluginEcp5(PluginBase):
         # -- Call parent constructor.
         super().__init__(apio_env)
 
+        # -- Make sure the require args we expect are indeed there.
+        args = apio_env.args
+        args.check_required_str_args(
+            args.YOSYS_PATH,
+            args.TRELLIS_PATH,
+            args.FPGA_PART_NUM,
+            args.FPGA_TYPE,
+            args.FPGA_PACK,
+        )
+
         # -- Cache values.
         self.database_path = os.path.join(
             apio_env.args.TRELLIS_PATH, "database"

--- a/apio/scons/plugin_gowin.py
+++ b/apio/scons/plugin_gowin.py
@@ -90,7 +90,7 @@ class PluginGowin(PluginBase):
             ).format(
                 args.FPGA_PART_NUM,
                 TARGET + ".pnr",
-                args.FPGA_TYPE.upper(),
+                args.FPGA_TYPE,
                 self.constrain_file(),
                 "" if args.VERBOSE_ALL or args.VERBOSE_PNR else "-q",
             ),
@@ -106,7 +106,7 @@ class PluginGowin(PluginBase):
         args = apio_env.args
         return Builder(
             action="gowin_pack -d {0} -o $TARGET $SOURCE".format(
-                args.FPGA_TYPE.upper()
+                args.FPGA_TYPE
             ),
             suffix=".fs",
             src_suffix=".pnr.json",

--- a/apio/scons/plugin_gowin.py
+++ b/apio/scons/plugin_gowin.py
@@ -37,6 +37,12 @@ class PluginGowin(PluginBase):
         # -- Call parent constructor.
         super().__init__(apio_env)
 
+        # -- Make sure the require args we expect are indeed there.
+        args = apio_env.args
+        args.check_required_str_args(
+            args.YOSYS_PATH, args.FPGA_PART_NUM, args.FPGA_TYPE
+        )
+
         # -- Cache values.
         self.yosys_lib_dir = apio_env.args.YOSYS_PATH + "/gowin"
         self.yosys_lib_file = self.yosys_lib_dir + "/cells_sim.v"

--- a/apio/scons/plugin_ice40.py
+++ b/apio/scons/plugin_ice40.py
@@ -37,6 +37,12 @@ class PluginIce40(PluginBase):
         # -- Call parent constructor.
         super().__init__(apio_env)
 
+        # -- Make sure the require args we expect are indeed there.
+        args = apio_env.args
+        args.check_required_str_args(
+            args.YOSYS_PATH, args.FPGA_PART_NUM, args.FPGA_TYPE, args.FPGA_PACK
+        )
+
         # -- Cache values.
         self.yosys_lib_dir = apio_env.args.YOSYS_PATH + "/ice40"
         self.yosys_lib_file = self.yosys_lib_dir + "/cells_sim.v"

--- a/apio/scons/plugin_ice40.py
+++ b/apio/scons/plugin_ice40.py
@@ -83,11 +83,10 @@ class PluginIce40(PluginBase):
         # -- Create the builder.
         return Builder(
             action=(
-                "nextpnr-ice40 --{0}{1} --package {2} --json $SOURCE "
-                "--asc $TARGET --report {3} --pcf {4} {5}"
+                "nextpnr-ice40 --{0} --package {1} --json $SOURCE "
+                "--asc $TARGET --report {2} --pcf {3} {4}"
             ).format(
                 args.FPGA_TYPE,
-                args.FPGA_SIZE,
                 args.FPGA_PACK,
                 TARGET + ".pnr",
                 self.constrain_file(),

--- a/apio/scons/plugin_util.py
+++ b/apio/scons/plugin_util.py
@@ -164,9 +164,9 @@ def verilog_src_scanner(apio_env: ApioEnv) -> Scanner.Base:
     # -- changed.
     core_dependencies = [
         "apio.ini",
-        "boards.json",
-        "fpgas.json",
-        "programmers.json",
+        "boards.jsonc",
+        "fpgas.jsonc",
+        "programmers.jsonc",
     ]
 
     def verilog_src_scanner_func(

--- a/apio/utils/pkg_util.py
+++ b/apio/utils/pkg_util.py
@@ -209,7 +209,7 @@ def package_version_ok(
 ) -> bool:
     """Return true if the packagea is both in profile and plagrom packages
     and its version in the provile meet the requirements in the
-    distribution.jsonc file. Otherwise return false."""
+    config.jsonc file. Otherwise return false."""
 
     # If this package is not applicable to this platform, return False.
     if package_name not in apio_ctx.platform_packages:

--- a/apio/utils/pkg_util.py
+++ b/apio/utils/pkg_util.py
@@ -297,7 +297,7 @@ def _list_section(title: str, items: List[List[str]], color: str) -> None:
     """A helper function for printing one serction of list_packages()."""
     # -- Construct horizontal lines at terminal width.
     config = util.get_terminal_config()
-    line_width = config.terminal_width if config.terminal_mode() else 80
+    line_width = config.terminal_width if config.terminal_mode else 80
     line = "─" * line_width
     dline = "═" * line_width
 

--- a/apio/utils/pkg_util.py
+++ b/apio/utils/pkg_util.py
@@ -209,7 +209,7 @@ def package_version_ok(
 ) -> bool:
     """Return true if the packagea is both in profile and plagrom packages
     and its version in the provile meet the requirements in the
-    distribution.json file. Otherwise return false."""
+    distribution.jsonc file. Otherwise return false."""
 
     # If this package is not applicable to this platform, return False.
     if package_name not in apio_ctx.platform_packages:

--- a/apio/utils/util.py
+++ b/apio/utils/util.py
@@ -99,12 +99,14 @@ class TerminalConfig:
     def __post_init__(self):
         """Validates initialization."""
         assert isinstance(self.mode, TerminalMode), self
-        assert (self.terminal_width is not None) == self.terminal_mode(), self
+        assert (self.terminal_width is not None) == self.terminal_mode, self
 
+    @property
     def terminal_mode(self) -> bool:
         """True iff in terminal mode."""
         return self.mode == TerminalMode.TERMINAL
 
+    @property
     def pipe_mode(self) -> bool:
         """True iff in pipe mode."""
         return self.mode == TerminalMode.PIPE

--- a/scripts/check-icestudio-test-examples.sh
+++ b/scripts/check-icestudio-test-examples.sh
@@ -20,13 +20,21 @@ for proj in $projects;  do
     # -- Go to the project's dir.
     pushd $proj
 
+    # -- Test if the project has testbenches.
+    set +e
+    ls *_tb.v
+    TB_STATUS=$?
+    set -e
+
+
     # -- Exceute apio commands in the project. They should succeeed.
     set -x
       apio clean
       apio build
       apio lint
-      # TODO: test only if there is a testbench
-      # apio test
+      if [ $TB_STATUS -eq 0 ]; then
+        apio test
+      fi   
       apio graph
       apio report
       apio clean

--- a/scripts/check-icestudio-test-examples.sh
+++ b/scripts/check-icestudio-test-examples.sh
@@ -24,13 +24,15 @@ for proj in $projects;  do
     set -x
       apio clean
       apio build
-      # apio lint
+      apio lint
+      # TODO: test only if there is a testbench
       # apio test
       apio graph
       apio report
       apio clean
     set +x
 
+    # -- Go back to the repo's root.
     popd
     
 done

--- a/scripts/check-icestudio-test-examples.sh
+++ b/scripts/check-icestudio-test-examples.sh
@@ -18,17 +18,20 @@ for proj in $projects;  do
     echo
 
     # -- Go to the project's dir.
-    cd $proj
+    pushd $proj
 
     # -- Exceute apio commands in the project. They should succeeed.
     set -x
+      apio clean
       apio build
-      apio lint
-      apio test
+      # apio lint
+      # apio test
       apio graph
       apio report
       apio clean
     set +x
+
+    popd
     
 done
 

--- a/test-examples/ecp5/colorlight-5a-75b-v8/parity/apio.ini
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/parity/apio.ini
@@ -1,0 +1,4 @@
+[env]
+board = colorlight-5a-75b-v8
+top-module = parity
+

--- a/test-examples/ecp5/colorlight-5a-75b-v8/parity/apio_testing.vh
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/parity/apio_testing.vh
@@ -1,0 +1,80 @@
+// Utility macros for testbenches that are compatible with apio.
+
+`default_nettype none
+
+`define DUMP_FILE_NAME(x) `"x.vcd`"
+
+// Call this macro at the begining of the testbench macro. It defines
+// a clk signal and a variable clk_num that indicates the clock num.
+`define DEF_CLK \
+    reg clk = 0; \
+    integer clk_num = 0; \
+    always begin \
+        #10 clk = ~clk; \
+        if (clk) clk_num += 1; \
+    end
+
+// Asserts that the value of 'signal' is 'value'. If not, it prints an error message and aborts
+// the simulation. When running under apio sim, the macro INTERACTIVE_SIM is defined
+// and the failed assertions does not exist to allow showing the sigmulation results
+// in the graphical window.
+`define EXPECT(signal, value) \
+    if (signal !== (value)) begin \
+        $display("*** ASSERTION FAILED in %m (clk_num=%0d): expected (signal == value), actual: 'h%h", (clk_num), (signal)); \
+        `ifndef INTERACTIVE_SIM \
+             $fatal; \
+        `endif \
+    end
+
+// Transition from clock low to clock high. Typically this is not
+// called directly and clock is managed using `CLK().
+`define CLK_HIGH \
+    begin \
+        `EXPECT(clk, 0); \
+        @ (posedge clk); \
+        #2; \
+        `EXPECT(clk, 1); \
+    end
+
+// Transition from clock high to clock low. Typically this is not
+// called directly and clock is managed using `CLK().
+`define CLK_LOW \
+    begin \
+        `EXPECT(clk, 1); \
+        @ (negedge clk); \
+        #2; \
+        `EXPECT(clk, 0); \
+    end
+
+// Simulate one clock. Wait for low to high and then high to low transition.
+`define CLK \
+    begin \
+        `CLK_HIGH \
+        `CLK_LOW \
+    end
+
+// Simulate n clocks.
+`define CLKS(n) \
+    begin \
+        repeat(n) begin \
+            `CLK \
+        end \
+    end
+
+// Place this macro immediatly after the 'initial begin' statement of the testbench.
+// 'testbench' is the name of the testbench module. The macro sets the file
+// that will contains the simulation results.
+// The macro VCD_OUTPUT is defined automatically by the apio commands sim and test
+// and contains base name of the expected output file.
+`define TEST_BEGIN(testbench) \
+    begin \
+            $dumpvars(0, testbench); \
+    end
+
+// Place this macro at the end of the 'initial begin' block of the testbench.
+`define TEST_END \
+    begin \
+        @ (posedge clk); \
+        $display("End of simulation"); \
+        $finish; \
+    end

--- a/test-examples/ecp5/colorlight-5a-75b-v8/parity/fpgas.jsonc
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/parity/fpgas.jsonc
@@ -1,0 +1,12 @@
+// Custom fpga definition. We use it to see how changing
+// the speed (6 | 7 | 8) affects the max clock speed.
+{
+  "lfe5u-25f-6bg256c": {
+    "part_num": "LFE5U-25F-6BG256C",
+    "arch": "ecp5",
+    "size": "25k",
+    "type": "25k",
+    "pack": "CABGA256",
+    "speed": "6"
+  }
+}

--- a/test-examples/ecp5/colorlight-5a-75b-v8/parity/parity.v
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/parity/parity.v
@@ -1,0 +1,18 @@
+// An examples that require high propogation delay to compute the 
+// parity of a large word. Should result in lower max clock speed than
+// usual.
+
+module parity (
+    input      sys_clk,
+    output reg led  // Active low
+);
+
+  // Placement fails around 269.
+  reg [260:0] counter = 0;
+
+  always @(posedge sys_clk) begin
+    counter <= counter + 1;
+    led <= ^counter;
+  end
+
+endmodule

--- a/test-examples/ecp5/colorlight-5a-75b-v8/parity/parity_tb.gtkw
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/parity/parity_tb.gtkw
@@ -1,0 +1,29 @@
+[*]
+[*] GTKWave Analyzer v3.4.0 (w)1999-2022 BSI
+[*] Sat Jan 18 17:31:28 2025
+[*]
+[dumpfile] "/Volumes/projects/apio-dev/repo/test-examples/ecp5/colorlight-5a-75b-v8/parity/_build/parity_tb.vcd"
+[dumpfile_mtime] "Sat Jan 18 17:30:59 2025"
+[dumpfile_size] 1558
+[savefile] "/Volumes/projects/apio-dev/repo/test-examples/ecp5/colorlight-5a-75b-v8/parity/parity_tb.gtkw"
+[timestart] 0
+[size] 1000 600
+[pos] 150 -1
+*-10.894506 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] parity_tb.
+[sst_width] 253
+[signals_width] 144
+[sst_expanded] 1
+[sst_vpaned_height] 158
+@420
+parity_tb.clk_num
+@28
+parity_tb.clk
+@200
+-
+@22
+parity_tb.parity.counter[260:0]
+@29
+parity_tb.parity.led
+[pattern_trace] 1
+[pattern_trace] 0

--- a/test-examples/ecp5/colorlight-5a-75b-v8/parity/parity_tb.v
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/parity/parity_tb.v
@@ -1,0 +1,30 @@
+// A testbench for testing the parity module.
+
+`include "apio_testing.vh"
+
+`timescale 10 ns / 1 ns
+
+module parity_tb ();
+
+  // This defines a managed signal called 'clk'.
+  `DEF_CLK
+
+  // Outputs.
+  wire led;
+
+  // Instantiate a parity that toggles the led every 5 clocks.
+  parity parity (
+      .sys_clk(clk),
+      .led(led)
+  );
+
+  initial begin
+    `TEST_BEGIN(parity_tb)
+
+    // Free run for 30 clocks.
+    `CLKS(30)
+
+    `TEST_END
+  end
+
+endmodule

--- a/test-examples/ecp5/colorlight-5a-75b-v8/parity/pinout.lpf
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/parity/pinout.lpf
@@ -1,0 +1,12 @@
+# -- Board: colorlight-5a-75e-v71-FT2232H
+
+# -- CLK
+LOCATE COMP "sys_clk" SITE "P6";
+IOBUF  PORT "sys_clk" PULLMODE=NONE IO_TYPE=LVCMOS33 DRIVE=4;
+
+# -- LED
+LOCATE COMP "led" SITE "T6";
+IOBUF PORT "led" PULLMODE=NONE IO_TYPE=LVCMOS33 DRIVE=4; 
+
+
+

--- a/test-examples/gowin/sipeed-tang-nano-9k/parity/apio.ini
+++ b/test-examples/gowin/sipeed-tang-nano-9k/parity/apio.ini
@@ -1,0 +1,6 @@
+
+[env]
+board = sipeed-tang-nano-9k
+top-module = parity
+
+

--- a/test-examples/gowin/sipeed-tang-nano-9k/parity/apio_testing.vh
+++ b/test-examples/gowin/sipeed-tang-nano-9k/parity/apio_testing.vh
@@ -1,0 +1,80 @@
+// Utility macros for testbenches that are compatible with apio.
+
+`default_nettype none
+
+`define DUMP_FILE_NAME(x) `"x.vcd`"
+
+// Call this macro at the begining of the testbench macro. It defines
+// a clk signal and a variable clk_num that indicates the clock num.
+`define DEF_CLK \
+    reg clk = 0; \
+    integer clk_num = 0; \
+    always begin \
+        #10 clk = ~clk; \
+        if (clk) clk_num += 1; \
+    end
+
+// Asserts that the value of 'signal' is 'value'. If not, it prints an error message and aborts
+// the simulation. When running under apio sim, the macro INTERACTIVE_SIM is defined
+// and the failed assertions does not exist to allow showing the sigmulation results
+// in the graphical window.
+`define EXPECT(signal, value) \
+    if (signal !== (value)) begin \
+        $display("*** ASSERTION FAILED in %m (clk_num=%0d): expected (signal == value), actual: 'h%h", (clk_num), (signal)); \
+        `ifndef INTERACTIVE_SIM \
+             $fatal; \
+        `endif \
+    end
+
+// Transition from clock low to clock high. Typically this is not
+// called directly and clock is managed using `CLK().
+`define CLK_HIGH \
+    begin \
+        `EXPECT(clk, 0); \
+        @ (posedge clk); \
+        #2; \
+        `EXPECT(clk, 1); \
+    end
+
+// Transition from clock high to clock low. Typically this is not
+// called directly and clock is managed using `CLK().
+`define CLK_LOW \
+    begin \
+        `EXPECT(clk, 1); \
+        @ (negedge clk); \
+        #2; \
+        `EXPECT(clk, 0); \
+    end
+
+// Simulate one clock. Wait for low to high and then high to low transition.
+`define CLK \
+    begin \
+        `CLK_HIGH \
+        `CLK_LOW \
+    end
+
+// Simulate n clocks.
+`define CLKS(n) \
+    begin \
+        repeat(n) begin \
+            `CLK \
+        end \
+    end
+
+// Place this macro immediatly after the 'initial begin' statement of the testbench.
+// 'testbench' is the name of the testbench module. The macro sets the file
+// that will contains the simulation results.
+// The macro VCD_OUTPUT is defined automatically by the apio commands sim and test
+// and contains base name of the expected output file.
+`define TEST_BEGIN(testbench) \
+    begin \
+            $dumpvars(0, testbench); \
+    end
+
+// Place this macro at the end of the 'initial begin' block of the testbench.
+`define TEST_END \
+    begin \
+        @ (posedge clk); \
+        $display("End of simulation"); \
+        $finish; \
+    end

--- a/test-examples/gowin/sipeed-tang-nano-9k/parity/parity.cst
+++ b/test-examples/gowin/sipeed-tang-nano-9k/parity/parity.cst
@@ -1,0 +1,10 @@
+// Board details at
+// https://wiki.sipeed.com/hardware/en/tang/Tang-Nano-9K/Nano-9K.html
+
+// See examples here https://github.com/sipeed/TangNano-9K-example/tree/main
+
+IO_LOC "sys_clk"   52;
+IO_PORT "sys_clk" IO_TYPE=LVCMOS33 PULL_MODE=NONE;
+
+IO_LOC "led"       10; // Active low
+

--- a/test-examples/gowin/sipeed-tang-nano-9k/parity/parity.v
+++ b/test-examples/gowin/sipeed-tang-nano-9k/parity/parity.v
@@ -1,0 +1,18 @@
+// An examples that require high propogation delay to compute the 
+// parity of a large word. Should result in lower max clock speed than
+// usual.
+
+module parity (
+    input      sys_clk,
+    output reg led  // Active low
+);
+
+  // Placement fails around 269.
+  reg [260:0] counter = 0;
+
+  always @(posedge sys_clk) begin
+    counter <= counter + 1;
+    led <= ^counter;
+  end
+
+endmodule

--- a/test-examples/gowin/sipeed-tang-nano-9k/parity/parity_tb.gtkw
+++ b/test-examples/gowin/sipeed-tang-nano-9k/parity/parity_tb.gtkw
@@ -1,0 +1,29 @@
+[*]
+[*] GTKWave Analyzer v3.4.0 (w)1999-2022 BSI
+[*] Sat Jan 18 17:14:16 2025
+[*]
+[dumpfile] "/Volumes/projects/apio-dev/repo/test-examples/gowin/sipeed-tang-nano-9k/parity/_build/parity_tb.vcd"
+[dumpfile_mtime] "Sat Jan 18 17:12:40 2025"
+[dumpfile_size] 6524
+[savefile] "/Volumes/projects/apio-dev/repo/test-examples/gowin/sipeed-tang-nano-9k/parity/parity_tb.gtkw"
+[timestart] 0
+[size] 1288 763
+[pos] 117 29
+*-13.032831 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] parity_tb.
+[sst_width] 253
+[signals_width] 202
+[sst_expanded] 1
+[sst_vpaned_height] 231
+@420
+parity_tb.clk_num
+@28
+parity_tb.clk
+@200
+-
+@25
+parity_tb.parity.blink_counter[1023:0]
+@28
+parity_tb.parity.led
+[pattern_trace] 1
+[pattern_trace] 0

--- a/test-examples/gowin/sipeed-tang-nano-9k/parity/parity_tb.v
+++ b/test-examples/gowin/sipeed-tang-nano-9k/parity/parity_tb.v
@@ -1,0 +1,30 @@
+// A testbench for testing the parity module.
+
+`include "apio_testing.vh"
+
+`timescale 10 ns / 1 ns
+
+module parity_tb ();
+
+  // This defines a managed signal called 'clk'.
+  `DEF_CLK
+
+  // Outputs.
+  wire led;
+
+  // Instantiate a parity that toggles the led every 5 clocks.
+  parity parity (
+      .sys_clk(clk),
+      .led(led)
+  );
+
+  initial begin
+    `TEST_BEGIN(parity_tb)
+
+    // Free run for 30 clocks.
+    `CLKS(30)
+
+    `TEST_END
+  end
+
+endmodule

--- a/test/commands/test_apio_fpgas.py
+++ b/test/commands/test_apio_fpgas.py
@@ -18,7 +18,7 @@ CUSTOM_FPGAS = """
 
 
 def test_fpgas_ok(apio_runner: ApioRunner):
-    """Test "apio fpgas" command with standard fpgas.json."""
+    """Test "apio fpgas" command with standard fpgas.jsonc."""
 
     with apio_runner.in_sandbox() as sb:
 
@@ -27,29 +27,29 @@ def test_fpgas_ok(apio_runner: ApioRunner):
         sb.assert_ok(result)
         # -- Note: pytest sees the piped version of the command's output.
         # -- Run 'apio fpgas' | cat' to reproduce it.
-        assert "Loading custom 'fpgas.json'" not in result.output
+        assert "Loading custom 'fpgas.jsonc'" not in result.output
         assert "ice40-hx4k-tq144" in result.output
         assert "my_custom_fpga" not in result.output
 
 
 def test_custom_fpga(apio_runner: ApioRunner):
-    """Test "apio fpgas" command with a custom fpgas.json."""
+    """Test "apio fpgas" command with a custom fpgas.jsonc."""
 
     with apio_runner.in_sandbox() as sb:
 
         # -- Write apio.ini for apio to pick the project's default
-        # -- fpgas.json.
+        # -- fpgas.jsonc.
         sb.write_default_apio_ini()
 
-        # -- Write a custom boards.json file in the project's directory.
-        sb.write_file("fpgas.json", CUSTOM_FPGAS)
+        # -- Write a custom boards.jsonc file in the project's directory.
+        sb.write_file("fpgas.jsonc", CUSTOM_FPGAS)
 
         # -- Execute "apio boards"
         result = sb.invoke_apio_cmd(apio, ["fpgas"])
         sb.assert_ok(result)
         # -- Note: pytest sees the piped version of the command's output.
         # -- Run 'apio build' | cat' to reproduce it.
-        assert "Loading custom 'fpgas.json'" in result.output
+        assert "Loading custom 'fpgas.jsonc'" in result.output
         assert "ice40-hx4k-tq144" not in result.output
         assert "my_custom_fpga" in result.output
         assert "Total of 1 fpga" in result.output

--- a/test/commands/test_apio_fpgas.py
+++ b/test/commands/test_apio_fpgas.py
@@ -28,7 +28,7 @@ def test_fpgas_ok(apio_runner: ApioRunner):
         # -- Note: pytest sees the piped version of the command's output.
         # -- Run 'apio fpgas' | cat' to reproduce it.
         assert "Loading custom 'fpgas.jsonc'" not in result.output
-        assert "ice40-hx4k-tq144" in result.output
+        assert "ice40hx4k-tq144-8k" in result.output
         assert "my_custom_fpga" not in result.output
 
 
@@ -50,6 +50,6 @@ def test_custom_fpga(apio_runner: ApioRunner):
         # -- Note: pytest sees the piped version of the command's output.
         # -- Run 'apio build' | cat' to reproduce it.
         assert "Loading custom 'fpgas.jsonc'" in result.output
-        assert "ice40-hx4k-tq144" not in result.output
+        assert "ice40hx4k-tq144-8k" not in result.output
         assert "my_custom_fpga" in result.output
         assert "Total of 1 fpga" in result.output

--- a/test/commands/test_apio_fpgas.py
+++ b/test/commands/test_apio_fpgas.py
@@ -9,7 +9,7 @@ CUSTOM_FPGAS = """
 {
   "my_custom_fpga": {
     "arch": "ice40",
-    "type": "lp",
+    "type": "lp1k",
     "size": "1k",
     "pack": "swg16tr"
   }

--- a/test/integration/test_commands.py
+++ b/test/integration/test_commands.py
@@ -14,7 +14,7 @@ CUSTOM_BOARDS = """
 {
   "my_custom_board": {
     "name": "My Custom Board v3.1c",
-    "fpga": "ice40-up5k-sg48",
+    "fpga": "ice40up5k-sg48",
     "programmer": {
       "type": "iceprog"
     },

--- a/test/integration/test_commands.py
+++ b/test/integration/test_commands.py
@@ -31,7 +31,7 @@ CUSTOM_BOARDS = """
 
 
 def test_boards_custom_board(apio_runner: ApioRunner):
-    """Test boards listing with a custom boards.json file."""
+    """Test boards listing with a custom boards.jsonc file."""
 
     # -- If the option 'offline' is passed, the test is skip
     # -- (This test is slow and requires internet connectivity)
@@ -43,21 +43,21 @@ def test_boards_custom_board(apio_runner: ApioRunner):
         # -- Write an apio.ini file.
         sb.write_apio_ini({"board": "my_custom_board", "top-module": "main"})
 
-        # -- Write a custom boards.json file in the project's directory.
-        sb.write_file("boards.json", CUSTOM_BOARDS)
+        # -- Write a custom boards.jsonc file in the project's directory.
+        sb.write_file("boards.jsonc", CUSTOM_BOARDS)
 
         # -- Execute "apio boards"
         result = sb.invoke_apio_cmd(apio, ["boards"])
         sb.assert_ok(result)
         # -- Note: pytest sees the piped version of the command's output.
-        assert "Loading custom 'boards.json'" in result.output
+        assert "Loading custom 'boards.jsonc'" in result.output
         assert "alhambra-ii" not in result.output
         assert "my_custom_board" in result.output
         assert "Total of 1 board" in result.output
 
 
 def test_boards_list_ok(apio_runner: ApioRunner):
-    """Test normal board listing with the apio's boards.json."""
+    """Test normal board listing with the apio's boards.jsonc."""
 
     # -- If the option 'offline' is passed, the test is skip
     # -- (This test is slow and requires internet connectivity)
@@ -69,7 +69,7 @@ def test_boards_list_ok(apio_runner: ApioRunner):
         # -- Run 'apio boards'
         result = sb.invoke_apio_cmd(apio, ["boards"])
         sb.assert_ok(result)
-        assert "Loading custom 'boards.json'" not in result.output
+        assert "Loading custom 'boards.jsonc'" not in result.output
         assert "PACK" not in result.output
         assert "alhambra-ii" in result.output
         assert "my_custom_board" not in result.output
@@ -78,7 +78,7 @@ def test_boards_list_ok(apio_runner: ApioRunner):
         # -- Run 'apio boards -v'
         result = sb.invoke_apio_cmd(apio, ["boards", "-v"])
         sb.assert_ok(result)
-        assert "Loading custom 'boards.json'" not in result.output
+        assert "Loading custom 'boards.jsonc'" not in result.output
         assert "PACK" in result.output
         assert "alhambra-ii" in result.output
         assert "my_custom_board" not in result.output

--- a/test/integration/test_commands.py
+++ b/test/integration/test_commands.py
@@ -205,7 +205,7 @@ def _test_project(
         )
         sb.assert_ok(result)
         assert f"Copying {example} example files" in result.output
-        assert "Fetched successfully" in result.output
+        assert "fetched successfully" in result.output
         assert getsize(sb.proj_dir / "apio.ini")
 
         # -- Remember the original list of project files.

--- a/test/integration/test_examples.py
+++ b/test/integration/test_examples.py
@@ -34,10 +34,9 @@ def test_examples(apio_runner: ApioRunner):
         )
         sb.assert_ok(result)
         assert "Copying alhambra-ii/ledon example files" in result.output
-        assert (
-            "Fetched successfully the files of example "
-            "'alhambra-ii/ledon'" in result.output
-        )
+        assert "Fetched file apio.ini" in result.output
+        assert "Fetched file ledon.v" in result.output
+        assert "Example fetched successfully" in result.output
         assert getsize("ledon.v")
 
         # -- 'apio examples fetch-board alhambra-ii'
@@ -47,7 +46,7 @@ def test_examples(apio_runner: ApioRunner):
         )
         sb.assert_ok(result)
         assert "Creating directory alhambra-ii" in result.output
-        assert "has been fetched successfully" in result.output
+        assert "Board examples fetched successfully" in result.output
         assert getsize("alhambra-ii/ledon/ledon.v")
 
         # -- 'apio examples fetch alhambra-ii/ledon -d dir1'
@@ -57,10 +56,7 @@ def test_examples(apio_runner: ApioRunner):
         )
         sb.assert_ok(result)
         assert "Copying alhambra-ii/ledon example files" in result.output
-        assert (
-            "Fetched successfully the files of example "
-            "'alhambra-ii/ledon'" in result.output
-        )
+        assert "Example fetched successfully" in result.output
         assert getsize("dir1/ledon.v")
 
         # -- 'apio examples fetch-board alhambra -d dir2
@@ -70,8 +66,5 @@ def test_examples(apio_runner: ApioRunner):
         )
         sb.assert_ok(result)
         assert f"Creating directory dir2{os.sep}alhambra-ii" in result.output
-        assert (
-            "Board 'alhambra-ii' examples has been fetched "
-            "successfully" in result.output
-        )
+        assert "Board examples fetched successfully" in result.output
         assert getsize("dir2/alhambra-ii/ledon/ledon.v")

--- a/test/scons/test_apio_args.py
+++ b/test/scons/test_apio_args.py
@@ -22,7 +22,6 @@ def test_apio_args_with_values(apio_runner: ApioRunner):
             "platform_id": "platform123",
             "fpga_arch": "arch1",
             "fpga_part_num": "part_num_0001",
-            "fpga_size": "size1",
             "fpga_type": "type1",
             "fpga_pack": "pack1",
             "top_module": "top1",
@@ -47,7 +46,6 @@ def test_apio_args_with_values(apio_runner: ApioRunner):
         assert apio_args.PROG == "programmer"
         assert apio_args.FPGA_ARCH == "arch1"
         assert apio_args.FPGA_PART_NUM == "part_num_0001"
-        assert apio_args.FPGA_SIZE == "size1"
         assert apio_args.FPGA_TYPE == "type1"
         assert apio_args.FPGA_PACK == "pack1"
         assert apio_args.TOP_MODULE == "top1"
@@ -84,7 +82,6 @@ def test_apio_args_no_values(apio_runner: ApioRunner):
         assert apio_args.PROG == ""
         assert apio_args.FPGA_ARCH == ""
         assert apio_args.FPGA_PART_NUM == ""
-        assert apio_args.FPGA_SIZE == ""
         assert apio_args.FPGA_TYPE == ""
         assert apio_args.FPGA_PACK == ""
         assert apio_args.TOP_MODULE == ""

--- a/test/scons/test_apio_args.py
+++ b/test/scons/test_apio_args.py
@@ -24,6 +24,7 @@ def test_apio_args_with_values(apio_runner: ApioRunner):
             "fpga_part_num": "part_num_0001",
             "fpga_type": "type1",
             "fpga_pack": "pack1",
+            "fpga_speed": "7",
             "top_module": "top1",
             "testbench": "testbench1",
             "nowarn": "warn1,warn2",
@@ -48,6 +49,7 @@ def test_apio_args_with_values(apio_runner: ApioRunner):
         assert apio_args.FPGA_PART_NUM == "part_num_0001"
         assert apio_args.FPGA_TYPE == "type1"
         assert apio_args.FPGA_PACK == "pack1"
+        assert apio_args.FPGA_SPEED == "7"
         assert apio_args.TOP_MODULE == "top1"
         assert apio_args.TESTBENCH == "testbench1"
         assert apio_args.VERILATOR_NOWARNS == ["warn1", "warn2"]
@@ -84,6 +86,7 @@ def test_apio_args_no_values(apio_runner: ApioRunner):
         assert apio_args.FPGA_PART_NUM == ""
         assert apio_args.FPGA_TYPE == ""
         assert apio_args.FPGA_PACK == ""
+        assert apio_args.FPGA_SPEED == ""
         assert apio_args.TOP_MODULE == ""
         assert apio_args.TESTBENCH == ""
         assert apio_args.VERILATOR_NOWARNS == []

--- a/test/scons/test_apio_args.py
+++ b/test/scons/test_apio_args.py
@@ -26,7 +26,6 @@ def test_apio_args_with_values(apio_runner: ApioRunner):
             "fpga_type": "type1",
             "fpga_pack": "pack1",
             "top_module": "top1",
-            "fpga_idcode": "idcode1",
             "testbench": "testbench1",
             "nowarn": "warn1,warn2",
             "warn": "warn3,warn4",
@@ -52,7 +51,6 @@ def test_apio_args_with_values(apio_runner: ApioRunner):
         assert apio_args.FPGA_TYPE == "type1"
         assert apio_args.FPGA_PACK == "pack1"
         assert apio_args.TOP_MODULE == "top1"
-        assert apio_args.FPGA_IDCODE == "idcode1"
         assert apio_args.TESTBENCH == "testbench1"
         assert apio_args.VERILATOR_NOWARNS == ["warn1", "warn2"]
         assert apio_args.VERILATOR_WARNS == ["warn3", "warn4"]
@@ -90,7 +88,6 @@ def test_apio_args_no_values(apio_runner: ApioRunner):
         assert apio_args.FPGA_TYPE == ""
         assert apio_args.FPGA_PACK == ""
         assert apio_args.TOP_MODULE == ""
-        assert apio_args.FPGA_IDCODE == ""
         assert apio_args.TESTBENCH == ""
         assert apio_args.VERILATOR_NOWARNS == []
         assert apio_args.VERILATOR_WARNS == []

--- a/test/scons/test_plugin_util.py
+++ b/test/scons/test_plugin_util.py
@@ -105,9 +105,9 @@ def test_verilog_src_scanner(apio_runner: ApioRunner):
         # -- Create file lists
         core_dependencies = [
             "apio.ini",
-            "boards.json",
-            "programmers.json",
-            "fpgas.json",
+            "boards.jsonc",
+            "programmers.jsonc",
+            "fpgas.jsonc",
         ]
 
         file_dependencies = [

--- a/test/test_apio_context.py
+++ b/test/test_apio_context.py
@@ -3,14 +3,10 @@ Tests of apio_context.py
 """
 
 import os
-import re
 from pathlib import Path
 from test.conftest import ApioRunner
 from pytest import LogCaptureFixture, raises
 from apio.apio_context import ApioContext, ApioContextScope
-
-# pylint: disable=fixme
-# TODO: Add more tests.
 
 
 def test_init(apio_runner: ApioRunner):
@@ -86,76 +82,3 @@ def test_home_dir_with_relative_path(
             "Error: apio home dir should be an absolute path"
             in capsys.readouterr().out
         )
-
-
-# -- These programmers are known to be unused.
-# -- https://github.com/FPGAwars/apio/issues/536
-KNOWN_UNUSED_PROGRAMMERS = ["ujprog"]
-
-
-def test_resources_references(apio_runner: ApioRunner):
-    """Tests the consistency of the board references to fpgas and
-    programmers."""
-
-    with apio_runner.in_sandbox():
-
-        # -- Create an apio context so we can access the resources.
-        apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
-
-        unused_programmers = set(apio_ctx.programmers.keys())
-
-        for board_name, board_info in apio_ctx.boards.items():
-            # -- Prepare a context message for failing assertions.
-            board_msg = f"While testing board {board_name}"
-
-            # -- Assert that required fields exist.
-            assert "fpga" in board_info, board_msg
-            assert "programmer" in board_info, board_msg
-            assert "type" in board_info["programmer"], board_msg
-
-            # -- Check that the fpga exists.
-            board_fpga = board_info["fpga"]
-            assert apio_ctx.fpgas[board_fpga], board_msg
-
-            # -- Check that the programmer exists.
-            board_programmer_type = board_info["programmer"]["type"]
-            assert apio_ctx.programmers[board_programmer_type], board_msg
-
-            # -- Track unused programmers. Since a programmer may be used
-            # -- by more than one board, it may already be removed.
-            if board_programmer_type in unused_programmers:
-                unused_programmers.remove(board_programmer_type)
-
-        # -- Remove programmers that are known to be unused.
-        for programmer in KNOWN_UNUSED_PROGRAMMERS:
-            unused_programmers.remove(programmer)
-
-        # -- We should end up with an empty set of unused programmers.
-        assert not unused_programmers, unused_programmers
-
-
-def test_resources_names(apio_runner: ApioRunner):
-    """Tests the formats of boards, fpgas, and programmers names."""
-
-    # -- For boards we allow lower-case-0-9.
-    board_name_regex = re.compile(r"^[a-z][a-z0-9-]*$")
-
-    # -- For fpga names we allow lower-case-0-9.
-    fpga_name_regex = re.compile(r"^[a-z][a-z0-9-/]*$")
-
-    # -- For programmer names we allow lower-case-0-9.
-    programmer_name_regex = re.compile(r"^[a-z][a-z0-9-]*$")
-
-    with apio_runner.in_sandbox():
-
-        # -- Create an apio context so we can access the resources.
-        apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
-
-        for board in apio_ctx.boards.keys():
-            assert board_name_regex.match(board), f"{board=}"
-
-        for fpga in apio_ctx.fpgas.keys():
-            assert fpga_name_regex.match(fpga), f"{fpga=}"
-
-        for programmer in apio_ctx.programmers.keys():
-            assert programmer_name_regex.match(programmer), f"{programmer=}"

--- a/test/test_apio_context.py
+++ b/test/test_apio_context.py
@@ -88,10 +88,6 @@ def test_home_dir_with_relative_path(
         )
 
 
-# -- This board is known to be problematic so we skip it.
-# -- See https://github.com/FPGAwars/apio/issues/535
-KNOWN_BAD_BOARDS = ["odt-rpga-feather"]
-
 # -- These programmers are known to be unused.
 # -- https://github.com/FPGAwars/apio/issues/536
 KNOWN_UNUSED_PROGRAMMERS = ["ujprog"]
@@ -109,10 +105,6 @@ def test_resources_references(apio_runner: ApioRunner):
         unused_programmers = set(apio_ctx.programmers.keys())
 
         for board_name, board_info in apio_ctx.boards.items():
-            # -- Skip boards that are known to be problematic.
-            if board_name in KNOWN_BAD_BOARDS:
-                continue
-
             # -- Prepare a context message for failing assertions.
             board_msg = f"While testing board {board_name}"
 

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -1,0 +1,130 @@
+"""
+Tests of apio_context.py
+"""
+
+import re
+from test.conftest import ApioRunner
+from apio.apio_context import ApioContext, ApioContextScope
+
+
+# -- These programmers are known to be unused.
+# -- https://github.com/FPGAwars/apio/issues/536
+KNOWN_UNUSED_PROGRAMMERS = ["ujprog"]
+
+
+def test_resources_references(apio_runner: ApioRunner):
+    """Tests the consistency of the board references to fpgas and
+    programmers."""
+
+    with apio_runner.in_sandbox():
+
+        # -- Create an apio context so we can access the resources.
+        apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
+
+        unused_programmers = set(apio_ctx.programmers.keys())
+
+        for board_name, board_info in apio_ctx.boards.items():
+            # -- Prepare a context message for failing assertions.
+            board_msg = f"While testing board {board_name}"
+
+            # -- Assert that required fields exist.
+            assert "fpga" in board_info, board_msg
+            assert "programmer" in board_info, board_msg
+            assert "type" in board_info["programmer"], board_msg
+
+            # -- Check that the fpga exists.
+            board_fpga = board_info["fpga"]
+            assert apio_ctx.fpgas[board_fpga], board_msg
+
+            # -- Check that the programmer exists.
+            board_programmer_type = board_info["programmer"]["type"]
+            assert apio_ctx.programmers[board_programmer_type], board_msg
+
+            # -- Track unused programmers. Since a programmer may be used
+            # -- by more than one board, it may already be removed.
+            if board_programmer_type in unused_programmers:
+                unused_programmers.remove(board_programmer_type)
+
+        # -- Remove programmers that are known to be unused.
+        for programmer in KNOWN_UNUSED_PROGRAMMERS:
+            unused_programmers.remove(programmer)
+
+        # -- We should end up with an empty set of unused programmers.
+        assert not unused_programmers, unused_programmers
+
+
+def test_resources_names(apio_runner: ApioRunner):
+    """Tests the formats of boards, fpgas, and programmers names."""
+
+    # -- For boards we allow lower-case-0-9.
+    board_name_regex = re.compile(r"^[a-z][a-z0-9-]*$")
+
+    # -- For fpga names we allow lower-case-0-9.
+    fpga_name_regex = re.compile(r"^[a-z][a-z0-9-/]*$")
+
+    # -- For programmer names we allow lower-case-0-9.
+    programmer_name_regex = re.compile(r"^[a-z][a-z0-9-]*$")
+
+    with apio_runner.in_sandbox():
+
+        # -- Create an apio context so we can access the resources.
+        apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
+
+        for board in apio_ctx.boards.keys():
+            assert board_name_regex.match(board), f"{board=}"
+
+        for fpga in apio_ctx.fpgas.keys():
+            assert fpga_name_regex.match(fpga), f"{fpga=}"
+
+        for programmer in apio_ctx.programmers.keys():
+            assert programmer_name_regex.match(programmer), f"{programmer=}"
+
+
+def test_fpga_definitions(apio_runner: ApioRunner):
+    """Tests the fields of the fpga definitions."""
+
+    with apio_runner.in_sandbox():
+
+        # -- Create an apio context so we can access the resources.
+        apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
+
+        for fpga_id, fpga_info in apio_ctx.fpgas.items():
+
+            context = f"In fpga definition {fpga_id}"
+
+            # -- Verify the "arch" field.
+            assert "arch" in fpga_info, context
+            arch = fpga_info["arch"]
+
+            # -- Lattice
+            if arch in ["ice40", "ecp5"]:
+                assert fpga_info.keys() == {
+                    "part_num",
+                    "arch",
+                    "size",
+                    "type",
+                    "pack",
+                }, context
+                assert fpga_info["part_num"], context
+                assert fpga_info["arch"], context
+                assert fpga_info["size"], context
+                assert fpga_info["type"], context
+                assert fpga_info["pack"], context
+                continue
+
+            # -- Gowin
+            if arch == "gowin":
+                assert fpga_info.keys() == {
+                    "part_num",
+                    "arch",
+                    "size",
+                    "type",
+                }, context
+                assert fpga_info["part_num"], context
+                assert fpga_info["arch"], context
+                assert fpga_info["size"], context
+                assert fpga_info["type"], context
+                continue
+
+            # -- Unknown arch
+            raise ValueError(f"Unknown arch value: {arch}")

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -12,6 +12,11 @@ from apio.apio_context import ApioContext, ApioContextScope
 KNOWN_UNUSED_PROGRAMMERS = ["ujprog"]
 
 
+def lc_part_num(part_num: str) -> str:
+    """Convert an fpga part number to a lower-case id."""
+    return part_num.lower().replace("/", "-")
+
+
 def test_resources_references(apio_runner: ApioRunner):
     """Tests the consistency of the board references to fpgas and
     programmers."""
@@ -73,8 +78,16 @@ def test_resources_names(apio_runner: ApioRunner):
         for board in apio_ctx.boards.keys():
             assert board_name_regex.match(board), f"{board=}"
 
-        for fpga in apio_ctx.fpgas.keys():
-            assert fpga_name_regex.match(fpga), f"{fpga=}"
+        for fpga_id, fgpa_info in apio_ctx.fpgas.items():
+            assert fpga_name_regex.match(fpga_id), f"{fpga_id=}"
+            # Fpga id is either the fpga part num converted to lower-case
+            # or its the lower-case part num with a suffix that starts with
+            # '-'. E.g, for part num 'PART-NUM', the fpga id can be 'part-num'
+            # or 'part-num-somethings'
+            lc_part = lc_part_num(fgpa_info["part_num"])
+            assert fpga_id == lc_part or fpga_id.startswith(
+                lc_part + "-"
+            ), f"{fpga_id=}"
 
         for programmer in apio_ctx.programmers.keys():
             assert programmer_name_regex.match(programmer), f"{programmer=}"

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -96,8 +96,8 @@ def test_fpga_definitions(apio_runner: ApioRunner):
             assert "arch" in fpga_info, context
             arch = fpga_info["arch"]
 
-            # -- Lattice
-            if arch in ["ice40", "ecp5"]:
+            # -- Ice40
+            if arch == "ice40":
                 assert fpga_info.keys() == {
                     "part_num",
                     "arch",
@@ -110,6 +110,24 @@ def test_fpga_definitions(apio_runner: ApioRunner):
                 assert fpga_info["size"], context
                 assert fpga_info["type"], context
                 assert fpga_info["pack"], context
+                continue
+
+            # -- Ecp5
+            if arch == "ecp5":
+                assert set(fpga_info.keys()) == {
+                    "part_num",
+                    "arch",
+                    "size",
+                    "type",
+                    "pack",
+                    "speed",
+                }, context
+                assert fpga_info["part_num"], context
+                assert fpga_info["arch"], context
+                assert fpga_info["size"], context
+                assert fpga_info["type"], context
+                assert fpga_info["pack"], context
+                assert fpga_info["speed"], context
                 continue
 
             # -- Gowin

--- a/test/utils/test_jsonc.py
+++ b/test/utils/test_jsonc.py
@@ -1,0 +1,38 @@
+"""
+Tests of jsonc.py
+"""
+
+import os
+import pytest
+from apio.utils import jsonc 
+
+# -- The jsonc input. Notice the '//' inside the string. It should 
+# -- not be classified as comment start.
+BEFORE = """
+    // Comment 1.
+    "image": { 
+        // Comment 2.
+        "src": "Images//Sun.png", // Comment 3
+        "name": "aaa\n",
+        "hOffset": 250
+    }
+"""
+
+# -- The expected json output. Some of the lines below have trailing
+# -- spaces after the comments removal.
+AFTER = """
+    
+    "image": { 
+        
+        "src": "Images//Sun.png", 
+        "name": "aaa\n",
+        "hOffset": 250
+    }
+"""
+
+
+def test_to_json():
+    """Test the comments removal."""
+    assert jsonc.to_json(BEFORE) == AFTER
+
+

--- a/test/utils/test_jsonc.py
+++ b/test/utils/test_jsonc.py
@@ -2,15 +2,14 @@
 Tests of jsonc.py
 """
 
-import os
-import pytest
-from apio.utils import jsonc 
+from apio.utils import jsonc
 
-# -- The jsonc input. Notice the '//' inside the string. It should 
-# -- not be classified as comment start.
+# -- The converstion input and expected output strings. Notice the '//' within
+# -- the string, it should not be classified as a comment. The '_' characters
+# -- are place holders for trailing white space.
 BEFORE = """
     // Comment 1.
-    "image": { 
+    "image": {__
         // Comment 2.
         "src": "Images//Sun.png", // Comment 3
         "name": "aaa\n",
@@ -18,13 +17,11 @@ BEFORE = """
     }
 """
 
-# -- The expected json output. Some of the lines below have trailing
-# -- spaces after the comments removal.
 AFTER = """
-    
-    "image": { 
-        
-        "src": "Images//Sun.png", 
+____
+    "image": {__
+________
+        "src": "Images//Sun.png",_
         "name": "aaa\n",
         "hOffset": 250
     }
@@ -33,6 +30,4 @@ AFTER = """
 
 def test_to_json():
     """Test the comments removal."""
-    assert jsonc.to_json(BEFORE) == AFTER
-
-
+    assert jsonc.to_json(BEFORE.replace("_", " ")) == AFTER.replace("_", " ")


### PR DESCRIPTION
Details in the individual commits.

Highlights
* Renamed .json files .jsonc (jason with comments) which accpet // comments.
* PNR options are now architecture specific (e..g Gowin PNR doesn't need to 'pack' option).
* Added for ECP5 arch a 'speed' PNR option (some ecp5 fpgas come with different speed grade options, e.g, 6, 7, 8)
* Cleaned up the apio board and apio fpgas reports.
* Added a convention for oversized fpgas (e.g. 4k used as 8k).
* Renamed apio/resources/distribution.jsonc to apio/resources/config.json since the packages versions are not defined in it anymore (they moved to remote config and to static pip packages installations).

Hi @cavearr, can you review and accept?