### PR TITLE
Added a github workflow for building linux-x86-64 installer

### DIFF
--- a/.github/workflows/build-darwin-arm64-installer.yml
+++ b/.github/workflows/build-darwin-arm64-installer.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build-darwin-arm64-installer:
     runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash  # Set Bash as the default shell
 
     steps:
       - name: Log architecture info

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -1,0 +1,170 @@
+name: build-linux-x86-64-installer
+
+on:
+  # For now we use only manual triggers.
+  workflow_dispatch:  # 👈 Enables manual trigger
+
+jobs:
+  build-linux-x86-64-installer:
+    runs-on: linux-latest
+
+    steps:
+      - name: Log architecture info
+        run: uname -m
+  
+      # - name: Install python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.11'  # Adjust version as needed
+
+
+      # - name: Checkout the apio repo
+      #   uses: actions/checkout@v4
+      #   with:
+      #     path: apio-repo
+
+
+      # - name: Pip install apio.
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install -e apio-repo
+
+
+      # - name: Pip install pyinstaller
+      #   run: |
+      #     pip install pyinstaller
+
+
+      # - name: Extract apio version
+      #   run: |
+      #     echo "APIO_VERSION=$(pip show apio | grep Version: | cut -d ' ' -f2)" >> $GITHUB_ENV
+
+
+      # - name: Echo apio version
+      #   run: |
+      #     echo "$APIO_VERSION"
+
+
+      # - name: Setup working directories.
+      #   run: |
+      #     mkdir _work
+      #     mkdir _dist
+      #     mkdir _scripts
+      #     pwd
+      #     ls -la .
+
+
+      # - name: Run pyinstaller
+      #   run: |
+      #     pyinstaller \
+      #       --workpath _work \
+      #       --distpath _dist \
+      #       apio-repo/.github/workflows/resources/apio-pyinstaller.spec
+      #     echo "_dist:"
+      #     ls -al _dist
+      #     echo "_dist/apio:"
+      #     ls -al _dist/apio
+
+
+      # - name: Add LICENSE file
+      #   run: |
+      #     cp apio-repo/LICENSE _dist/apio
+      #     echo "_dist:"
+      #     ls -al _dist
+      #     echo "_dist/apio:"
+      #     ls -al _dist/apio
+
+
+      # - name: Add INFO file
+      #   run: |
+      #     info_file="_dist/apio/INFO"
+      #     echo "Build information" >  ${info_file}
+      #     echo "Time:         $(date +'%Y-%m-%d %H:%M:%S %Z')" >> ${info_file}
+      #     echo "Run ID:       $GITHUB_RUN_ID" >> ${info_file}
+      #     echo "Run number:   $GITHUB_RUN_NUMBER" >> ${info_file}
+      #     echo "Commit SHA:   $GITHUB_SHA" >>  ${info_file}
+      #     echo "Branch:       ${GITHUB_REF#refs/heads/}" >> ${info_file}
+      #     echo "Repo owner:   $GITHUB_REPOSITORY_OWNER" >> ${info_file}
+      #     echo "ReponName:    ${GITHUB_REPOSITORY#*/} ">> ${info_file}       
+      #     echo "_dist/apio:"
+      #     ls -al _dist/apio
+      #     cat _dist/apio/INFO
+
+      # - name: Add 'activate' file
+      #   run: |
+      #     cp apio-repo/.github/workflows/darwin-resources/activate _dist/apio/activate
+      #     echo "_dist/apio:"
+      #     ls -al _dist/apio
+      #     cat _dist/apio/activate
+
+      # - name: Zip the pyinstaller package
+      #   run: |
+      #     pushd _dist
+      #     package="apio-darwin-arm64-${{env.APIO_VERSION}}-package.zip"
+      #     zip -r -y ../${package} apio
+      #     popd
+      #     ls -al 
+
+
+      # - name: Delete the 'activate' file
+      #   run: |
+      #     rm _dist/apio/activate
+      #     echo "_dist/apio:"
+      #     ls -al _dist/apio
+
+
+      # # This sets the app name in /Applications
+      # - name: Rename apio to Apio
+      #   run: |
+      #     mv _dist/apio _dist/Apio
+      #     echo "_dist:"
+      #     ls -al _dist
+
+
+      # - name: Create installer postinstall scripts
+      #   run: |
+      #     cp apio-repo/.github/workflows/darwin-resources/postinstall _scripts/postinstall
+      #     chmod 755 _scripts/postinstall
+      #     echo "_scripts:"
+      #     ls -al _scripts
+      #     echo "_scripts/postinstall:"
+      #     cat _scripts/postinstall
+          
+          
+      # - name: Run pkgbuild
+      #   run: |
+      #     pkgbuild --root _dist \
+      #              --install-location /Applications \
+      #              --identifier "io.github.fpgawars.apio" \
+      #              --version "${{env.APIO_VERSION}}" \
+      #              --scripts _scripts \
+      #              --ownership recommended \
+      #              apio-component.pkg
+      #     pwd
+      #     ls -al
+
+
+      # - name: Run productbuild
+      #   run: |
+      #     productbuild --resources apio-repo/.github/workflows/darwin-resources \
+      #                  --distribution apio-repo/.github/workflows/darwin-resources/distribution.xml \
+      #                  --package-path . \
+      #                  "apio-darwin-arm64-${{env.APIO_VERSION}}-installer.pkg"
+      #     pwd
+      #     ls -al
+
+
+      # - name: Export the pyinstaller archive as an artifact.
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: "apio-darwin-arm64-package"
+      #     path: "apio-darwin-arm64-${{env.APIO_VERSION}}-package.zip"
+
+
+      # - name: Export the installer file as an artifact.
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: "apio-darwin-arm64-installer"
+      #     path: "apio-darwin-arm64-${{env.APIO_VERSION}}-installer.pkg"
+
+      

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -115,7 +115,7 @@ jobs:
           
           # /usr/local/bin
           mkdir -p _debian/usr/local/bin
-          pushd _debian/user/local/bin
+          pushd _debian/usr/local/bin
           ln -s ../../../opt/apio/apio apio
           popd
           

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -144,21 +144,12 @@ jobs:
       #     ls -al
 
 
-      # - name: Run productbuild
-      #   run: |
-      #     productbuild --resources apio-repo/.github/workflows/darwin-resources \
-      #                  --distribution apio-repo/.github/workflows/darwin-resources/distribution.xml \
-      #                  --package-path . \
-      #                  "apio-linux-x86-64-${{env.APIO_VERSION}}-installer.pkg"
-      #     pwd
-      #     ls -al
-
-
       - name: Export the pyinstaller archive as an artifact.
         uses: actions/upload-artifact@v4
         with:
           name: "apio-linux-x86-64-package"
           path: "apio-linux-x86-64-${{env.APIO_VERSION}}-package.zip"
+          if-no-files-found: error
 
 
       # - name: Export the installer file as an artifact.

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-linux-x86-64-installer:
-    runs-on: linux-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Log architecture info

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build-linux-x86-64-installer:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash  # Set Bash as the default shell
 
     steps:
       - name: Log architecture info
@@ -17,12 +20,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'  # Adjust version as needed
-
-
-      # - name: Install dpkg tools
-      #   run: |
-      #     sudo apt update
-      #     sudo apt install -y dpkg-dev
 
 
       - name: Checkout the apio repo
@@ -96,12 +93,6 @@ jobs:
           ls -al _dist/apio
           cat _dist/apio/INFO
 
-      # - name: Add 'activate' file
-      #   run: |
-      #     cp apio-repo/.github/workflows/darwin-resources/activate _dist/apio/activate
-      #     echo "_dist/apio:"
-      #     ls -al _dist/apio
-      #     cat _dist/apio/activate
 
       - name: Zip the pyinstaller package
         run: |
@@ -110,6 +101,7 @@ jobs:
           zip -r -y ../${package} apio
           popd
           ls -al 
+
 
       - name: Populate the debian package
         run: |
@@ -132,37 +124,7 @@ jobs:
           dpkg-deb --build --root-owner-group _debian "apio-linux-x86-64-${APIO_VERSION}-debian.deb"
           ls -l 
 
-      # # This sets the app name in /Applications
-      # - name: Rename apio to Apio
-      #   run: |
-      #     mv _dist/apio _dist/Apio
-      #     echo "_dist:"
-      #     ls -al _dist
-
-
-      # - name: Create installer postinstall scripts
-      #   run: |
-      #     cp apio-repo/.github/workflows/darwin-resources/postinstall _scripts/postinstall
-      #     chmod 755 _scripts/postinstall
-      #     echo "_scripts:"
-      #     ls -al _scripts
-      #     echo "_scripts/postinstall:"
-      #     cat _scripts/postinstall
-          
-          
-      # - name: Run pkgbuild
-      #   run: |
-      #     pkgbuild --root _dist \
-      #              --install-location /Applications \
-      #              --identifier "io.github.fpgawars.apio" \
-      #              --version "${{env.APIO_VERSION}}" \
-      #              --scripts _scripts \
-      #              --ownership recommended \
-      #              apio-component.pkg
-      #     pwd
-      #     ls -al
-
-
+     
       - name: Export the pyinstaller archive as an artifact.
         uses: actions/upload-artifact@v4
         with:
@@ -177,9 +139,10 @@ jobs:
           name: "apio-linux-x86-64-debian"
           path: "apio-linux-x86-64-${{env.APIO_VERSION}}-debian.deb"
 
-      - name: Write run summary message
-        run: |
-          echo "line1" >> $GITHUB_STEP_SUMMARY
-          echo "${APIO_VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "line3" >> $GITHUB_STEP_SUMMARY
+
+      # - name: Write run summary message
+      #   run: |
+      #     echo "line1" >> $GITHUB_STEP_SUMMARY
+      #     echo "${APIO_VERSION}" >> $GITHUB_STEP_SUMMARY
+      #     echo "line3" >> $GITHUB_STEP_SUMMARY
         

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -119,7 +119,6 @@ jobs:
           mv _dist/apio/apio _debian/usr/local/bin
           # We move _internal instead of copying it, in case it has symlinks.
           mv _dist/apio/_internal _debian/usr/local/bin
-          cp apio-repo/.github/workflows/linux-resources/debian-control _debian/DEBIAN/control
           control="_debian/DEBIAN/control"
           sed "s/\[APIO-VERSION\]/$APIO_VERSION/g" apio-repo/.github/workflows/linux-resources/control.template > ${control}
           find _debian 

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -177,4 +177,9 @@ jobs:
           name: "apio-linux-x86-64-debian"
           path: "apio-linux-x86-64-${{env.APIO_VERSION}}-debian.deb"
 
-      
+      - name: Write run summary message
+        run: |
+          echo "line1" >> $GITHUB_STEP_SUMMARY
+          echo "${APIO_VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "line3" >> $GITHUB_STEP_SUMMARY
+        

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -115,7 +115,7 @@ jobs:
           
           # /usr/local/bin
           mkdir -p _debian/usr/local/bin
-          pushd _debian/user/lobal/bin
+          pushd _debian/user/local/bin
           ln -s ../../../opt/apio/apio apio
           popd
           

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -19,10 +19,10 @@ jobs:
           python-version: '3.11'  # Adjust version as needed
 
 
-      - name: Install dpkg tools
-        run: |
-          sudo apt update
-          sudo apt install -y dpkg-dev
+      # - name: Install dpkg tools
+      #   run: |
+      #     sudo apt update
+      #     sudo apt install -y dpkg-dev
 
 
       - name: Checkout the apio repo

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -105,6 +105,22 @@ jobs:
           popd
           ls -al 
 
+      - name: Populate the debian package
+        run: |
+          mkdir _debian
+          mkdir _debian/DEBIAN
+          mkdir -p _debian/usr/local/bin
+          mv _dist/apio/apio _debian/usr/local/bin
+          mv _dist/apio/_internal _debian/usr/local/bin
+          
+          
+          
+          pushd _dist
+          package="apio-linux-x86-64-${{env.APIO_VERSION}}-package.zip"
+          zip -r -y ../${package} apio
+          popd
+          ls -al 
+
 
       # - name: Delete the 'activate' file
       #   run: |

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -19,6 +19,12 @@ jobs:
           python-version: '3.11'  # Adjust version as needed
 
 
+      - name: Install dpkg tools
+        run: |
+          sudo apt update
+          sudo apt install -y dpkg-dev
+
+
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
@@ -111,23 +117,21 @@ jobs:
           mkdir _debian/DEBIAN
           mkdir -p _debian/usr/local/bin
           mv _dist/apio/apio _debian/usr/local/bin
+          # We move _internal instead of copying it, in case it has symlinks.
           mv _dist/apio/_internal _debian/usr/local/bin
-          
-          
-          
-          pushd _dist
-          package="apio-linux-x86-64-${{env.APIO_VERSION}}-package.zip"
-          zip -r -y ../${package} apio
-          popd
-          ls -al 
+          cp apio-repo/.github/workflows/linux-resources/debian-control _debian/DEBIAN/control
+          control="_debian/DEBIAN/control"
+          sed "s/\[APIO-VERSION\]/$APIO_VERSION/g" apio-repo/.github/workflows/linux-resources/control.template > ${control}
+          find _debian 
+          cat ${control}
 
+      - name: Set permissions for debian control file
+        run: find _debian/DEBIAN -type f -exec chmod 644 {} \;
 
-      # - name: Delete the 'activate' file
-      #   run: |
-      #     rm _dist/apio/activate
-      #     echo "_dist/apio:"
-      #     ls -al _dist/apio
-
+      - name: Build .deb package
+        run: |
+          dpkg-deb --build --root-owner-group _debian "apio-linux-x86-64-${APIO_VERSION}-debian.deb"
+          ls -l 
 
       # # This sets the app name in /Applications
       # - name: Rename apio to Apio
@@ -168,10 +172,10 @@ jobs:
           if-no-files-found: error
 
 
-      # - name: Export the installer file as an artifact.
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: "apio-linux-x86-64-installer"
-      #     path: "apio-linux-x86-64-${{env.APIO_VERSION}}-installer.pkg"
+      - name: Export the installer file as an artifact.
+        uses: actions/upload-artifact@v4
+        with:
+          name: "apio-linux-x86-64-debian"
+          path: "apio-linux-x86-64-${{env.APIO_VERSION}}-debian.deb"
 
       

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -10,85 +10,85 @@ jobs:
 
     steps:
       - name: Log architecture info
+        # Expecting 'x86_64'
         run: uname -m
   
-      # - name: Install python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.11'  # Adjust version as needed
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'  # Adjust version as needed
 
 
-      # - name: Checkout the apio repo
-      #   uses: actions/checkout@v4
-      #   with:
-      #     path: apio-repo
+      - name: Checkout the apio repo
+        uses: actions/checkout@v4
+        with:
+          path: apio-repo
 
 
-      # - name: Pip install apio.
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     pip install -e apio-repo
+      - name: Pip install apio.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e apio-repo
 
 
-      # - name: Pip install pyinstaller
-      #   run: |
-      #     pip install pyinstaller
+      - name: Pip install pyinstaller
+        run: |
+          pip install pyinstaller
 
 
-      # - name: Extract apio version
-      #   run: |
-      #     echo "APIO_VERSION=$(pip show apio | grep Version: | cut -d ' ' -f2)" >> $GITHUB_ENV
+      - name: Extract apio version
+        run: |
+          echo "APIO_VERSION=$(pip show apio | grep Version: | cut -d ' ' -f2)" >> $GITHUB_ENV
 
 
-      # - name: Echo apio version
-      #   run: |
-      #     echo "$APIO_VERSION"
+      - name: Echo apio version
+        run: |
+          echo "$APIO_VERSION"
 
 
-      # - name: Setup working directories.
-      #   run: |
-      #     mkdir _work
-      #     mkdir _dist
-      #     mkdir _scripts
-      #     pwd
-      #     ls -la .
+      - name: Setup working directories.
+        run: |
+          mkdir _work
+          mkdir _dist
+          pwd
+          ls -la .
 
 
-      # - name: Run pyinstaller
-      #   run: |
-      #     pyinstaller \
-      #       --workpath _work \
-      #       --distpath _dist \
-      #       apio-repo/.github/workflows/resources/apio-pyinstaller.spec
-      #     echo "_dist:"
-      #     ls -al _dist
-      #     echo "_dist/apio:"
-      #     ls -al _dist/apio
+      - name: Run pyinstaller
+        run: |
+          pyinstaller \
+            --workpath _work \
+            --distpath _dist \
+            apio-repo/.github/workflows/resources/apio-pyinstaller.spec
+          echo "_dist:"
+          ls -al _dist
+          echo "_dist/apio:"
+          ls -al _dist/apio
 
 
-      # - name: Add LICENSE file
-      #   run: |
-      #     cp apio-repo/LICENSE _dist/apio
-      #     echo "_dist:"
-      #     ls -al _dist
-      #     echo "_dist/apio:"
-      #     ls -al _dist/apio
+      - name: Add LICENSE file
+        run: |
+          cp apio-repo/LICENSE _dist/apio
+          echo "_dist:"
+          ls -al _dist
+          echo "_dist/apio:"
+          ls -al _dist/apio
 
 
-      # - name: Add INFO file
-      #   run: |
-      #     info_file="_dist/apio/INFO"
-      #     echo "Build information" >  ${info_file}
-      #     echo "Time:         $(date +'%Y-%m-%d %H:%M:%S %Z')" >> ${info_file}
-      #     echo "Run ID:       $GITHUB_RUN_ID" >> ${info_file}
-      #     echo "Run number:   $GITHUB_RUN_NUMBER" >> ${info_file}
-      #     echo "Commit SHA:   $GITHUB_SHA" >>  ${info_file}
-      #     echo "Branch:       ${GITHUB_REF#refs/heads/}" >> ${info_file}
-      #     echo "Repo owner:   $GITHUB_REPOSITORY_OWNER" >> ${info_file}
-      #     echo "ReponName:    ${GITHUB_REPOSITORY#*/} ">> ${info_file}       
-      #     echo "_dist/apio:"
-      #     ls -al _dist/apio
-      #     cat _dist/apio/INFO
+      - name: Add INFO file
+        run: |
+          info_file="_dist/apio/INFO"
+          echo "Build information" >  ${info_file}
+          echo "Time:         $(date +'%Y-%m-%d %H:%M:%S %Z')" >> ${info_file}
+          echo "Run ID:       $GITHUB_RUN_ID" >> ${info_file}
+          echo "Run number:   $GITHUB_RUN_NUMBER" >> ${info_file}
+          echo "Commit SHA:   $GITHUB_SHA" >>  ${info_file}
+          echo "Branch:       ${GITHUB_REF#refs/heads/}" >> ${info_file}
+          echo "Repo owner:   $GITHUB_REPOSITORY_OWNER" >> ${info_file}
+          echo "ReponName:    ${GITHUB_REPOSITORY#*/} ">> ${info_file}       
+          echo "_dist/apio:"
+          ls -al _dist/apio
+          cat _dist/apio/INFO
 
       # - name: Add 'activate' file
       #   run: |
@@ -97,13 +97,13 @@ jobs:
       #     ls -al _dist/apio
       #     cat _dist/apio/activate
 
-      # - name: Zip the pyinstaller package
-      #   run: |
-      #     pushd _dist
-      #     package="apio-darwin-arm64-${{env.APIO_VERSION}}-package.zip"
-      #     zip -r -y ../${package} apio
-      #     popd
-      #     ls -al 
+      - name: Zip the pyinstaller package
+        run: |
+          pushd _dist
+          package="apio-linux-x86-64-${{env.APIO_VERSION}}-package.zip"
+          zip -r -y ../${package} apio
+          popd
+          ls -al 
 
 
       # - name: Delete the 'activate' file
@@ -149,22 +149,22 @@ jobs:
       #     productbuild --resources apio-repo/.github/workflows/darwin-resources \
       #                  --distribution apio-repo/.github/workflows/darwin-resources/distribution.xml \
       #                  --package-path . \
-      #                  "apio-darwin-arm64-${{env.APIO_VERSION}}-installer.pkg"
+      #                  "apio-linux-x86-64-${{env.APIO_VERSION}}-installer.pkg"
       #     pwd
       #     ls -al
 
 
-      # - name: Export the pyinstaller archive as an artifact.
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: "apio-darwin-arm64-package"
-      #     path: "apio-darwin-arm64-${{env.APIO_VERSION}}-package.zip"
+      - name: Export the pyinstaller archive as an artifact.
+        uses: actions/upload-artifact@v4
+        with:
+          name: "apio-linux-x86-64-package"
+          path: "apio-linux-x86-64-${{env.APIO_VERSION}}-package.zip"
 
 
       # - name: Export the installer file as an artifact.
       #   uses: actions/upload-artifact@v4
       #   with:
-      #     name: "apio-darwin-arm64-installer"
-      #     path: "apio-darwin-arm64-${{env.APIO_VERSION}}-installer.pkg"
+      #     name: "apio-linux-x86-64-installer"
+      #     path: "apio-linux-x86-64-${{env.APIO_VERSION}}-installer.pkg"
 
       

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -106,13 +106,25 @@ jobs:
       - name: Populate the debian package
         run: |
           mkdir _debian
-          mkdir _debian/DEBIAN
-          mkdir -p _debian/usr/local/bin
-          mv _dist/apio/apio _debian/usr/local/bin
+          
+          # -- /opt/apio
+          mkdir -p _debian/opt/apio
+          mv _dist/apio/apio _debian/opt/apio
           # We move _internal instead of copying it, in case it has symlinks.
-          mv _dist/apio/_internal _debian/usr/local/bin
+          mv _dist/apio/_internal _debian/opt/apio
+          
+          # /usr/local/bin
+          mkdir -p _debian/usr/local/bin
+          pushd _debian/user/lobal/bin
+          ln -s ../../../opt/apio/apio apio
+          popd
+          
+          # Package control file
+          mkdir _debian/DEBIAN
           control="_debian/DEBIAN/control"
           sed "s/\[APIO-VERSION\]/$APIO_VERSION/g" apio-repo/.github/workflows/linux-resources/control.template > ${control}
+          
+          # Show info
           find _debian 
           cat ${control}
 

--- a/.github/workflows/linux-resources/control.template
+++ b/.github/workflows/linux-resources/control.template
@@ -1,0 +1,8 @@
+Package: apio 
+Version: [APIO-VERSION]
+Section: electronic
+Priority: optional
+Architecture: amd64
+Maintainer: Jesus Arroyo jesus.jkhlg@gmail.com, https://github.com/FPGAwars/apio
+Description: Open source FPGA design tool.
+


### PR DESCRIPTION
The new workflow create a zip with the files that the icestudio can include and a debian package that can be installed by the user.

@cavearr, file format do you have in mind for linux distribution?  If debian packages, do you plan to run an FPGAWars debian packages repo server?