### PR TITLE
Minor tweaks to the installers builders, mostly the linux/snap.

### DIFF
--- a/.github/workflows/build-darwin-arm64-installer.yml
+++ b/.github/workflows/build-darwin-arm64-installer.yml
@@ -176,4 +176,9 @@ jobs:
           name: "apio-darwin-arm64-package"
           path: "apio-darwin-arm64-${{env.APIO_VERSION}}-package.pkg"
 
-      
+
+      - name: Write a summary message
+        run: |
+          echo "NOTE: Github wraps the artifact files with an additional level of zip archive."    >> $GITHUB_STEP_SUMMARY
+          echo "To retrieve the artifact files, unzip the zip files you download from this page."  >> $GITHUB_STEP_SUMMARY       
+

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -215,8 +215,8 @@ jobs:
           path: "apio-linux-x86-64-${{env.APIO_VERSION}}-snap.snap"
 
 
-      # - name: Write run summary message
-      #   run: |
-      #     echo "line1" >> $GITHUB_STEP_SUMMARY
-      #     echo "${APIO_VERSION}" >> $GITHUB_STEP_SUMMARY
-      #     echo "line3" >> $GITHUB_STEP_SUMMARY        
+      - name: Write a summary message
+        run: |
+          echo "Note: Github workflows the artifacts with an additional level of zip archive." >> $GITHUB_STEP_SUMMARY
+          echo "To retrieve the artifact file, first unzip the artifact zip file downloaded >> $GITHUB_STEP_SUMMARY       
+          echo "from this page. >> $GITHUB_STEP_SUMMARY       

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -217,6 +217,5 @@ jobs:
 
       - name: Write a summary message
         run: |
-          echo "Note: Github workflows the artifacts with an additional level of zip archive." >> $GITHUB_STEP_SUMMARY
-          echo "To retrieve the artifact file, first unzip the artifact zip file downloaded"   >> $GITHUB_STEP_SUMMARY       
-          echo "from this page."                                                               >> $GITHUB_STEP_SUMMARY       
+          echo "Note: Github workflows the artifacts with an additional level of zip archive."               >> $GITHUB_STEP_SUMMARY
+          echo "To retrieve the artifact file, first unzip the artifact zip file downloaded from this page." >> $GITHUB_STEP_SUMMARY       

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -217,5 +217,5 @@ jobs:
 
       - name: Write a summary message
         run: |
-          echo "Note: Github workflows the artifacts with an additional level of zip archive."               >> $GITHUB_STEP_SUMMARY
+          echo "NOTE: Github workflows the artifacts with an additional level of zip archive."               >> $GITHUB_STEP_SUMMARY
           echo "To retrieve the artifact file, first unzip the artifact zip file downloaded from this page." >> $GITHUB_STEP_SUMMARY       

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -218,5 +218,5 @@ jobs:
       - name: Write a summary message
         run: |
           echo "Note: Github workflows the artifacts with an additional level of zip archive." >> $GITHUB_STEP_SUMMARY
-          echo "To retrieve the artifact file, first unzip the artifact zip file downloaded >> $GITHUB_STEP_SUMMARY       
-          echo "from this page. >> $GITHUB_STEP_SUMMARY       
+          echo "To retrieve the artifact file, first unzip the artifact zip file downloaded"   >> $GITHUB_STEP_SUMMARY       
+          echo "from this page."                                                               >> $GITHUB_STEP_SUMMARY       

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -217,5 +217,5 @@ jobs:
 
       - name: Write a summary message
         run: |
-          echo "NOTE: Github workflows the artifacts with an additional level of zip archive."               >> $GITHUB_STEP_SUMMARY
-          echo "To retrieve the artifact file, first unzip the artifact zip file downloaded from this page." >> $GITHUB_STEP_SUMMARY       
+          echo "NOTE: Github wraps the artifact files with an additional level of zip archive."    >> $GITHUB_STEP_SUMMARY
+          echo "To retrieve the artifact files, unzip the zip files you download from this page."  >> $GITHUB_STEP_SUMMARY       

--- a/.github/workflows/build-windows-amd64-installer.yml
+++ b/.github/workflows/build-windows-amd64-installer.yml
@@ -140,3 +140,7 @@ jobs:
           path: "apio-windows-amd64-${{env.APIO_VERSION}}-innosetup.exe"
 
       
+      - name: Write a summary message
+        run: |
+          echo "NOTE: Github wraps the artifact files with an additional level of zip archive."    >> $GITHUB_STEP_SUMMARY
+          echo "To retrieve the artifact files, unzip the zip files you download from this page."  >> $GITHUB_STEP_SUMMARY       

--- a/.github/workflows/linux-resources/snapcraft.template
+++ b/.github/workflows/linux-resources/snapcraft.template
@@ -24,9 +24,8 @@ apps:
       # Required manual connection by the user. Used for example
       # for boards with FT232/2232 interfaces.
       - raw-usb
-      # Safety net. May be needed for some boards such as those
-      # with serial interfaces or proprietary protocols.
-      - serial-port
+      # Not sure if this required. Added as a safety net until we 
+      # test with all the available board drivers.
       - hardware-observe
  
 parts:

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich import box
 from rich.color import ANSI_COLOR_NAMES
 from apio.common.apio_styles import BORDER, EMPH1, EMPH3, TITLE, INFO
-from apio.utils import util, cmd_util
+from apio.utils import util, cmd_util, snap_util
 from apio.utils.cmd_util import check_at_most_one_param
 from apio.apio_context import ApioContext, ApioContextScope
 from apio.utils.cmd_util import ApioGroup, ApioSubgroup, ApioCommand
@@ -322,15 +322,21 @@ def _system_cli():
 
     # -- Add rows
     table.add_row("Apio version", util.get_apio_version())
-    table.add_row("Python version ", util.get_python_version())
-    table.add_row("Platform id ", apio_ctx.platform_id)
-    table.add_row("Python package ", str(util.get_path_in_apio_package("")))
-    table.add_row("Apio home ", str(apio_ctx.home_dir))
-    table.add_row("Apio packages ", str(apio_ctx.packages_dir))
+    table.add_row("Python version", util.get_python_version())
+    table.add_row("Platform id", apio_ctx.platform_id)
+    table.add_row("Python package", str(util.get_path_in_apio_package("")))
+    table.add_row("Apio home", str(apio_ctx.home_dir))
+    table.add_row("Apio packages", str(apio_ctx.packages_dir))
     table.add_row(
-        "Veriable language server ",
+        "Veriable language server",
         str(apio_ctx.packages_dir / "verible/bin/verible-verilog-ls"),
     )
+    # -- If running under snap, show some snap info.
+    if snap_util.is_snap():
+        for plug in snap_util.MANUAL_PLUGS:
+            plug_connected = snap_util.is_plug_connected(plug)
+            plug_status = "Connected" if plug_connected else "Not connected"
+            table.add_row(f"Snap {plug}", plug_status)
 
     # -- Render the table.
     cout()

--- a/apio/managers/system.py
+++ b/apio/managers/system.py
@@ -10,7 +10,7 @@ import re
 import sys
 from apio.common.apio_console import cout, cerror
 from apio.common.apio_styles import INFO, ERROR, EMPH1
-from apio.utils import util, pkg_util
+from apio.utils import util, pkg_util, snap_util
 from apio.apio_context import ApioContext
 from apio.managers import installer
 
@@ -35,7 +35,7 @@ class System:  # pragma: no cover
             "using 'apio drivers install ftdi'.",
             style=INFO,
         )
-        if util.is_snap():
+        if snap_util.is_snap():
             cout(
                 "[Hint]: Snap applications may require "
                 "'snap connect apio:raw-usb' to access USB devices.",

--- a/apio/utils/env_options.py
+++ b/apio/utils/env_options.py
@@ -26,10 +26,6 @@ APIO_HOME_DIR = "APIO_HOME_DIR"
 # -- It's one of the overrides for the default apio home dir.
 SNAP_USER_COMMON = "SNAP_USER_COMMON"
 
-# -- Env variable that is set by the snap launcher when running under snap.
-# -- Used to detect if running under snap.
-SNAP_NAME = "SNAP_NAME"
-
 # -- Env variable to override the platform id that is determined automatically
 # -- from the system properties. If specified, the value should match one
 # -- of the platforms specified in resources/platforms.json.
@@ -51,7 +47,6 @@ _SUPPORTED_APIO_VARS = [
     APIO_HOME,
     APIO_HOME_DIR,  # Deprecated
     SNAP_USER_COMMON,
-    SNAP_NAME,
     APIO_PLATFORM,
     APIO_DEBUG,
 ]

--- a/apio/utils/snap_util.py
+++ b/apio/utils/snap_util.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# -- This file is part of the Apio project
+# -- (C) 2016-2018 FPGAwars
+# -- Author Jesús Arroyo
+# -- License GPLv2
+# -- Derived from:
+# ---- Platformio project
+# ---- (C) 2014-2016 Ivan Kravets <me@ikravets.com>
+# ---- License Apache v2
+"""Misc utility functions related to the linux Snap package manager."""
+
+import os
+import subprocess
+from subprocess import CompletedProcess
+import shutil
+
+RAW_USB_PLUG = "raw-usb"
+SERIAL_PORT_PLUG = "serial-port"
+
+MANUAL_PLUGS = [RAW_USB_PLUG, SERIAL_PORT_PLUG]
+
+
+def is_snap() -> bool:
+    """Returns True if the current process is running under snap."""
+    val = os.getenv("SNAP_NAME")
+    return val is not None
+
+
+def is_plug_connected(plug: str) -> bool:
+    """Returns the given manual snap plug is connected. Should be called only
+    if running under snap."""
+    # -- Check the preconditions.
+    assert is_snap(), "Not running under snap."
+    assert plug in MANUAL_PLUGS, f"Unexpected snap plug: {plug}"
+    assert shutil.which("snapctl"), "The command 'snapctl' is not available."
+    # -- Query the plug state.
+    result: CompletedProcess = subprocess.run(
+        ["snapctl", "is-connected", plug], check=False
+    )
+    return result.returncode == 0

--- a/apio/utils/snap_util.py
+++ b/apio/utils/snap_util.py
@@ -14,10 +14,11 @@ import subprocess
 from subprocess import CompletedProcess
 import shutil
 
+# -- Relevant snap plugs. See snapcraft.yaml.
 RAW_USB_PLUG = "raw-usb"
-SERIAL_PORT_PLUG = "serial-port"
+HARDWARE_OBSERVE = "hardware-observe"
 
-MANUAL_PLUGS = [RAW_USB_PLUG, SERIAL_PORT_PLUG]
+MANUAL_PLUGS = [RAW_USB_PLUG, HARDWARE_OBSERVE]
 
 
 def is_snap() -> bool:

--- a/apio/utils/util.py
+++ b/apio/utils/util.py
@@ -670,8 +670,3 @@ def subprocess_call(
 
     # -- Return with the error code.
     return exit_code
-
-
-def is_snap() -> bool:
-    """Returns True if the current process is running under snap."""
-    return env_options.is_defined(env_options.SNAP_NAME)


### PR DESCRIPTION
Hi @cavearr, please review and accept.

Also, can you give the linux/snap a try on your Linux system (you can force manually a build in the github actions dashboard after accepting this PR)?   

After downloading the unzipping the artifact you can install using the commands:

```
unzip apio-linux-x86-64-snap.zip
snap install ./apio-linux-x86-64-0.9.6-snap.snap --dangerous  # Install the unsigned snap.
snap connect apio:raw-usb  # Allows usb acces.
```

I tested it with Alhambra-ii and Gowin/Tang 9k.