### PR TITLE
Fixing a broken test

### DIFF
--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -317,7 +317,7 @@ def _system_cli():
         title_justify="left",
     )
 
-    table.add_column("ITEM", no_wrap=True)
+    table.add_column("ITEM", no_wrap=True, min_width=20)
     table.add_column("VALUE", no_wrap=True, style=EMPH1)
 
     # -- Add rows

--- a/test/commands/test_apio_info.py
+++ b/test/commands/test_apio_info.py
@@ -4,13 +4,15 @@
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio
-from apio.common.apio_console import cunstyle
+from apio.common.apio_console import cunstyle, cwidth
 
 
 def test_apio_info(apio_runner: ApioRunner):
     """Test "apio info" with different parameters"""
 
     with apio_runner.in_sandbox() as sb:
+        # -- For debugging table column truncation in github testing.
+        print(f"Apio console width = {cwidth()}")
 
         # -- Execute "apio info"
         result = sb.invoke_apio_cmd(apio, "info")


### PR DESCRIPTION
A test failed on github because a table column gets truncated. This PR should fix it.  

https://github.com/FPGAwars/apio/actions/runs/13618994071/job/38065778484

@cavearr, please review and accept. I would like to see if it fixes the failure. I could not reproduce on my own repo. 