### PR TITLE
Now running the tests daily. 

### DIFF
--- a/.github/workflows/build-darwin-arm64-installer.yml
+++ b/.github/workflows/build-darwin-arm64-installer.yml
@@ -5,7 +5,8 @@ name: build-darwin-arm64-installer
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Runs daily at midnight UTC
+    # We run the build daily at 2PM, after running the tests at midnight.
+    - cron: '0 2 * * *'
   workflow_dispatch:  # Manual triggers ok.
 
 jobs:

--- a/.github/workflows/build-linux-x86-64-installer.yml
+++ b/.github/workflows/build-linux-x86-64-installer.yml
@@ -2,7 +2,8 @@ name: build-linux-x86-64-installer
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Runs daily at midnight UTC
+    # We run the build daily at 2PM, after running the tests at midnight.
+    - cron: '0 2 * * *'
   workflow_dispatch:  # Manual triggers ok.
 
 

--- a/.github/workflows/build-windows-amd64-installer.yml
+++ b/.github/workflows/build-windows-amd64-installer.yml
@@ -4,7 +4,8 @@ name: build-windows-amd64-installer
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Runs daily at midnight UTC
+    # We run the build daily at 2PM, after running the tests at midnight.
+    - cron: '0 2 * * *'
   workflow_dispatch:  # Manual triggers ok.
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,11 @@ name: Test
 
 on:
   push:
+  # NOTE: We run the test daily, even if we don't push anything, to ensure
+  # that the tests are still passing, despite potential changes in the github
+  # dependencies.
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at midnight UTC
   workflow_dispatch:  # Allows manual trigger
 
 jobs:


### PR DESCRIPTION
The apio test are now run daily, to detect breaking changes in the github workflow environment.

No semantic change.