### PR TITLE
Cleaned up around the upload --sram and --flash flags.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -119,7 +119,6 @@
         "tinyprog",
         "truecolor",
         "udevadm",
-        "ujprog",
         "unstyling",
         "USBFTDI",
         "userimage",

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1164,8 +1164,8 @@ Usage: apio upload [OPTIONS]
 Options:
   --serial-port serial-port  Set the serial port.
   --ftdi-id ftdi-id          Set the FTDI id.
-  -s, --sram                 Perform SRAM programming.
-  -f, --flash                Perform FLASH programming.
+  -s, --sram                 Perform SRAM programming (iceprog* programmers
+                             only).
   -p, --project-dir path     Set the root directory for the project.
   -h, --help                 Show this message and exit.
 

--- a/apio/commands/apio_upload.py
+++ b/apio/commands/apio_upload.py
@@ -43,16 +43,7 @@ sram_option = click.option(
     "-s",
     "--sram",
     is_flag=True,
-    help="Perform SRAM programming.",
-    cls=cmd_util.ApioOption,
-)
-
-flash_option = click.option(
-    "flash",  # Var name.
-    "-f",
-    "--flash",
-    is_flag=True,
-    help="Perform FLASH programming.",
+    help="Perform SRAM programming (iceprog* programmers only).",
     cls=cmd_util.ApioOption,
 )
 
@@ -84,7 +75,6 @@ to grant the necessary permissions to access USB devices.
 @serial_port_option
 @ftdi_id_option
 @sram_option
-@flash_option
 @options.project_dir_option
 def cli(
     _: click.Context,
@@ -92,7 +82,6 @@ def cli(
     serial_port: str,
     ftdi_id: str,
     sram: bool,
-    flash: bool,
     project_dir: Path,
 ):
     """Implements the upload command."""
@@ -118,7 +107,6 @@ def cli(
         serial_port=serial_port,
         ftdi_id=ftdi_id,
         sram=sram,
-        flash=flash,
     )
 
     # Construct the scons upload params.

--- a/apio/managers/programmers.py
+++ b/apio/managers/programmers.py
@@ -18,14 +18,6 @@ from apio.managers.system import System
 from apio.apio_context import ApioContext
 
 
-# -- Constant for the dictionary PROG, which contains
-# -- the programming configuration
-SERIAL_PORT = "serial_port"
-FTDI_ID = "ftdi_id"
-SRAM = "sram"
-FLASH = "flash"
-
-
 def construct_programmer_cmd(
     apio_ctx: ApioContext,
     serial_port: str,

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -46,13 +46,6 @@ from apio.common.proto.apio_pb2 import (
     UploadParams,
 )
 
-# -- Constant for the dictionary PROG, which contains
-# -- the programming configuration
-SERIAL_PORT = "serial_port"
-FTDI_ID = "ftdi_id"
-SRAM = "sram"
-FLASH = "flash"
-
 
 # W0703: Catching too general exception Exception (broad-except)
 # pylint: disable=W0703

--- a/apio/resources/programmers.jsonc
+++ b/apio/resources/programmers.jsonc
@@ -44,10 +44,6 @@
     "command": "tinyprog",
     "args": "--pyserial -c ${SERIAL_PORT} --program"
   },
-  "ujprog": {
-    "command": "ujprog",
-    "args": "-q -j SRAM"
-  },
   "fujprog": {
     "command": "fujprog",
     "args": "-l 2"

--- a/test/managers/test_programmers.py
+++ b/test/managers/test_programmers.py
@@ -1,0 +1,90 @@
+"""
+Tests of the apio.managers.programmers.py module.
+"""
+
+from test.conftest import ApioRunner
+from pytest import LogCaptureFixture, raises
+from apio.apio_context import ApioContext, ApioContextScope
+from apio.managers.programmers import _construct_programmer_cmd_template
+
+
+def test_construct_programmer_cmd_template(apio_runner: ApioRunner):
+    """Tests _construct_programmer_cmd_template() with default arguments."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Construct an apio context.
+        sb.write_apio_ini({"board": "alhambra-ii", "top-module": "my_module"})
+        apio_ctx = ApioContext(scope=ApioContextScope.PROJECT_REQUIRED)
+        board_info = apio_ctx.boards.get(apio_ctx.project.get("board"))
+        assert board_info["programmer"]["type"] == "iceprog"
+
+        # -- Run the test with default arguments.
+        programmer_cmd = _construct_programmer_cmd_template(
+            apio_ctx=apio_ctx,
+            board_info=board_info,
+            sram=False,
+        )
+
+        # -- Check the command.
+        assert (
+            programmer_cmd
+            == "iceprog -d i:0x${VID}:0x${PID}:${FTDI_ID} $SOURCE"
+        )
+
+
+def test_construct_programmer_cmd_template_sram_ok(apio_runner: ApioRunner):
+    """Tests _construct_programmer_cmd_template() with --sram ok."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Construct an apio context.
+        sb.write_apio_ini({"board": "alhambra-ii", "top-module": "my_module"})
+        apio_ctx = ApioContext(scope=ApioContextScope.PROJECT_REQUIRED)
+        board_info = apio_ctx.boards.get(apio_ctx.project.get("board"))
+        assert board_info["programmer"]["type"] == "iceprog"
+
+        # -- Run the test with --sram.
+        programmer_cmd = _construct_programmer_cmd_template(
+            apio_ctx=apio_ctx,
+            board_info=board_info,
+            sram=True,  # -- SRAM is enabled
+        )
+
+        # Notice the additional -S for SRAM.
+        assert (
+            programmer_cmd
+            == "iceprog -d i:0x${VID}:0x${PID}:${FTDI_ID} $SOURCE -S"
+        )
+
+
+def test_construct_programmer_cmd_template_sram_error(
+    apio_runner: ApioRunner, capsys: LogCaptureFixture
+):
+    """Tests _construct_programmer_cmd_template() with --sram error."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Construct an apio context with a board that does not
+        # -- support the flag --sram.
+        sb.write_apio_ini(
+            {"board": "colorlight-5a-75b-v7", "top-module": "my_module"}
+        )
+        apio_ctx = ApioContext(scope=ApioContextScope.PROJECT_REQUIRED)
+        board_info = apio_ctx.boards.get(apio_ctx.project.get("board"))
+        assert board_info["programmer"]["type"] == "openfpgaloader"
+
+        # -- Run the test with --sram.
+        with raises(SystemExit) as e:
+            _construct_programmer_cmd_template(
+                apio_ctx=apio_ctx,
+                board_info=board_info,
+                sram=True,  # -- SRAM is enabled
+            )
+
+        # -- Check the error message.
+        assert e.value.code == 1
+        assert (
+            "Error: The --sram flag is not available for the "
+            "openfpgaloader programmer." in capsys.readouterr().out
+        )

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -7,11 +7,6 @@ from test.conftest import ApioRunner
 from apio.apio_context import ApioContext, ApioContextScope
 
 
-# -- These programmers are known to be unused.
-# -- https://github.com/FPGAwars/apio/issues/536
-KNOWN_UNUSED_PROGRAMMERS = ["ujprog"]
-
-
 def lc_part_num(part_num: str) -> str:
     """Convert an fpga part number to a lower-case id."""
     return part_num.lower().replace("/", "-")
@@ -49,10 +44,6 @@ def test_resources_references(apio_runner: ApioRunner):
             # -- by more than one board, it may already be removed.
             if board_programmer_type in unused_programmers:
                 unused_programmers.remove(board_programmer_type)
-
-        # -- Remove programmers that are known to be unused.
-        for programmer in KNOWN_UNUSED_PROGRAMMERS:
-            unused_programmers.remove(programmer)
 
         # -- We should end up with an empty set of unused programmers.
         assert not unused_programmers, unused_programmers


### PR DESCRIPTION
This is a response to https://github.com/FPGAwars/apio/issues/584

The upload --sram flag now exists with an error if used with a programmer that doesn't support it and the --flash flag was removed because it was not support for any existing board.

Long term, we should generalize the concept of programming variants and move the hard coded logic to programmers and boards definitions.

@cavearr, review and accept.