### PR TITLE
Cleaned up --ftdi-id flag of apio upload

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1156,8 +1156,9 @@ Usage: apio upload [OPTIONS]
   'apio build' command) and uploads it to the FPGA board.
 
   Examples:
-    apio upload
-    apio upload --sram  # See SRAM restrictions below
+    apio upload              # Typical usage.
+    apio upload --ftdi-idx 2 # Consider only FTDI device at index 2
+    apio upload --sram       # See below
 
   The command programs the board’s default configuration memory, which
   is typically a non-volatile FLASH memory. For SRAM programming (also
@@ -1171,13 +1172,19 @@ Usage: apio upload [OPTIONS]
   accordingly. Refer to your board’s documentation for details (SRAM
   programming is also referred to as ICE programming).
 
+  The optional flag '--ftdi-idx' is used in special cases involving
+  boards with FTDI devices, particularly when multiple boards are
+  connected to the host computer. It tells Apio to consider only the
+  device at the specified index in the list shown by the command: 'apio
+  devices list ftdi'. The first device in the list has index 0.
+
   [Note] When apio is installed on Linux using the Snap package manager,
   run the command 'snap connect apio:raw-usb' once to grant the
   necessary permissions to access USB devices.
 
 Options:
   --serial-port serial-port  Set the serial port.
-  --ftdi-id ftdi-id          Set the FTDI id.
+  --ftdi-idx ftdi-idx        Consider only FTDI device with given index.
   -s, --sram                 Perform SRAM programming (see restrictions).
   -p, --project-dir path     Set the root directory for the project.
   -h, --help                 Show this message and exit.

--- a/apio/commands/apio_upload.py
+++ b/apio/commands/apio_upload.py
@@ -30,12 +30,13 @@ serial_port_option = click.option(
     cls=cmd_util.ApioOption,
 )
 
-ftdi_id_option = click.option(
-    "ftdi_id",  # Var name.
-    "--ftdi-id",
-    type=str,
-    metavar="ftdi-id",
-    help="Set the FTDI id.",
+ftdi_idx_option = click.option(
+    "ftdi_idx",  # Var name.
+    "--ftdi-idx",
+    type=int,
+    default=None,  # 0 is a valid value.
+    metavar="ftdi-idx",
+    help="Consider only FTDI device with given index.",
 )
 
 sram_option = click.option(
@@ -54,8 +55,9 @@ The command 'apio upload' builds the bitstream file (similar to the \
 'apio build' command) and uploads it to the FPGA board.
 
 Examples:[code]
-  apio upload
-  apio upload --sram  # See SRAM restrictions below[/code]
+  apio upload              # Typical usage.
+  apio upload --ftdi-idx 2 # Consider only FTDI device at index 2
+  apio upload --sram       # See below[/code]
 
 The command programs the board’s default configuration memory, which is \
 typically a non-volatile FLASH memory. For SRAM programming (also known \
@@ -68,6 +70,12 @@ name begins with 'iceprog'.
 2. The board must support SRAM programming and be configured accordingly. \
 Refer to your board’s documentation for details (SRAM programming is \
 also referred to as ICE programming).
+
+The optional flag '--ftdi-idx' is used in special cases involving boards with \
+FTDI devices, particularly when multiple boards are connected to the host \
+computer. It tells Apio to consider only the device at the specified index in \
+the list shown by the command: 'apio devices list ftdi'. The first device in \
+the list has index 0.
 
 [Note] When apio is installed on Linux using the Snap package \
 manager, run the command 'snap connect apio:raw-usb' once \
@@ -86,14 +94,14 @@ to grant the necessary permissions to access USB devices.
 )
 @click.pass_context
 @serial_port_option
-@ftdi_id_option
+@ftdi_idx_option
 @sram_option
 @options.project_dir_option
 def cli(
     _: click.Context,
     # Options
     serial_port: str,
-    ftdi_id: str,
+    ftdi_idx: int,
     sram: bool,
     project_dir: Path,
 ):
@@ -118,7 +126,7 @@ def cli(
     programmer_cmd = construct_programmer_cmd(
         apio_ctx,
         serial_port=serial_port,
-        ftdi_id=ftdi_id,
+        ftdi_idx=ftdi_idx,
         sram=sram,
     )
 

--- a/apio/managers/system.py
+++ b/apio/managers/system.py
@@ -8,6 +8,7 @@
 
 import re
 import sys
+from typing import Dict, List
 from apio.common.apio_console import cout, cerror
 from apio.common.apio_styles import INFO, ERROR, EMPH1
 from apio.utils import util, pkg_util, snap_util
@@ -136,7 +137,7 @@ class System:  # pragma: no cover
         # -- from the command stdout
         # -- Ex: [{'index': '0', 'manufacturer': 'AlhambraBits',
         # --      'description': 'Alhambra II v1.0A - B07-095'}]
-        ftdi_devices = self._parse_ftdi_devices(result.out_text)
+        ftdi_devices = self._parse_lsftdi_devices(result.out_text)
 
         # -- Return the devices
         return ftdi_devices
@@ -231,10 +232,18 @@ class System:  # pragma: no cover
         return usb_devices
 
     @staticmethod
-    def _parse_ftdi_devices(text):
+    def _parse_lsftdi_devices(text: str) -> List[Dict]:
+        """Get a list of FTDI devices from the output text of lsftdi."""
         pattern = r"Number\sof\sFTDI\sdevices\sfound:\s(?P<n>\d+?)\n"
         match = re.search(pattern, text)
         num = int(match.group("n")) if match else 0
+
+        # pylint: disable=fixme
+        # TODO: Change the parsing to iterate over lines and create a device
+        # from each line. This will make the code more intuitive and robust.
+
+        # TODO: Change the output format from a list of dicts to a list of
+        # dataclass objects. Motivation is code quality.
 
         pattern = r".*Checking\sdevice:\s(?P<index>.*?)\n.*"
         index = re.findall(pattern, text)
@@ -254,5 +263,9 @@ class System:  # pragma: no cover
                 "description": description[i],
             }
             ftdi_devices.append(ftdi_device)
+
+            # -- Dump the device info if in debug mode..
+            if util.is_debug():
+                cout(f"FTDI device: {ftdi_device}")
 
         return ftdi_devices

--- a/test/managers/test_system.py
+++ b/test/managers/test_system.py
@@ -1,0 +1,67 @@
+"""
+Tests of apio.managers.system.py
+"""
+
+from test.conftest import ApioRunner
+from apio.managers.system import System
+from apio.apio_context import ApioContext, ApioContextScope
+
+# pylint: disable=fixme
+# TODO: Add more tests.
+
+# pylint: disable=protected-access
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+
+def test_parse_lsftdi_devices(apio_runner: ApioRunner):
+    """Test the parsing of the lsftdi command output."""
+
+    with apio_runner.in_sandbox():
+
+        # -- Setup a System object
+        apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
+        sys = System(apio_ctx)
+
+        # -- NOTE: The test text below was generated with 'apio raw -- lsftdi'.
+
+        # -- Test with no devices.
+        devices = sys._parse_lsftdi_devices("Number of FTDI devices found: 0")
+        assert devices == []
+
+        # -- Test with a single device.
+        devices = sys._parse_lsftdi_devices(
+            "Number of FTDI devices found: 1\n"
+            "Checking device: 0\n"
+            "Manufacturer: AlhambraBits, Description: Alhambra II v1.0A - "
+            "B09-335\n"
+        )
+        assert devices == [
+            {
+                "description": "Alhambra II v1.0A - B09-335",
+                "index": "0",
+                "manufacturer": "AlhambraBits",
+            }
+        ]
+
+        # -- Test with two devices.
+        devices = sys._parse_lsftdi_devices(
+            "Number of FTDI devices found: 2\n"
+            "Checking device: 0\n"
+            "Manufacturer: tinyVision.ai, Description: UPduino v3.1c\n"
+            "\n"
+            "Checking device: 1\n"
+            "Manufacturer: AlhambraBits, Description: Alhambra II v1.0A - "
+            "B09-335\n"
+        )
+        assert devices == [
+            {
+                "index": "0",
+                "manufacturer": "tinyVision.ai",
+                "description": "UPduino v3.1c",
+            },
+            {
+                "index": "1",
+                "manufacturer": "AlhambraBits",
+                "description": "Alhambra II v1.0A - B09-335",
+            },
+        ]


### PR DESCRIPTION
Renamed --ftdi-id to --ftdi-idx and clarified in the help text that it's an index in the device list generated by 'apio drivers list ftdi' rather than an ftdi device id.

Per https://github.com/FPGAwars/apio/issues/587

