### PR TITLE
Assorted changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04, macos-latest, windows-latest]
-                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+                python-version: ['3.11', '3.12', '3.13']
 
         steps:
             - name: Checkout sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,9 @@ jobs:
             shell: bash
 
         strategy:
-            # max-parallel: 3
             matrix:
                 os: [ubuntu-22.04, macos-latest, windows-latest]
                 python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-                # Windows test are almost x10 slower on github so we drop the
-                # less critical ones.
-                exclude:
-                  - os: windows-latest
-                    python-version: '3.9'
-                  - os: windows-latest
-                    python-version: '3.10'
 
         steps:
             - name: Checkout sources

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,9 @@
 # Configuration file for pylint.
 
+[MESSAGES CONTROL]
+# Do not warn about TODOs.
+disable=fixme
+
 [SIMILARITIES]
 # Reducing the sensitivity of duplicate code (default is 4)
 min-similarity-lines=15

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+# Configuration file for pylint.
+
+[SIMILARITIES]
+# Reducing the sensitivity of duplicate code (default is 4)
+min-similarity-lines=15

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![PyPI Version][pypi-image]][pypi-url] [![License][license-image]][license-url]
 
-[![Test](https://github.com/FPGAwars/apio/actions/workflows/test.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/test.yml)
-[![build-linux-x86-64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-linux-x86-64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-linux-x86-64-installer.yml)
-[![build-darwin-arm64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-darwin-arm64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-darwin-arm64-installer.yml)
+[![Test](https://github.com/FPGAwars/apio/actions/workflows/test.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/test.yml)<br>
+[![build-linux-x86-64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-linux-x86-64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-linux-x86-64-installer.yml)<br>
+[![build-darwin-arm64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-darwin-arm64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-darwin-arm64-installer.yml)<br>
 [![build-windows-amd64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-windows-amd64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-windows-amd64-installer.yml)
 
 ![][linux-logo]&nbsp;&nbsp;&nbsp;![][macosx-logo]&nbsp;&nbsp;&nbsp;![][windows-logo]&nbsp;&nbsp;&nbsp;![][ubuntu-logo]&nbsp;&nbsp;&nbsp;![][raspbian-logo]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 [![][apio-logo]][wiki]
 
-[![PyPI Version][pypi-image]][pypi-url]
-[![Build Status][build-image]][build-url]
-[![License][license-image]][license-url]
+[![PyPI Version][pypi-image]][pypi-url] [![License][license-image]][license-url]
+
+[![Test](https://github.com/FPGAwars/apio/actions/workflows/test.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/test.yml)
+[![build-linux-x86-64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-linux-x86-64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-linux-x86-64-installer.yml)
+[![build-darwin-arm64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-darwin-arm64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-darwin-arm64-installer.yml)
+[![build-windows-amd64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-windows-amd64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-windows-amd64-installer.yml)
 
 ![][linux-logo]&nbsp;&nbsp;&nbsp;![][macosx-logo]&nbsp;&nbsp;&nbsp;![][windows-logo]&nbsp;&nbsp;&nbsp;![][ubuntu-logo]&nbsp;&nbsp;&nbsp;![][raspbian-logo]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![][apio-logo]][wiki]
 
-[![PyPI Version][pypi-image]][pypi-url] [![License][license-image]][license-url]
-
+[![PyPI Version][pypi-image]][pypi-url]<br>
+[![License][license-image]][license-url]<br>
 [![Test](https://github.com/FPGAwars/apio/actions/workflows/test.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/test.yml)<br>
 [![build-linux-x86-64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-linux-x86-64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-linux-x86-64-installer.yml)<br>
 [![build-darwin-arm64-installer](https://github.com/FPGAwars/apio/actions/workflows/build-darwin-arm64-installer.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/build-darwin-arm64-installer.yml)<br>

--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -3,11 +3,11 @@
 
 import sys
 
-# pylint: disable=import-outside-toplevel
-
 
 def main():
     """Apio starting point."""
+
+    # pylint: disable=import-outside-toplevel
 
     # -- Handle the case in which we run under pyinstaller and the pyinstaller
     # -- program was invoked to run the scons subprocess. This case doesn't

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -82,9 +82,10 @@ class ApioContextScope(Enum):
     PROJECT_REQUIRED = 3
 
 
-# pylint: disable=too-many-instance-attributes
 class ApioContext:
     """Apio context. Class for accessing apio resources and configurations."""
+
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
@@ -554,8 +555,9 @@ class ApioContext:
         return "windows" in self.platform_id
 
 
-# pylint: disable=too-few-public-methods
 class _ProjectResolverImpl(ProjectResolver):
+    # pylint: disable=too-few-public-methods
+
     def __init__(self, apio_context: ApioContext):
         """When ApioContext instances this object, ApioContext is fully
         constructed, except for the project field."""

--- a/apio/commands/apio_api.py
+++ b/apio/commands/apio_api.py
@@ -78,7 +78,6 @@ output_option = click.option(
 )
 
 
-# pylint: disable=too-many-locals
 @click.command(
     name="info",
     cls=ApioCommand,
@@ -97,6 +96,8 @@ def _info_cli(
     force: bool,
 ):
     """Implements the 'apio apio info' command."""
+
+    # pylint: disable=too-many-locals
 
     # -- Should have at list one section
     if not sections:

--- a/apio/commands/apio_boards.py
+++ b/apio/commands/apio_boards.py
@@ -24,10 +24,11 @@ from apio.commands import options
 from apio.managers.examples import Examples
 
 
-# pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class Entry:
     """Holds the values of a single board report line."""
+
+    # pylint: disable=too-many-instance-attributes
 
     board: str
     examples_count: str
@@ -46,10 +47,10 @@ class Entry:
         return (util.fpga_arch_sort_key(self.fpga_arch), self.board.lower())
 
 
-# R0914: Too many local variables (17/15)
-# pylint: disable=R0914
 def list_boards(apio_ctx: ApioContext, verbose: bool):
     """Prints all the available board definitions."""
+
+    # pylint: disable=too-many-locals
 
     # -- Get examples counts by board. This is a sparse dictionary.
     examples = Examples(apio_ctx)

--- a/apio/commands/apio_boards.py
+++ b/apio/commands/apio_boards.py
@@ -24,7 +24,6 @@ from apio.commands import options
 from apio.managers.examples import Examples
 
 
-# pylint: disable=duplicate-code
 # pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class Entry:
@@ -153,8 +152,6 @@ def list_boards(apio_ctx: ApioContext, verbose: bool):
 
 
 # ------------- apio boards
-
-# pylint: disable=duplicate-code
 
 
 # -- Text in the rich-text format of the python rich library.

--- a/apio/commands/apio_build.py
+++ b/apio/commands/apio_build.py
@@ -73,7 +73,6 @@ def cli(
     # -- Create the scons manager.
     scons = SCons(apio_ctx)
 
-    # pylint: disable=duplicate-code
     # -- Build the project with the given parameters
     exit_code = scons.build(
         Verbosity(all=verbose, synth=verbose_synth, pnr=verbose_pnr)

--- a/apio/commands/apio_examples.py
+++ b/apio/commands/apio_examples.py
@@ -44,7 +44,6 @@ def examples_sort_key(entry: ExampleInfo) -> Any:
     return (util.fpga_arch_sort_key(entry.fpga_arch), entry.name)
 
 
-# pylint: disable=duplicate-code
 def list_examples(apio_ctx: ApioContext, verbose: bool) -> None:
     """Print all the examples available. Return a process exit
     code, 0 if ok, non zero otherwise."""

--- a/apio/commands/apio_fpgas.py
+++ b/apio/commands/apio_fpgas.py
@@ -22,10 +22,11 @@ from apio.utils import util, cmd_util
 from apio.commands import options
 
 
-# pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class Entry:
     """A class to hold the field of a single line of the report."""
+
+    # pylint: disable=too-many-instance-attributes
 
     fpga: str
     board_count: int
@@ -41,9 +42,10 @@ class Entry:
         return (util.fpga_arch_sort_key(self.fpga_arch), self.fpga.lower())
 
 
-# pylint: disable=too-many-locals
 def list_fpgas(apio_ctx: ApioContext, verbose: bool):
     """Prints all the available FPGA definitions."""
+
+    # pylint: disable=too-many-locals
 
     # -- Collect a sparse dict with fpga ids to board count.
     boards_counts: Dict[str, int] = {}

--- a/apio/commands/apio_fpgas.py
+++ b/apio/commands/apio_fpgas.py
@@ -22,7 +22,6 @@ from apio.utils import util, cmd_util
 from apio.commands import options
 
 
-# pylint: disable=duplicate-code
 # pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class Entry:
@@ -142,7 +141,6 @@ def list_fpgas(apio_ctx: ApioContext, verbose: bool):
 
 # -------- apio fpgas
 
-# pylint: disable=duplicate-code
 
 # -- Text in the rich-text format of the python rich library.
 APIO_FPGAS_HELP = """

--- a/apio/commands/apio_graph.py
+++ b/apio/commands/apio_graph.py
@@ -61,8 +61,6 @@ graph, and on Mac OS type 'open _build/hardware.svg'.
 """
 
 
-# pylint: disable=too-many-arguments
-# pylint: disable=too-many-positional-arguments
 @click.command(
     name="graph",
     cls=cmd_util.ApioCommand,
@@ -87,6 +85,10 @@ def cli(
     top_module: str,
 ):
     """Implements the apio graph command."""
+
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
+
     # -- Make pylint happy.
     _ = (svg,)
 

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -219,7 +219,6 @@ same functionality.
 """
 
 
-# pylint: disable=duplicate-code
 @click.command(
     name="resources",
     cls=ApioCommand,
@@ -291,7 +290,6 @@ environment variable 'APIO_HOME'.
 """
 
 
-# pylint: disable=duplicate-code
 @click.command(
     name="system",
     cls=ApioCommand,
@@ -446,7 +444,6 @@ print_option = click.option(
 )
 
 
-# pylint: disable=duplicate-code
 # pylint: disable=too-many-locals
 @click.command(
     name="colors",

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -444,7 +444,6 @@ print_option = click.option(
 )
 
 
-# pylint: disable=too-many-locals
 @click.command(
     name="colors",
     cls=ApioCommand,
@@ -463,6 +462,8 @@ def _colors_cli(
     print_: bool,
 ):
     """Implements the 'apio info colors' command."""
+
+    # pylint: disable=too-many-locals
 
     # -- Make pylint happy.
     _ = (rich_,)

--- a/apio/commands/apio_lint.py
+++ b/apio/commands/apio_lint.py
@@ -69,8 +69,6 @@ Examples:[code]
 """
 
 
-# pylint: disable=too-many-arguments
-# pylint: disable=too-many-positional-arguments
 @click.command(
     name="lint",
     cls=cmd_util.ApioCommand,
@@ -97,6 +95,9 @@ def cli(
     project_dir: Path,
 ):
     """Lint the verilog code."""
+
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
 
     # -- Create the apio context.
     apio_ctx = ApioContext(

--- a/apio/commands/apio_packages.py
+++ b/apio/commands/apio_packages.py
@@ -20,7 +20,6 @@ from apio.commands import options
 from apio.utils.cmd_util import ApioGroup, ApioSubgroup, ApioCommand
 
 
-# pylint: disable=duplicate-code
 def print_packages_report(apio_ctx: ApioContext) -> None:
     """A common function to print the state of the packages."""
 

--- a/apio/commands/apio_preferences.py
+++ b/apio/commands/apio_preferences.py
@@ -61,7 +61,6 @@ def _list_themes_colors():
     print()
 
 
-# pylint: disable=duplicate-code
 def _list_preferences(apio_ctx: ApioContext):
     """Lists the preferences."""
 

--- a/apio/commands/apio_report.py
+++ b/apio/commands/apio_report.py
@@ -31,7 +31,6 @@ Examples:[code]
 """
 
 
-# pylint: disable=duplicate-code
 @click.command(
     name="report",
     cls=cmd_util.ApioCommand,

--- a/apio/commands/apio_sim.py
+++ b/apio/commands/apio_sim.py
@@ -21,7 +21,6 @@ from apio.utils import cmd_util
 
 # --------- apio sim
 
-# pylint: disable=duplicate-code
 
 # -- Text in the rich-text format of the python rich library.
 APIO_SIM_HELP = """

--- a/apio/commands/apio_test.py
+++ b/apio/commands/apio_test.py
@@ -19,7 +19,6 @@ from apio.utils import cmd_util
 
 # --------- apio test
 
-# pylint: disable=duplicate-code
 
 # -- Text in the rich-text format of the python rich library.
 APIO_TEST_HELP = """

--- a/apio/commands/options.py
+++ b/apio/commands/options.py
@@ -25,10 +25,12 @@ from apio.utils import cmd_util
 # ----------------------------------
 
 
-# W0622: Redefining built-in 'help'
-# pylint: disable=W0622
 def force_option_gen(*, help: str):
     """Generate a --force option with given help text."""
+
+    # W0622: Redefining built-in 'help'
+    # pylint: disable=redefined-builtin
+
     return click.option(
         "force",  # Var name
         "-f",
@@ -39,10 +41,12 @@ def force_option_gen(*, help: str):
     )
 
 
-# W0622: Redefining built-in 'help'
-# pylint: disable=W0622
 def list_option_gen(*, help: str):
     """Generate a --list option with given help text."""
+
+    # W0622: Redefining built-in 'help'
+    # pylint: disable=redefined-builtin
+
     return click.option(
         "list_",  # Var name. Deconflicting from python builtin 'list'.
         "-l",
@@ -53,13 +57,15 @@ def list_option_gen(*, help: str):
     )
 
 
-# W0622: Redefining built-in 'help'
-# pylint: disable=W0622
 def top_module_option_gen(
     *,
     help: str = "Set the top level module name.",
 ):
     """Generate a --top-module option with given help text."""
+
+    # W0622: Redefining built-in 'help'
+    # pylint: disable=redefined-builtin
+
     return click.option(
         "top_module",  # Var name.
         "-t",
@@ -74,6 +80,10 @@ def top_module_option_gen(
 
 def dst_option_gen(*, help: str):
     """Generate a --dst option with given help text."""
+
+    # W0622: Redefining built-in 'help'
+    # pylint: disable=redefined-builtin
+
     dst_option = click.option(
         "dst",  # Var name.
         "-d",

--- a/apio/common/apio_console.py
+++ b/apio/common/apio_console.py
@@ -64,13 +64,15 @@ _state: ConsoleState = None
 
 # NOTE: not declaring terminal_mode and  theme_name is Optional[] because it
 # causes the tests to fail with python 3.9.
-# pylint: disable=global-statement
 def configure(
     *,
     terminal_mode: TerminalMode = None,
     theme_name: str = None,
 ) -> None:
     """Change the apio console settings."""
+
+    # pylint: disable=global-statement
+
     global _state
 
     # -- Force utf-8 output encoding. This is a workaround for rich library

--- a/apio/common/common_util.py
+++ b/apio/common/common_util.py
@@ -11,9 +11,8 @@
 scons (child) process."""
 
 import os
-import functools
 from pathlib import Path
-from typing import List, Union
+from typing import List, Union, Any
 import debugpy
 from apio.common.apio_styles import EMPH3, SUCCESS
 
@@ -44,23 +43,16 @@ def maybe_wait_for_remote_debugger(env_var_name: str):
         )
 
 
-def file_sort_compare_func(a: Union[str, Path], b: Union[str, Path]) -> int:
-    """Compare functions for sorting files. It sorts first by directory
-    and then by file name. Returns -1 if a < b, 0 if a == b and 1 if a > b."""
-    # -- files as Path objects.
-    path1 = Path(a)
-    path2 = Path(b)
-
-    # -- List of parents.
-    parents1: List[str] = [s.lower() for s in path1.parent.parts]
-    parents2: List[str] = [s.lower() for s in path2.parent.parts]
-
-    # -- Key to sort by parents and then by name.
-    key1 = [parents1, path1.name.lower()]
-    key2 = [parents2, path2.name.lower()]
-
-    # -- Resolve as -1, 0 or 1.
-    return (key1 > key2) - (key1 < key2)
+def file_sort_key_func(f: Union[str, Path]) -> Any:
+    """Given a file name or path, return a key to sort a file list.
+    The order is lexicography and case sensitive."""
+    path = Path(f)
+    # -- List of directory names in lower case.
+    parents: List[str] = [s.lower() for s in path.parent.parts]
+    # -- File name in lower case.
+    name: str = path.name.lower()
+    # -- Sort by directory and then by file name.
+    return [parents, name]
 
 
 def sort_files(files: List[str]) -> List[str]:
@@ -68,4 +60,4 @@ def sort_files(files: List[str]) -> List[str]:
     A new sorted list is returned.
     """
     # -- Sort the files by directory and then by file name.
-    return sorted(files, key=functools.cmp_to_key(file_sort_compare_func))
+    return sorted(files, key=file_sort_key_func)

--- a/apio/common/rich_lib_windows.py
+++ b/apio/common/rich_lib_windows.py
@@ -15,9 +15,6 @@ import platform
 import rich.console
 from apio.common.proto.apio_pb2 import RichLibWindowsParams
 
-# For accessing rich.console._windows_console_features
-# pylint: disable=protected-access
-
 
 def fix_windows_stdout_encoding() -> bool:
     """Called on the apio process (parent) to fix its output encoding.
@@ -37,6 +34,10 @@ def fix_windows_stdout_encoding() -> bool:
 def get_workaround_params() -> RichLibWindowsParams:
     """Called on the apio (parent) process side, when running on windows,
     to collect the parameters for the rich library workaround."""
+
+    # For accessing rich.console._windows_console_features
+    # pylint: disable=protected-access
+
     result = RichLibWindowsParams(
         vt=rich.console._windows_console_features.vt,
         truecolor=rich.console._windows_console_features.truecolor,
@@ -49,6 +50,9 @@ def apply_workaround(params: RichLibWindowsParams):
     """Called on the scons (child) process side, when running on windows,
     to apply the the workaround for the rich library."""
     assert params.IsInitialized, params
+
+    # For accessing rich.console._windows_console_features
+    # pylint: disable=protected-access
 
     # -- This takes care of the table graphic box.
     # -- See https://github.com/Textualize/rich/issues/3625

--- a/apio/managers/downloader.py
+++ b/apio/managers/downloader.py
@@ -11,7 +11,6 @@
 packages release repositories.
 """
 
-# pylint: disable=fixme
 # TODO: capture all the exceptions and return them as method return status.
 # Motivation is simplifying the usage.
 

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -7,7 +7,7 @@
 # ---- Platformio project
 # ---- (C) 2014-2016 Ivan Kravets <me@ikravets.com>
 # ---- License Apache v2
-"""Utility functionality for apio click commands. """
+"""Utility functionality for apio click commands."""
 
 import sys
 from abc import ABC, abstractmethod

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -114,12 +114,13 @@ REQUIRED_OPTIONS = {
 }
 
 
-# pylint: disable=too-few-public-methods
 class ProjectResolver(ABC):
     """An abstract class with services that are needed for project validation.
     Generally speaking it provides a subset of the functionality of ApioContext
     and we use it to avoid a cyclic import between Project and ApioContext.
     """
+
+    # pylint: disable=too-few-public-methods
 
     @abstractmethod
     def lookup_board_name(self, board: str) -> str:

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -339,7 +339,6 @@ class SCons:
         assert result.IsInitialized(), result
         return result
 
-    # pylint: disable=too-many-locals
     def _run(
         self,
         scons_command: str,
@@ -348,6 +347,8 @@ class SCons:
         uses_packages: bool,
     ):
         """Invoke an scons subprocess."""
+
+        # pylint: disable=too-many-locals
 
         # -- Pass to the scons process the name of the sconstruct file it
         # -- should use.

--- a/apio/managers/scons_filter.py
+++ b/apio/managers/scons_filter.py
@@ -6,7 +6,6 @@
 # -- Author Jesús Arroyo
 # -- License GPLv2
 
-# pylint: disable=fixme
 # TODO: Implement range detectors for Fumo, Tinyprog, and Iceprog, similar to
 # the pnr detector. This will avoid matching of output from other programs.
 
@@ -227,8 +226,6 @@ class SconsFilter:
         if self._is_debug:
             cout(f"IGNORED: {line}")
 
-    # pylint: disable=too-many-return-statements
-    # pylint: disable=too-many-branches
     def on_line(self, pipe_id: PipeId, line: str) -> None:
         """A shared handler for stdout/err lines from the scons sub process.
         The handler writes both stdout and stderr lines to stdout, possibly
@@ -240,6 +237,9 @@ class SconsFilter:
         came from that program. That is to minimize the risk of matching lines
         from other programs. See the PNR detector for an example.
         """
+
+        # pylint: disable=too-many-return-statements
+        # pylint: disable=too-many-branches
 
         # -- Update the range detectors.
         in_pnr_verbose_range = self._pnr_detector.update(pipe_id, line)

--- a/apio/managers/system.py
+++ b/apio/managers/system.py
@@ -173,7 +173,6 @@ class System:  # pragma: no cover
         installer.install_missing_packages_on_the_fly(self.apio_ctx)
         pkg_util.set_env_for_packages(self.apio_ctx, quiet=True)
 
-        # pylint: disable=fixme
         # TODO: Is this necessary or does windows accepts commands without
         # the '.exe' extension?
         if self.apio_ctx.is_windows:
@@ -256,7 +255,6 @@ class System:  # pragma: no cover
         # -- lines, we extract the information by field rather than by device
         # -- line. It's awkward, but it works.
 
-        # pylint: disable=fixme
         # TODO: Change the output format from a list of dicts to a list of
         # dataclass objects. Motivation is code quality.
 

--- a/apio/scons/apio_env.py
+++ b/apio/scons/apio_env.py
@@ -71,7 +71,6 @@ class ApioEnv:
         that name that contains a wrapper to that builder."""
         self.scons_env.Append(BUILDERS={builder_id: builder})
 
-    # pylint: disable=too-many-arguments
     def builder_target(
         self,
         *,
@@ -82,6 +81,9 @@ class ApioEnv:
         always_build: bool = False,
     ):
         """Creates an return a target that uses the builder with given id."""
+
+        # pylint: disable=too-many-arguments
+
         # -- Scons wraps the builder with a wrapper. We use it to create the
         # -- new target.
         builder_wrapper: BuilderWrapper = getattr(self.scons_env, builder_id)

--- a/apio/scons/plugin_base.py
+++ b/apio/scons/plugin_base.py
@@ -39,7 +39,6 @@ class ArchPluginInfo:
     clk_name_index: int
 
 
-# pylint: disable=consider-using-f-string
 class PluginBase:
     """Base apio arch plugin handler"""
 
@@ -105,6 +104,8 @@ class PluginBase:
     def yosys_dot_builder(self) -> BuilderBase:
         """Creates and returns the yosys dot builder. Should be called
         only when serving the graph command."""
+
+        # pylint: disable=consider-using-f-string
 
         # -- Sanity checks
         assert self.apio_env.targeting("graph")

--- a/apio/scons/plugin_ecp5.py
+++ b/apio/scons/plugin_ecp5.py
@@ -29,7 +29,6 @@ from apio.scons.plugin_util import (
 )
 
 
-# pylint: disable=consider-using-f-string
 class PluginEcp5(PluginBase):
     """Apio scons plugin for the ice40 architecture."""
 
@@ -56,6 +55,9 @@ class PluginEcp5(PluginBase):
     # @overrides
     def synth_builder(self) -> BuilderBase:
         """Creates and returns the synth builder."""
+
+        # pylint: disable=consider-using-f-string
+
         # -- Keep short references.
         apio_env = self.apio_env
         params = apio_env.params
@@ -78,6 +80,9 @@ class PluginEcp5(PluginBase):
     # @overrides
     def pnr_builder(self) -> BuilderBase:
         """Creates and returns the pnr builder."""
+
+        # pylint: disable=consider-using-f-string
+
         # -- Keep short references.
         apio_env = self.apio_env
         params = apio_env.params
@@ -110,6 +115,9 @@ class PluginEcp5(PluginBase):
     # @overrides
     def bitstream_builder(self) -> BuilderBase:
         """Creates and returns the bitstream builder."""
+
+        # pylint: disable=consider-using-f-string
+
         return Builder(
             action="ecppack --compress --db {0} $SOURCE $TARGET".format(
                 self.database_path,

--- a/apio/scons/plugin_gowin.py
+++ b/apio/scons/plugin_gowin.py
@@ -29,7 +29,6 @@ from apio.scons.plugin_util import (
 )
 
 
-# pylint: disable=consider-using-f-string
 class PluginGowin(PluginBase):
     """Apio scons plugin for the ice40 architecture."""
 
@@ -53,6 +52,9 @@ class PluginGowin(PluginBase):
     # @overrides
     def synth_builder(self) -> BuilderBase:
         """Creates and returns the synth builder."""
+
+        # pylint: disable=consider-using-f-string
+
         # -- Keep short references.
         apio_env = self.apio_env
         params = apio_env.params
@@ -75,6 +77,9 @@ class PluginGowin(PluginBase):
     # @overrides
     def pnr_builder(self) -> BuilderBase:
         """Creates and returns the pnr builder."""
+
+        # pylint: disable=consider-using-f-string
+
         # -- Keep short references.
         apio_env = self.apio_env
         params = apio_env.params
@@ -106,6 +111,9 @@ class PluginGowin(PluginBase):
     # @overrides
     def bitstream_builder(self) -> BuilderBase:
         """Creates and returns the bitstream builder."""
+
+        # pylint: disable=consider-using-f-string
+
         return Builder(
             action="gowin_pack -d {0} -o $TARGET $SOURCE".format(
                 self.apio_env.params.fpga_info.gowin.family

--- a/apio/scons/plugin_ice40.py
+++ b/apio/scons/plugin_ice40.py
@@ -29,7 +29,6 @@ from apio.scons.plugin_util import (
 )
 
 
-# pylint: disable=consider-using-f-string
 class PluginIce40(PluginBase):
     """Apio scons plugin for the ice40 architecture."""
 
@@ -53,6 +52,9 @@ class PluginIce40(PluginBase):
     # @overrides
     def synth_builder(self) -> BuilderBase:
         """Creates and returns the synth builder."""
+
+        # pylint: disable=consider-using-f-string
+
         # -- Keep short references.
         apio_env = self.apio_env
         params = apio_env.params
@@ -75,6 +77,9 @@ class PluginIce40(PluginBase):
     # @overrides
     def pnr_builder(self) -> BuilderBase:
         """Creates and returns the pnr builder."""
+
+        # pylint: disable=consider-using-f-string
+
         # -- Keep short references.
         apio_env = self.apio_env
         params = apio_env.params

--- a/apio/scons/plugin_util.py
+++ b/apio/scons/plugin_util.py
@@ -9,7 +9,6 @@
 # ---- License Apache v2
 """Helper functions for apio scons plugins."""
 
-# pylint: disable=consider-using-f-string
 
 import sys
 import os
@@ -233,6 +232,8 @@ def verilator_lint_action(
     * lib_files: Optional additional files to include.
     """
 
+    # pylint: disable=consider-using-f-string
+
     # -- Sanity checks
     assert apio_env.targeting("lint")
     assert apio_env.params.target.HasField("lint")
@@ -288,6 +289,8 @@ def waves_target(
     vcd_file_target is the simulator target that generated the vcd file
     with the signals. Returns the new targets.
     """
+
+    # pylint: disable=consider-using-f-string
 
     # -- Construct the commands list.
     commands = []
@@ -672,7 +675,6 @@ def get_programmer_cmd(apio_env: ApioEnv) -> str:
     return programmer_cmd
 
 
-# pylint: disable=too-many-arguments
 def iverilog_action(
     *,
     verbose: bool,
@@ -693,6 +695,9 @@ def iverilog_action(
     *
     * Returns the scons action string for the IVerilog command.
     """
+
+    # pylint: disable=too-many-arguments
+    # pylint: disable=consider-using-f-string
 
     # Escaping for windows. '\' -> '\\'
     escaped_vcd_output_name = vcd_output_name.replace("\\", "\\\\")

--- a/apio/scons/plugin_util.py
+++ b/apio/scons/plugin_util.py
@@ -522,7 +522,6 @@ def source_files(apio_env: ApioEnv) -> Tuple[List[str], List[str]]:
     return (synth_srcs, test_srcs)
 
 
-# pylint: disable=duplicate-code
 def _print_pnr_utilization_report(report: Dict[str, any]):
     table = Table(
         show_header=True,

--- a/apio/utils/cmd_util.py
+++ b/apio/utils/cmd_util.py
@@ -7,7 +7,7 @@
 # ---- Platformio project
 # ---- (C) 2014-2016 Ivan Kravets <me@ikravets.com>
 # ---- License Apache v2
-"""Utility functionality for apio click commands. """
+"""Utility functionality for apio click commands."""
 
 import sys
 from dataclasses import dataclass

--- a/apio/utils/pkg_util.py
+++ b/apio/utils/pkg_util.py
@@ -241,12 +241,13 @@ def package_version_ok(
     return current_ver == remote_ver
 
 
-# pylint: disable=too-many-branches
 def scan_packages(
     apio_ctx: ApioContext, *, cached_config_ok: bool, verbose: bool
 ) -> PackageScanResults:
     """Scans the available and installed packages and returns
     the findings as a PackageScanResults object."""
+
+    # pylint: disable=too-many-branches
 
     # Initialize the result with empty data.
     result = PackageScanResults([], [], [], [], [], [], [])

--- a/apio/utils/util.py
+++ b/apio/utils/util.py
@@ -351,10 +351,11 @@ def get_tinyprog_meta() -> list:
     return meta
 
 
-# pylint: disable=E1101
-# -- E1101: Instance of 'module' has no '__file__' member (no-member)
 def get_bin_dir() -> Path:
     """Get the Apio executable Path"""
+
+    # E1101: Instance of 'module' has no '__file__' member (no-member)
+    # pylint: disable=no-member
 
     # -- Get the apio main module
     main_mod = sys.modules["__main__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers=[
         'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
 ]
 description-file = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 requires = [
     'click==8.1.8',
     'colorama==0.4.6',
@@ -57,7 +57,7 @@ apio = "apio.__main__:main"
 
 [tool.black]
 line-length = 79
-target-version = ['py39']
+target-version = ['py311']
 
 # NOTE: For pylint control see .pylintrc in this directory.
 # It allows controls that pyproject.toml doesn't support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,5 @@ apio = "apio.__main__:main"
 line-length = 79
 target-version = ['py39']
 
-[tool.pylint.messages_control]
-disable = [ ]
+# NOTE: For pylint control see .pylintrc in this directory.
+# It allows controls that pyproject.toml doesn't support.

--- a/test/commands/test_apio.py
+++ b/test/commands/test_apio.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio" (root) command.
-"""
+"""Test for the "apio" (root) command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_api.py
+++ b/test/commands/test_apio_api.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio api" command
-"""
+"""Test for the "apio api" command."""
 
 import json
 from test.conftest import ApioRunner

--- a/test/commands/test_apio_boards.py
+++ b/test/commands/test_apio_boards.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio boards" command
-"""
+"""Test for the "apio boards" command."""
 
 # 'apio boards' requires the packages examples and therefore it's tests
 # are in test/integration/test_commands.py.

--- a/test/commands/test_apio_build.py
+++ b/test/commands/test_apio_build.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio build" command
-"""
+"""Test for the "apio build" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_build.py
+++ b/test/commands/test_apio_build.py
@@ -6,7 +6,6 @@ from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio
 
 
-# pylint: disable=duplicate-code
 def test_build_without_apio_init(apio_runner: ApioRunner):
     """Tests build with various valid and invalid apio variation, all tests
     are offline and without any apio package installed."""

--- a/test/commands/test_apio_clean.py
+++ b/test/commands/test_apio_clean.py
@@ -19,7 +19,6 @@ def test_clean_without_apio_ini(apio_runner: ApioRunner):
         assert "Error: Missing project file apio.ini" in result.output
 
 
-# pylint: disable=duplicate-code
 def test_clean_with_apio_ini(apio_runner: ApioRunner):
     """Tests the apio clean command with an apio.ini file."""
 

--- a/test/commands/test_apio_clean.py
+++ b/test/commands/test_apio_clean.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio clean" command
-"""
+"""Test for the "apio clean" command."""
 
 from os.path import join
 from pathlib import Path

--- a/test/commands/test_apio_create.py
+++ b/test/commands/test_apio_create.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio create" command
-"""
+"""Test for the "apio create" command."""
 
 from pathlib import Path
 from os.path import isfile, exists

--- a/test/commands/test_apio_create.py
+++ b/test/commands/test_apio_create.py
@@ -10,7 +10,6 @@ from configobj import ConfigObj
 from apio.commands.apio import cli as apio
 
 
-# pylint: disable=duplicate-code
 def _check_ini_file(apio_ini: Path, expected_vars: Dict[str, str]) -> None:
     """Assert that apio.ini contains exactly the given vars."""
     # Read the ini file.

--- a/test/commands/test_apio_drivers.py
+++ b/test/commands/test_apio_drivers.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio drivers" command
-"""
+"""Test for the "apio drivers" command."""
 
 from test.conftest import ApioRunner
 from apio.common.apio_console import cunstyle

--- a/test/commands/test_apio_examples.py
+++ b/test/commands/test_apio_examples.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio examples" command
-"""
+"""Test for the "apio examples" command."""
 
 from test.conftest import ApioRunner
 from apio.common.apio_console import cunstyle

--- a/test/commands/test_apio_format.py
+++ b/test/commands/test_apio_format.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio format" command
-"""
+"""Test for the "apio format" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_fpgas.py
+++ b/test/commands/test_apio_fpgas.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio boards" command
-"""
+"""Test for the "apio boards" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_graph.py
+++ b/test/commands/test_apio_graph.py
@@ -6,7 +6,6 @@ from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio
 
 
-# pylint: disable=duplicate-code
 def test_graph_no_apio_ini(apio_runner: ApioRunner):
     """Test: apio graph with no apio.ini"""
 

--- a/test/commands/test_apio_graph.py
+++ b/test/commands/test_apio_graph.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio graph" command
-"""
+"""Test for the "apio graph" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_info.py
+++ b/test/commands/test_apio_info.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio system" command
-"""
+"""Test for the "apio system" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_lint.py
+++ b/test/commands/test_apio_lint.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio lint" command
-"""
+"""Test for the "apio lint" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_packages.py
+++ b/test/commands/test_apio_packages.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio packages" command
-"""
+"""Test for the "apio packages" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_preferences.py
+++ b/test/commands/test_apio_preferences.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio preferences" command
-"""
+"""Test for the "apio preferences" command."""
 
 import re
 from test.conftest import ApioRunner

--- a/test/commands/test_apio_raw.py
+++ b/test/commands/test_apio_raw.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio raw" command
-"""
+"""Test for the "apio raw" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_report.py
+++ b/test/commands/test_apio_report.py
@@ -6,7 +6,6 @@ from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio
 
 
-# pylint: disable=duplicate-code
 def test_report_no_apio(apio_runner: ApioRunner):
     """Tests the apio report command without an apio.ini file."""
 

--- a/test/commands/test_apio_report.py
+++ b/test/commands/test_apio_report.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio report" command
-"""
+"""Test for the "apio report" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_sim.py
+++ b/test/commands/test_apio_sim.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio sim" command
-"""
+"""Test for the "apio sim" command"""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_test.py
+++ b/test/commands/test_apio_test.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio test" command
-"""
+"""Test for the "apio test" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_apio_upgrade.py
+++ b/test/commands/test_apio_upgrade.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio upgrade" command
-"""
+"""Test for the "apio upgrade" command."""
 
 from test.conftest import ApioRunner
 import pytest

--- a/test/commands/test_apio_upload.py
+++ b/test/commands/test_apio_upload.py
@@ -6,7 +6,6 @@ from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio
 
 
-# pylint: disable=duplicate-code
 def test_upload_without_apio_ini(apio_runner: ApioRunner):
     """Test: apio upload
     when no apio.ini file is given

--- a/test/commands/test_apio_upload.py
+++ b/test/commands/test_apio_upload.py
@@ -1,6 +1,4 @@
-"""
-  Test for the "apio upload" command
-"""
+"""Test for the "apio upload" command."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/commands/test_shortcuts.py
+++ b/test/commands/test_shortcuts.py
@@ -1,6 +1,4 @@
-"""
-  Test command shortcuts.
-"""
+"""Test command shortcuts."""
 
 from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio

--- a/test/common/test_common_utils.py
+++ b/test/common/test_common_utils.py
@@ -1,40 +1,40 @@
 """Test for common_utils.py."""
 
 from pathlib import Path
-from apio.common.common_util import sort_files, file_sort_compare_func
+from apio.common.common_util import sort_files, file_sort_key_func
 
 
 def test_file_sort_compare_func():
     """Test"""
 
-    # -- Use a shortcut for the function name.
-    f = file_sort_compare_func
+    # -- A shortcut to the tested key function.
+    key = file_sort_key_func
 
-    assert f("a", "a") == 0
-    assert f("A", "a") == 0
-    assert f("a", "A") == 0
-    assert f("A", "A") == 0
+    assert key("a") == key("a")
+    assert key("A") == key("a")
+    assert key("a") == key("A")
+    assert key("A") == key("A")
 
-    assert f("a", "b") == -1
-    assert f("A", "b") == -1
-    assert f("a", "B") == -1
-    assert f("A", "B") == -1
+    assert key("a") < key("b")
+    assert key("A") < key("b")
+    assert key("a") < key("B")
+    assert key("A") < key("B")
 
-    assert f("b", "a") == 1
-    assert f("B", "a") == 1
-    assert f("b", "A") == 1
-    assert f("B", "A") == 1
+    assert key("b") > key("a")
+    assert key("B") > key("a")
+    assert key("b") > key("A")
+    assert key("B") > key("A")
 
-    assert f("b", "a/a") == -1
-    assert f("a/a", "b") == 1
+    assert key("b") < key("a/a")
+    assert key("a/a") > key("b")
 
-    assert f("a/a", "a/b") == -1
-    assert f("a/b", "a/ ") == 1
+    assert key("a/a") < key("a/b")
+    assert key("a/b") > key("a/ ")
 
-    assert f(Path("a"), Path("b")) == -1
-    assert f(Path("b"), Path("A")) == 1
-    assert f(Path("a"), Path("a")) == 0
-    assert f(Path("B"), Path("a")) == 1
+    assert key(Path("a")) < key(Path("b"))
+    assert key(Path("b")) > key(Path("A"))
+    assert key(Path("a")) == key(Path("a"))
+    assert key(Path("B")) > key(Path("a"))
 
 
 def test_sort_files():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -86,10 +86,6 @@ class ApioSandbox:
         """Returns the sandbox's apio packages dir."""
         return self.home_dir / "packages"
 
-    # R0913: Too many arguments (7/5) (too-many-arguments)
-    # pylint: disable=R0913
-    # W0622: Redefining built-in 'input' (redefined-builtin)
-    # pylint: disable=W0622
     def invoke_apio_cmd(
         self,
         cli,
@@ -101,6 +97,10 @@ class ApioSandbox:
         **extra,
     ):
         """Invoke an apio command."""
+
+        # pylint: disable=too-many-arguments
+        # W0622: Redefining built-in 'input' (redefined-builtin)
+        # pylint: disable=redefined-builtin
 
         print(f"\nInvoking apio command [{cli.name}], args={args}.")
 

--- a/test/integration/test_commands.py
+++ b/test/integration/test_commands.py
@@ -85,7 +85,6 @@ def test_boards_list_ok(apio_runner: ApioRunner):
         assert "Total of 1 board" not in result.output
 
 
-# pylint: disable=duplicate-code
 def test_utilities(apio_runner: ApioRunner):
     """Tests apio utility commands."""
 
@@ -202,7 +201,6 @@ def test_files_order(apio_runner: ApioRunner):
 
 # Too many statements (60/50) (too-many-statements)
 # pylint: disable=too-many-statements
-# pylint: disable=duplicate-code
 # R0913: Too many arguments (6/5) (too-many-arguments)
 # pylint: disable=too-many-arguments
 def _test_project(

--- a/test/integration/test_commands.py
+++ b/test/integration/test_commands.py
@@ -199,10 +199,6 @@ def test_files_order(apio_runner: ApioRunner):
         assert expected_text in result.output
 
 
-# Too many statements (60/50) (too-many-statements)
-# pylint: disable=too-many-statements
-# R0913: Too many arguments (6/5) (too-many-arguments)
-# pylint: disable=too-many-arguments
 def _test_project(
     apio_runner: ApioRunner,
     *,
@@ -215,6 +211,9 @@ def _test_project(
     """A common project integration test. Invoked per each tested
     architecture.
     """
+
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-statements
 
     # -- If the option 'offline' is passed, the test is skip
     # -- (This test is slow and requires internet connectivity)

--- a/test/integration/test_examples.py
+++ b/test/integration/test_examples.py
@@ -9,7 +9,6 @@ import pytest
 from apio.commands.apio import cli as apio
 
 
-# pylint: disable=duplicate-code
 def test_examples(apio_runner: ApioRunner):
     """Tests the listing and fetching apio examples."""
 

--- a/test/integration/test_packages.py
+++ b/test/integration/test_packages.py
@@ -1,6 +1,4 @@
-"""
-  Test different "apio" commands
-"""
+"""Test different "apio" commands."""
 
 from os import listdir
 from test.conftest import ApioRunner

--- a/test/integration/test_packages.py
+++ b/test/integration/test_packages.py
@@ -8,7 +8,6 @@ import pytest
 from apio.commands.apio import cli as apio
 
 
-# pylint: disable=duplicate-code
 def test_packages(apio_runner: ApioRunner):
     """Tests listing, installation and uninstallation of packages."""
 

--- a/test/managers/test_project.py
+++ b/test/managers/test_project.py
@@ -5,7 +5,6 @@ Tests of project.py
 from test.conftest import ApioRunner
 from apio.apio_context import ApioContext, ApioContextScope
 
-# pylint: disable=fixme
 # TODO: Add more tests.
 
 

--- a/test/managers/test_scons.py
+++ b/test/managers/test_scons.py
@@ -13,7 +13,6 @@ from apio.common.proto.apio_pb2 import (
 from apio.apio_context import ApioContext, ApioContextScope
 from apio.managers.scons import SCons
 
-# pylint: disable=duplicate-code
 
 TEST_APIO_INI_DICT = {
     # -- Required.

--- a/test/managers/test_scons_filters.py
+++ b/test/managers/test_scons_filters.py
@@ -4,7 +4,6 @@ Tests of scons_filters.py
 
 from apio.managers.scons_filter import PnrRangeDetector, PipeId
 
-# pylint: disable=fixme
 # TODO: Add more tests.
 
 

--- a/test/managers/test_system.py
+++ b/test/managers/test_system.py
@@ -6,15 +6,16 @@ from test.conftest import ApioRunner
 from apio.managers.system import System, FtdiDevice
 from apio.apio_context import ApioContext, ApioContextScope
 
-# pylint: disable=fixme
 # TODO: Add more tests.
-
-# pylint: disable=protected-access
-# pylint: disable=use-implicit-booleaness-not-comparison
 
 
 def test_parse_lsftdi_devices(apio_runner: ApioRunner):
     """Test the parsing of the lsftdi command output."""
+
+    # Access to a protected member _parse_lsftdi_devices of a client class
+    # pylint: disable=protected-access
+
+    # pylint: disable=use-implicit-booleaness-not-comparison
 
     with apio_runner.in_sandbox():
 

--- a/test/scons/testing.py
+++ b/test/scons/testing.py
@@ -11,7 +11,6 @@ from google.protobuf import text_format
 from apio.scons.apio_env import ApioEnv
 from apio.common.proto.apio_pb2 import SconsParams, TargetParams
 
-# pylint: disable=duplicate-code
 
 TEST_PARAMS = """
 timestamp: "20123412052"

--- a/test/utils/test_cmd_util.py
+++ b/test/utils/test_cmd_util.py
@@ -11,7 +11,6 @@ from apio.utils.cmd_util import (
     check_at_most_one_param,
 )
 
-# pylint: disable=fixme
 # TODO: Add more tests.
 
 

--- a/test/utils/test_util.py
+++ b/test/utils/test_util.py
@@ -6,7 +6,6 @@ import os
 import pytest
 from apio.utils.util import plurality, list_plurality, is_debug
 
-# pylint: disable=fixme
 # TODO: Add more tests.
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@
 #
 
 # Installing python interpreters
-# Mac:   brew install python@3.10
+# Mac:   brew install python@3.12
 # Win:   ???
 # Linux: ???
 
@@ -39,8 +39,6 @@ isolated_build = True
 # since more compatibility errors happens with the older version.
 envlist = 
     lint
-    py39
-    py310
     py311
     py312
     py313

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ isolated_build = True
 
 # Runs testenv:x for each env x here. Listing in increasing order
 # since more compatibility errors happens with the older version.
-envlist = 
+envlist =
     lint
     py311
     py312
@@ -48,10 +48,10 @@ envlist =
 # Lints the apio code and tests.
 [testenv:lint]
 deps =
-    black==24.8.0
-    flake8==7.1.1
-    pylint==3.3.0
-    pytest==8.3.3
+    black==25.1.0
+    flake8==7.2.0
+    pylint==3.3.7
+    pytest==8.3.5
 
 setenv=
     LINT_ITEMS = \
@@ -65,7 +65,7 @@ setenv=
 # The --prefer-stubs option is for the protocol buffers file, telling lint
 # to use the definitions in the .pyi stubs instead of the cryptic protocol
 # buffers .py files.
-commands = 
+commands =
     black   {env:LINT_ITEMS}  --exclude apio/common/proto
     flake8  {env:LINT_ITEMS}  --exclude apio/common/proto
     pylint  {env:LINT_ITEMS}  --enable=useless-suppression --prefer-stubs True 


### PR DESCRIPTION

1. Removed support for python 3.9, 3.10.  
2. Cleaned up pylint directives (e.g. moved them to function or class scope, to limit their scope).
3. Simplified the files sorting code.
4. Added build and test badges to README.md
5. Updated the python tools pytest, pylint, flake and black to their latest version.

@cavearr, please review and accept.