### PR TITLE
Removed the 'experimental' qualification of System Verilog

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -27,11 +27,12 @@
   * [apio info](#apio-info) - Apio's info and info.
     * [apio info cli](#apio-info-cli) - Command line conventions.
     * [apio info colors](#apio-info-colors) - Colors table.
+    * [apio info files](#apio-info-files) - Apio project files types.
     * [apio info options](#apio-info-options) - Apio.ini options.
     * [apio info platforms](#apio-info-platforms) - Supported platforms.
     * [apio info resources](#apio-info-resources) - Additional resources.
     * [apio info system](#apio-info-system) - Show system information.
-  * [apio lint](#apio-lint) - Lint the verilog code.
+  * [apio lint](#apio-lint) - Lint the source code.
   * [apio packages](#apio-packages) - Manage the apio packages.
     * [apio packages fix](#apio-packages-fix) - Fix broken apio packages.
     * [apio packages install](#apio-packages-install) - Install apio packages.
@@ -87,7 +88,7 @@ Build commands:
   apio clean        Delete the apio generated files.
 
 Verification commands:
-  apio lint         Lint the verilog code.
+  apio lint         Lint the source code.
   apio format       Format verilog source files.
   apio sim          Simulate a testbench with graphic results.
   apio test         Test all or a single verilog testbench module.
@@ -197,21 +198,22 @@ Options:
 ```
 Usage: apio build [OPTIONS]
 
-  The command 'apio build' processes the project’s source files and
-  generates a bitstream file, which can then be uploaded to your FPGA.
-
-  The 'apio build' command compiles all .v files (e.g., my_module.v) in
-  the project directory, except those whose names end with '_tb' (e.g.,
-  my_module_tb.v) which are assumed to be testbenches.
-
-  [NOTE] The files are compiled in the order they are found in the sub
-  directories of the source tree. This provides a simple way to control
-  the compilation order by naming subdirectories for the desired build
-  order.
+  The command 'apio build' processes the project’s synthesis source
+  files and generates a bitstream file, which can then be uploaded to
+  your FPGA.
 
   Examples:
-    apio build       # Build
-    apio build -v    # Build with verbose info
+    apio build                   # Typical usage
+    apio build -v                # Verbose info (all)
+    apio build --verbose-synth   # Verbose synthesis info
+    apio build --verbose-pnr     # Verbose place and route info
+
+  NOTES:
+  * The files are sorted in a deterministic lexicographic order.
+  * You can specify the name of the top module in apio.ini.
+  * The build command ignores testbench files (*_tb.v, and *_tb.sv).
+  * It is unnecessary to run 'apio build' before 'apio upload'.
+  * To force a rebuild from scratch use the command 'apio clean' first.
 
 Options:
   -p, --project-dir path  Set the root directory for the project.
@@ -582,7 +584,7 @@ Options:
 ```
 Usage: apio format [OPTIONS] [FILES]...
 
-  The command 'apio format' formats Verilog source files to ensure
+  The command 'apio format' formats the project's source files to ensure
   consistency and style without altering their semantics. The command
   accepts the names of specific source files to format or formats all
   project source files by default.
@@ -654,7 +656,7 @@ Options:
 Usage: apio graph [OPTIONS]
 
   The command 'apio graph' generates a graphical representation of the
-  Verilog code in the project.
+  design.
 
   Examples:
     apio graph               # Generate a svg file.
@@ -695,6 +697,7 @@ Options:
 Documentation:
   apio info options    Apio.ini options.
   apio info cli        Command line conventions.
+  apio info files      Apio project files types.
   apio info resources  Additional resources.
 
 Information:
@@ -747,6 +750,24 @@ Options:
   -c, --click  Output using the click lib.
   -p, --print  Output using python's print().
   -h, --help   Show this message and exit.
+
+```
+
+<br>
+
+### apio info files
+
+```
+Usage: apio info files [OPTIONS]
+
+  The command 'apio info options' provides information about the various
+  files types used in an Apio project.
+
+  Examples:
+    apio info files
+
+Options:
+  -h, --help  Show this message and exit.
 
 ```
 
@@ -840,7 +861,7 @@ Options:
 ```
 Usage: apio lint [OPTIONS]
 
-  The command 'apio lint' scans the project's Verilog code and reports
+  The command 'apio lint' scans the project's source files and reports
   errors, inconsistencies, and style violations. The command uses the
   Verilator tool, which is included in the standard Apio installation.
 
@@ -1069,16 +1090,21 @@ Usage: apio sim [OPTIONS] [TESTBENCH]
   The command 'apio sim' simulates the default or the specified
   testbench file and displays its simulation results in a graphical
   GTKWave window. The testbench is expected to have a name ending with
-  _tb, such as main_tb.v or main_tb.sv. The default testbench file can
-  be specified using the apio.ini option 'default-testbench'. If
+  _tb, such as 'main_tb.v' or 'main_tb.sv'. The default testbench file
+  can be specified using the apio.ini option 'default-testbench'. If
   'default-testbench' is not specified and the project has exactly one
   testbench file, that file will be used as the default testbench.
 
   Example:
     apio sim                   # Simulate the default testbench.
     apio sim my_module_tb.v    # Simulate the specified testbench.
+    apio sim my_module_tb.sv   # Simulate the specified testbench.
 
-  [Important] Avoid using the Verilog '$dumpfile()' function in your
+  [NOTE] Testbench specification is always the testbench file path
+  relative to the project directory, even if using the '--project-dir'
+  option.
+
+  [IMPORTANT] Avoid using the Verilog '$dumpfile()' function in your
   testbenches, as this may override the default name and location Apio
   sets for the generated .vcd file.
 
@@ -1118,7 +1144,11 @@ Usage: apio test [OPTIONS] [TESTBENCH_FILE]
     apio test                 # Run all *_tb.v testbenches.
     apio test my_module_tb.v  # Run a single testbench.
 
-  [Important] Avoid using the Verilog '$dumpfile()' function in your
+  [NOTE] Testbench specification is always the testbench file path
+  relative to the project directory, even if using the '--project-dir'
+  option.
+
+  [IMPORTANT] Avoid using the Verilog '$dumpfile()' function in your
   testbenches, as this may override the default name and location Apio
   sets for the generated .vcd file.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## What is Apio?
 
-* Apio is an **extremely easy to use** toolbox for FPGA programming.
+* Apio is an **extremely easy to use** toolbox for programming FPGAs in **Verilog** and **System Verilog**.
 * Apio is **easy to install**, no more dealing with 'toolcahins', licenses, scripts, and makefiles.
 * Apio runs on a wide range of platforms, **Linux, Windows, Mac, and more**.
 * Apio is **open source and free to use**.
@@ -23,7 +23,7 @@
 * Apio can be used with **any text editor** and also **plays well with Visual Studio Code and github**.
 * Apio supports out of the **more than 80 boards** and **custom boards can be easily added**.
 * Apio provides out of the box tens of simple **project examples ready to build and upload**.
-* Apio currently supports the ``ICE40`` and ``ECP5`` FPGA architecture with ``GOWIN`` architecture in the works.
+* Apio currently supports the **ICE40** and **ECP5** FPGA architecture with **GOWIN** architecture in the works.
 
 ## The Apio philosophy
 

--- a/apio/commands/apio_build.py
+++ b/apio/commands/apio_build.py
@@ -20,20 +20,21 @@ from apio.common.proto.apio_pb2 import Verbosity
 
 # -- Text in the rich-text format of the python rich library.
 APIO_BUILD_HELP = """
-The command 'apio build' processes the project’s source files and generates \
-a bitstream file, which can then be uploaded to your FPGA.
-
-The 'apio build' command compiles all .v files (e.g., my_module.v) in the \
-project directory, except those whose names end with '_tb' \
-(e.g., my_module_tb.v) which are assumed to be testbenches.
-
-[NOTE] The files are compiled in the order they are found in the sub \
-directories of the source tree. This provides a simple way to control the \
-compilation order by naming subdirectories for the desired build order.
+The command 'apio build' processes the project’s synthesis source files and \
+generates a bitstream file, which can then be uploaded to your FPGA.
 
 Examples:[code]
-  apio build       # Build
-  apio build -v    # Build with verbose info[/code]
+  apio build                   # Typical usage
+  apio build -v                # Verbose info (all)
+  apio build --verbose-synth   # Verbose synthesis info
+  apio build --verbose-pnr     # Verbose place and route info[/code]
+
+NOTES:
+* The files are sorted in a deterministic lexicographic order.
+* You can specify the name of the top module in apio.ini.
+* The build command ignores testbench files (*_tb.v, and *_tb.sv).
+* It is unnecessary to run 'apio build' before 'apio upload'.
+* To force a rebuild from scratch use the command 'apio clean' first.
 """
 
 
@@ -59,10 +60,6 @@ def cli(
     """Implements the apio build command. It invokes the toolchain
     to synthesize the source files into a bitstream file.
     """
-
-    # The bitstream is generated from the source files (verilog)
-    # by means of the scons tool
-    # https://www.scons.org/documentation.html
 
     # -- Create the apio context.
     apio_ctx = ApioContext(

--- a/apio/commands/apio_format.py
+++ b/apio/commands/apio_format.py
@@ -27,9 +27,10 @@ from apio.utils import util, pkg_util, cmd_util
 
 # -- Text in the rich-text format of the python rich library.
 APIO_FORMAT_HELP = """
-The command 'apio format' formats Verilog source files to ensure consistency \
-and style without altering their semantics. The command accepts the names of \
-specific source files to format or formats all project source files by default.
+The command 'apio format' formats the project's source files to ensure \
+consistency and style without altering their semantics. The command accepts \
+the names of specific source files to format or formats all project source \
+files by default.
 
 Examples:[code]
   apio format                    # Format all source files.

--- a/apio/commands/apio_graph.py
+++ b/apio/commands/apio_graph.py
@@ -45,8 +45,7 @@ pdf_option = click.option(
 
 # -- Text in the rich-text format of the python rich library.
 APIO_GRAPH_HELP = """
-The command 'apio graph' generates a graphical representation of the Verilog \
-code in the project.
+The command 'apio graph' generates a graphical representation of the design.
 
 Examples:[code]
   apio graph               # Generate a svg file.

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -157,10 +157,6 @@ def _options_cli(
 ):
     """Implements the 'apio info options' command."""
 
-    # -- Create the apio context. We don't really need it here but it also
-    # -- reads the user preferences and configure the console's colors.
-    ApioContext(scope=ApioContextScope.NO_PROJECT)
-
     # -- If option was specified, validate it.
     if option:
         if option not in project.OPTIONS:
@@ -195,6 +191,60 @@ def _options_cli(
         docs_rule()
 
 
+# -- apio info files
+
+# -- Text in the rich-text format of the python rich library.
+APIO_INFO_FILES_HELP = """
+The command 'apio info options' provides information about the various \
+files types used in an Apio project.
+
+Examples:[code]
+  apio info files
+"""
+
+# -- Text in the rich-text format of the python rich library.
+APIO_INFO_FILES_DOC = """
+Following are apio conventions for project file names. The list does not \
+include files that are specific to a particular architecture or toolchain.
+
+[b]apio.ini[/] - This is a required project configuration configuration. \
+Run 'apio info options' for the list of supported options.
+
+[b]*.v, *.sv[/] - Verilog and System Verilog synthesis sources files \
+(unless they match the testbench patterns below).
+
+[b]*_tb.v, *_tb.sv[/] - Verilog and System Verilog testbench files.
+
+[b]*.vh, *.svh[/] - Verilog and System Verilog include files.
+
+[b]_build[/] - This is an auto created directory that contains the generated \
+files. The directory '_build' is removed when the command 'apio clean' is run.
+
+[b].sconsign.dblite[/] - This is a cache info file that is created by the \
+Apio in the project directory and can be ignored and removed. The file \
+`.sconsign.dblite` is removed when the command 'apio clean' is run.
+
+[NOTE] If using git for your project, it is recommended to have the following \
+entires in your '.gitignore' file:
+[code]
+  _build
+  .sconsign.dblite[/code]
+"""
+
+
+@click.command(
+    name="files",
+    cls=cmd_util.ApioCommand,
+    short_help="Apio project files types.",
+    help=APIO_INFO_FILES_HELP,
+)
+def _files_cli():
+    """Implements the 'apio info files' command."""
+
+    # -- Print the text.
+    docs_text(APIO_INFO_FILES_DOC)
+
+
 # -- apio info resources
 
 # -- Text in the rich-text format of the python rich library.
@@ -227,10 +277,6 @@ same functionality.
 )
 def _resources_cli():
     """Implements the 'apio info resources' command."""
-
-    # -- Create the apio context. We don't really need it here but it also
-    # -- reads the user preferences and configure the console's colors.
-    ApioContext(scope=ApioContextScope.NO_PROJECT)
 
     docs_text(APIO_INFO_RESOURCES_SUMMARY, width=73)
 
@@ -533,6 +579,7 @@ SUBGROUPS = [
         [
             _options_cli,
             _cli_cli,
+            _files_cli,
             _resources_cli,
         ],
     ),

--- a/apio/commands/apio_lint.py
+++ b/apio/commands/apio_lint.py
@@ -58,7 +58,7 @@ warn_option = click.option(
 
 # -- Text in the rich-text format of the python rich library.
 APIO_LINT_HELP = """
-The command 'apio lint' scans the project's Verilog code and reports errors, \
+The command 'apio lint' scans the project's source files and reports errors, \
 inconsistencies, and style violations. The command uses the Verilator tool, \
 which is included in the standard Apio installation.
 
@@ -72,7 +72,7 @@ Examples:[code]
 @click.command(
     name="lint",
     cls=cmd_util.ApioCommand,
-    short_help="Lint the verilog code.",
+    short_help="Lint the source code.",
     help=APIO_LINT_HELP,
 )
 @click.pass_context
@@ -94,7 +94,7 @@ def cli(
     top_module: str,
     project_dir: Path,
 ):
-    """Lint the verilog code."""
+    """Lint the source code."""
 
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-positional-arguments

--- a/apio/commands/apio_sim.py
+++ b/apio/commands/apio_sim.py
@@ -27,14 +27,15 @@ APIO_SIM_HELP = """
 The command 'apio sim' simulates the default or the specified testbench file \
 and displays its simulation results in a graphical GTKWave window. \
 The testbench is expected to have a name ending with _tb, such as \
-main_tb.v or main_tb.sv. The default testbench file can be specified using \
-the apio.ini option 'default-testbench'. If 'default-testbench' is not \
+'main_tb.v' or 'main_tb.sv'. The default testbench file can be specified \
+using the apio.ini option 'default-testbench'. If 'default-testbench' is not \
 specified and the project has exactly one testbench file, that file will be \
 used as the default testbench.
 
 Example:[code]
   apio sim                   # Simulate the default testbench.
-  apio sim my_module_tb.v    # Simulate the specified testbench.[/code]
+  apio sim my_module_tb.v    # Simulate the specified testbench.
+  apio sim my_module_tb.sv   # Simulate the specified testbench.[/code]
 
 [NOTE] Testbench specification is always the testbench file path relative to \
 the project directory, even if using the '--project-dir' option.

--- a/apio/common/proto/apio.proto
+++ b/apio/common/proto/apio.proto
@@ -81,7 +81,7 @@ message Environment {
 
   // The terminal mode to apply to apio_console.
   required TerminalMode terminal_mode = 3;
-  
+
   // The apio_console theme name.
   required string theme_name = 4;
 
@@ -93,8 +93,8 @@ message Environment {
   required string trellis_path = 7;
 }
 
-// Information about the project.
-message Project {
+// Information about the resolved active env from apio.ini.
+message ApioEnvParams {
   required string board_id = 1;
   required string top_module = 2;
   // The value of 'yosys-synth-extra-options' from apio.ini.
@@ -190,7 +190,7 @@ message SconsParams {
   required Environment environment = 5;
 
   // General information about the project
-  required Project project = 6;
+  required ApioEnvParams apio_env_params = 6;
 
   // Additional params for for scons targets that need it..
   optional TargetParams target = 7;

--- a/apio/common/proto/apio_pb2.py
+++ b/apio/common/proto/apio_pb2.py
@@ -30,19 +30,19 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\napio.proto\x12\x11\x61pio.common.proto\"+\n\rIce40FpgaInfo\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0c\n\x04pack\x18\x02 \x02(\t\"9\n\x0c\x45\x63p5FpgaInfo\x12\x0c\n\x04type\x18\x04 \x02(\t\x12\x0c\n\x04pack\x18\x05 \x02(\t\x12\r\n\x05speed\x18\x06 \x02(\t\"\x1f\n\rGowinFpgaInfo\x12\x0e\n\x06\x66\x61mily\x18\x04 \x02(\t\"\xda\x01\n\x08\x46pgaInfo\x12\x0f\n\x07\x66pga_id\x18\x01 \x02(\t\x12\x10\n\x08part_num\x18\x02 \x02(\t\x12\x0c\n\x04size\x18\x03 \x02(\t\x12\x31\n\x05ice40\x18\n \x01(\x0b\x32 .apio.common.proto.Ice40FpgaInfoH\x00\x12/\n\x04\x65\x63p5\x18\x0b \x01(\x0b\x32\x1f.apio.common.proto.Ecp5FpgaInfoH\x00\x12\x31\n\x05gowin\x18\x0c \x01(\x0b\x32 .apio.common.proto.GowinFpgaInfoH\x00\x42\x06\n\x04\x61rch\"I\n\tVerbosity\x12\x12\n\x03\x61ll\x18\x01 \x01(\x08:\x05\x66\x61lse\x12\x14\n\x05synth\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x12\n\x03pnr\x18\x03 \x01(\x08:\x05\x66\x61lse\"\xc5\x01\n\x0b\x45nvironment\x12\x13\n\x0bplatform_id\x18\x01 \x02(\t\x12\x12\n\nis_windows\x18\x02 \x02(\x08\x12\x36\n\rterminal_mode\x18\x03 \x02(\x0e\x32\x1f.apio.common.proto.TerminalMode\x12\x12\n\ntheme_name\x18\x04 \x02(\t\x12\x17\n\x08is_debug\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x12\n\nyosys_path\x18\x06 \x02(\t\x12\x14\n\x0ctrellis_path\x18\x07 \x02(\t\"T\n\x07Project\x12\x10\n\x08\x62oard_id\x18\x01 \x02(\t\x12\x12\n\ntop_module\x18\x02 \x02(\t\x12#\n\x19yosys_synth_extra_options\x18\x03 \x01(\t:\x00\"\x98\x01\n\nLintParams\x12\x14\n\ntop_module\x18\x01 \x01(\t:\x00\x12\x1c\n\rverilator_all\x18\x02 \x01(\x08:\x05\x66\x61lse\x12!\n\x12verilator_no_style\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x1a\n\x12verilator_no_warns\x18\x04 \x03(\t\x12\x17\n\x0fverilator_warns\x18\x05 \x03(\t\"Z\n\x0bGraphParams\x12\x37\n\x0boutput_type\x18\x01 \x02(\x0e\x32\".apio.common.proto.GraphOutputType\x12\x12\n\ntop_module\x18\x02 \x01(\t\"3\n\tSimParams\x12\x13\n\ttestbench\x18\x01 \x01(\t:\x00\x12\x11\n\tforce_sim\x18\x02 \x02(\x08\"%\n\x0e\x41pioTestParams\x12\x13\n\ttestbench\x18\x01 \x01(\t:\x00\"&\n\x0cUploadParams\x12\x16\n\x0eprogrammer_cmd\x18\x01 \x01(\t\"\x8b\x02\n\x0cTargetParams\x12-\n\x04lint\x18\n \x01(\x0b\x32\x1d.apio.common.proto.LintParamsH\x00\x12/\n\x05graph\x18\x0b \x01(\x0b\x32\x1e.apio.common.proto.GraphParamsH\x00\x12+\n\x03sim\x18\x0c \x01(\x0b\x32\x1c.apio.common.proto.SimParamsH\x00\x12\x31\n\x04test\x18\r \x01(\x0b\x32!.apio.common.proto.ApioTestParamsH\x00\x12\x31\n\x06upload\x18\x0e \x01(\x0b\x32\x1f.apio.common.proto.UploadParamsH\x00\x42\x08\n\x06target\"5\n\x14RichLibWindowsParams\x12\n\n\x02vt\x18\x01 \x02(\x08\x12\x11\n\ttruecolor\x18\x02 \x02(\x08\"\x89\x03\n\x0bSconsParams\x12\x11\n\ttimestamp\x18\x01 \x02(\t\x12)\n\x04\x61rch\x18\x02 \x02(\x0e\x32\x1b.apio.common.proto.ApioArch\x12.\n\tfpga_info\x18\x03 \x02(\x0b\x32\x1b.apio.common.proto.FpgaInfo\x12/\n\tverbosity\x18\x04 \x01(\x0b\x32\x1c.apio.common.proto.Verbosity\x12\x33\n\x0b\x65nvironment\x18\x05 \x02(\x0b\x32\x1e.apio.common.proto.Environment\x12+\n\x07project\x18\x06 \x02(\x0b\x32\x1a.apio.common.proto.Project\x12/\n\x06target\x18\x07 \x01(\x0b\x32\x1f.apio.common.proto.TargetParams\x12H\n\x17rich_lib_windows_params\x18\x08 \x01(\x0b\x32\'.apio.common.proto.RichLibWindowsParams*@\n\x08\x41pioArch\x12\x14\n\x10\x41RCH_UNSPECIFIED\x10\x00\x12\t\n\x05ICE40\x10\x01\x12\x08\n\x04\x45\x43P5\x10\x02\x12\t\n\x05GOWIN\x10\x03*_\n\x0cTerminalMode\x12\x18\n\x14TERMINAL_UNSPECIFIED\x10\x00\x12\x11\n\rAUTO_TERMINAL\x10\x01\x12\x12\n\x0e\x46ORCE_TERMINAL\x10\x02\x12\x0e\n\nFORCE_PIPE\x10\x03*B\n\x0fGraphOutputType\x12\x14\n\x10TYPE_UNSPECIFIED\x10\x00\x12\x07\n\x03SVG\x10\x01\x12\x07\n\x03PNG\x10\x02\x12\x07\n\x03PDF\x10\x03')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\napio.proto\x12\x11\x61pio.common.proto\"+\n\rIce40FpgaInfo\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0c\n\x04pack\x18\x02 \x02(\t\"9\n\x0c\x45\x63p5FpgaInfo\x12\x0c\n\x04type\x18\x04 \x02(\t\x12\x0c\n\x04pack\x18\x05 \x02(\t\x12\r\n\x05speed\x18\x06 \x02(\t\"\x1f\n\rGowinFpgaInfo\x12\x0e\n\x06\x66\x61mily\x18\x04 \x02(\t\"\xda\x01\n\x08\x46pgaInfo\x12\x0f\n\x07\x66pga_id\x18\x01 \x02(\t\x12\x10\n\x08part_num\x18\x02 \x02(\t\x12\x0c\n\x04size\x18\x03 \x02(\t\x12\x31\n\x05ice40\x18\n \x01(\x0b\x32 .apio.common.proto.Ice40FpgaInfoH\x00\x12/\n\x04\x65\x63p5\x18\x0b \x01(\x0b\x32\x1f.apio.common.proto.Ecp5FpgaInfoH\x00\x12\x31\n\x05gowin\x18\x0c \x01(\x0b\x32 .apio.common.proto.GowinFpgaInfoH\x00\x42\x06\n\x04\x61rch\"I\n\tVerbosity\x12\x12\n\x03\x61ll\x18\x01 \x01(\x08:\x05\x66\x61lse\x12\x14\n\x05synth\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x12\n\x03pnr\x18\x03 \x01(\x08:\x05\x66\x61lse\"\xc5\x01\n\x0b\x45nvironment\x12\x13\n\x0bplatform_id\x18\x01 \x02(\t\x12\x12\n\nis_windows\x18\x02 \x02(\x08\x12\x36\n\rterminal_mode\x18\x03 \x02(\x0e\x32\x1f.apio.common.proto.TerminalMode\x12\x12\n\ntheme_name\x18\x04 \x02(\t\x12\x17\n\x08is_debug\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x12\n\nyosys_path\x18\x06 \x02(\t\x12\x14\n\x0ctrellis_path\x18\x07 \x02(\t\"Z\n\rApioEnvParams\x12\x10\n\x08\x62oard_id\x18\x01 \x02(\t\x12\x12\n\ntop_module\x18\x02 \x02(\t\x12#\n\x19yosys_synth_extra_options\x18\x03 \x01(\t:\x00\"\x98\x01\n\nLintParams\x12\x14\n\ntop_module\x18\x01 \x01(\t:\x00\x12\x1c\n\rverilator_all\x18\x02 \x01(\x08:\x05\x66\x61lse\x12!\n\x12verilator_no_style\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x1a\n\x12verilator_no_warns\x18\x04 \x03(\t\x12\x17\n\x0fverilator_warns\x18\x05 \x03(\t\"Z\n\x0bGraphParams\x12\x37\n\x0boutput_type\x18\x01 \x02(\x0e\x32\".apio.common.proto.GraphOutputType\x12\x12\n\ntop_module\x18\x02 \x01(\t\"3\n\tSimParams\x12\x13\n\ttestbench\x18\x01 \x01(\t:\x00\x12\x11\n\tforce_sim\x18\x02 \x02(\x08\"%\n\x0e\x41pioTestParams\x12\x13\n\ttestbench\x18\x01 \x01(\t:\x00\"&\n\x0cUploadParams\x12\x16\n\x0eprogrammer_cmd\x18\x01 \x01(\t\"\x8b\x02\n\x0cTargetParams\x12-\n\x04lint\x18\n \x01(\x0b\x32\x1d.apio.common.proto.LintParamsH\x00\x12/\n\x05graph\x18\x0b \x01(\x0b\x32\x1e.apio.common.proto.GraphParamsH\x00\x12+\n\x03sim\x18\x0c \x01(\x0b\x32\x1c.apio.common.proto.SimParamsH\x00\x12\x31\n\x04test\x18\r \x01(\x0b\x32!.apio.common.proto.ApioTestParamsH\x00\x12\x31\n\x06upload\x18\x0e \x01(\x0b\x32\x1f.apio.common.proto.UploadParamsH\x00\x42\x08\n\x06target\"5\n\x14RichLibWindowsParams\x12\n\n\x02vt\x18\x01 \x02(\x08\x12\x11\n\ttruecolor\x18\x02 \x02(\x08\"\x97\x03\n\x0bSconsParams\x12\x11\n\ttimestamp\x18\x01 \x02(\t\x12)\n\x04\x61rch\x18\x02 \x02(\x0e\x32\x1b.apio.common.proto.ApioArch\x12.\n\tfpga_info\x18\x03 \x02(\x0b\x32\x1b.apio.common.proto.FpgaInfo\x12/\n\tverbosity\x18\x04 \x01(\x0b\x32\x1c.apio.common.proto.Verbosity\x12\x33\n\x0b\x65nvironment\x18\x05 \x02(\x0b\x32\x1e.apio.common.proto.Environment\x12\x39\n\x0f\x61pio_env_params\x18\x06 \x02(\x0b\x32 .apio.common.proto.ApioEnvParams\x12/\n\x06target\x18\x07 \x01(\x0b\x32\x1f.apio.common.proto.TargetParams\x12H\n\x17rich_lib_windows_params\x18\x08 \x01(\x0b\x32\'.apio.common.proto.RichLibWindowsParams*@\n\x08\x41pioArch\x12\x14\n\x10\x41RCH_UNSPECIFIED\x10\x00\x12\t\n\x05ICE40\x10\x01\x12\x08\n\x04\x45\x43P5\x10\x02\x12\t\n\x05GOWIN\x10\x03*_\n\x0cTerminalMode\x12\x18\n\x14TERMINAL_UNSPECIFIED\x10\x00\x12\x11\n\rAUTO_TERMINAL\x10\x01\x12\x12\n\x0e\x46ORCE_TERMINAL\x10\x02\x12\x0e\n\nFORCE_PIPE\x10\x03*B\n\x0fGraphOutputType\x12\x14\n\x10TYPE_UNSPECIFIED\x10\x00\x12\x07\n\x03SVG\x10\x01\x12\x07\n\x03PNG\x10\x02\x12\x07\n\x03PDF\x10\x03')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'apio_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_APIOARCH']._serialized_start=1852
-  _globals['_APIOARCH']._serialized_end=1916
-  _globals['_TERMINALMODE']._serialized_start=1918
-  _globals['_TERMINALMODE']._serialized_end=2013
-  _globals['_GRAPHOUTPUTTYPE']._serialized_start=2015
-  _globals['_GRAPHOUTPUTTYPE']._serialized_end=2081
+  _globals['_APIOARCH']._serialized_start=1872
+  _globals['_APIOARCH']._serialized_end=1936
+  _globals['_TERMINALMODE']._serialized_start=1938
+  _globals['_TERMINALMODE']._serialized_end=2033
+  _globals['_GRAPHOUTPUTTYPE']._serialized_start=2035
+  _globals['_GRAPHOUTPUTTYPE']._serialized_end=2101
   _globals['_ICE40FPGAINFO']._serialized_start=33
   _globals['_ICE40FPGAINFO']._serialized_end=76
   _globals['_ECP5FPGAINFO']._serialized_start=78
@@ -55,22 +55,22 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_VERBOSITY']._serialized_end=464
   _globals['_ENVIRONMENT']._serialized_start=467
   _globals['_ENVIRONMENT']._serialized_end=664
-  _globals['_PROJECT']._serialized_start=666
-  _globals['_PROJECT']._serialized_end=750
-  _globals['_LINTPARAMS']._serialized_start=753
-  _globals['_LINTPARAMS']._serialized_end=905
-  _globals['_GRAPHPARAMS']._serialized_start=907
-  _globals['_GRAPHPARAMS']._serialized_end=997
-  _globals['_SIMPARAMS']._serialized_start=999
-  _globals['_SIMPARAMS']._serialized_end=1050
-  _globals['_APIOTESTPARAMS']._serialized_start=1052
-  _globals['_APIOTESTPARAMS']._serialized_end=1089
-  _globals['_UPLOADPARAMS']._serialized_start=1091
-  _globals['_UPLOADPARAMS']._serialized_end=1129
-  _globals['_TARGETPARAMS']._serialized_start=1132
-  _globals['_TARGETPARAMS']._serialized_end=1399
-  _globals['_RICHLIBWINDOWSPARAMS']._serialized_start=1401
-  _globals['_RICHLIBWINDOWSPARAMS']._serialized_end=1454
-  _globals['_SCONSPARAMS']._serialized_start=1457
-  _globals['_SCONSPARAMS']._serialized_end=1850
+  _globals['_APIOENVPARAMS']._serialized_start=666
+  _globals['_APIOENVPARAMS']._serialized_end=756
+  _globals['_LINTPARAMS']._serialized_start=759
+  _globals['_LINTPARAMS']._serialized_end=911
+  _globals['_GRAPHPARAMS']._serialized_start=913
+  _globals['_GRAPHPARAMS']._serialized_end=1003
+  _globals['_SIMPARAMS']._serialized_start=1005
+  _globals['_SIMPARAMS']._serialized_end=1056
+  _globals['_APIOTESTPARAMS']._serialized_start=1058
+  _globals['_APIOTESTPARAMS']._serialized_end=1095
+  _globals['_UPLOADPARAMS']._serialized_start=1097
+  _globals['_UPLOADPARAMS']._serialized_end=1135
+  _globals['_TARGETPARAMS']._serialized_start=1138
+  _globals['_TARGETPARAMS']._serialized_end=1405
+  _globals['_RICHLIBWINDOWSPARAMS']._serialized_start=1407
+  _globals['_RICHLIBWINDOWSPARAMS']._serialized_end=1460
+  _globals['_SCONSPARAMS']._serialized_start=1463
+  _globals['_SCONSPARAMS']._serialized_end=1870
 # @@protoc_insertion_point(module_scope)

--- a/apio/common/proto/apio_pb2.pyi
+++ b/apio/common/proto/apio_pb2.pyi
@@ -113,7 +113,7 @@ class Environment(_message.Message):
     trellis_path: str
     def __init__(self, platform_id: _Optional[str] = ..., is_windows: bool = ..., terminal_mode: _Optional[_Union[TerminalMode, str]] = ..., theme_name: _Optional[str] = ..., is_debug: bool = ..., yosys_path: _Optional[str] = ..., trellis_path: _Optional[str] = ...) -> None: ...
 
-class Project(_message.Message):
+class ApioEnvParams(_message.Message):
     __slots__ = ("board_id", "top_module", "yosys_synth_extra_options")
     BOARD_ID_FIELD_NUMBER: _ClassVar[int]
     TOP_MODULE_FIELD_NUMBER: _ClassVar[int]
@@ -188,13 +188,13 @@ class RichLibWindowsParams(_message.Message):
     def __init__(self, vt: bool = ..., truecolor: bool = ...) -> None: ...
 
 class SconsParams(_message.Message):
-    __slots__ = ("timestamp", "arch", "fpga_info", "verbosity", "environment", "project", "target", "rich_lib_windows_params")
+    __slots__ = ("timestamp", "arch", "fpga_info", "verbosity", "environment", "apio_env_params", "target", "rich_lib_windows_params")
     TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
     ARCH_FIELD_NUMBER: _ClassVar[int]
     FPGA_INFO_FIELD_NUMBER: _ClassVar[int]
     VERBOSITY_FIELD_NUMBER: _ClassVar[int]
     ENVIRONMENT_FIELD_NUMBER: _ClassVar[int]
-    PROJECT_FIELD_NUMBER: _ClassVar[int]
+    APIO_ENV_PARAMS_FIELD_NUMBER: _ClassVar[int]
     TARGET_FIELD_NUMBER: _ClassVar[int]
     RICH_LIB_WINDOWS_PARAMS_FIELD_NUMBER: _ClassVar[int]
     timestamp: str
@@ -202,7 +202,7 @@ class SconsParams(_message.Message):
     fpga_info: FpgaInfo
     verbosity: Verbosity
     environment: Environment
-    project: Project
+    apio_env_params: ApioEnvParams
     target: TargetParams
     rich_lib_windows_params: RichLibWindowsParams
-    def __init__(self, timestamp: _Optional[str] = ..., arch: _Optional[_Union[ApioArch, str]] = ..., fpga_info: _Optional[_Union[FpgaInfo, _Mapping]] = ..., verbosity: _Optional[_Union[Verbosity, _Mapping]] = ..., environment: _Optional[_Union[Environment, _Mapping]] = ..., project: _Optional[_Union[Project, _Mapping]] = ..., target: _Optional[_Union[TargetParams, _Mapping]] = ..., rich_lib_windows_params: _Optional[_Union[RichLibWindowsParams, _Mapping]] = ...) -> None: ...
+    def __init__(self, timestamp: _Optional[str] = ..., arch: _Optional[_Union[ApioArch, str]] = ..., fpga_info: _Optional[_Union[FpgaInfo, _Mapping]] = ..., verbosity: _Optional[_Union[Verbosity, _Mapping]] = ..., environment: _Optional[_Union[Environment, _Mapping]] = ..., apio_env_params: _Optional[_Union[ApioEnvParams, _Mapping]] = ..., target: _Optional[_Union[TargetParams, _Mapping]] = ..., rich_lib_windows_params: _Optional[_Union[RichLibWindowsParams, _Mapping]] = ...) -> None: ...

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -67,7 +67,8 @@ contains more than one testbench file and a testbench was not specified in \
 the 'apio sim' command.
 
 Example:[code]
-  default-testbench = my_module_tb.v[/code]
+  default-testbench = my_module_tb.v
+  default-testbench = my_module_tb.sv[/code]
 """
 
 FORMAT_VERIBLE_OPTIONS_DOC = """

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -31,7 +31,7 @@ from apio.common.proto.apio_pb2 import (
     SconsParams,
     TargetParams,
     FpgaInfo,
-    Project,
+    ApioEnvParams,
     Ice40FpgaInfo,
     Ecp5FpgaInfo,
     GowinFpgaInfo,
@@ -313,8 +313,8 @@ class SCons:
         assert result.environment.IsInitialized(), result
 
         # -- Populate the Project params.
-        result.project.MergeFrom(
-            Project(
+        result.apio_env_params.MergeFrom(
+            ApioEnvParams(
                 board_id=project["board"],
                 top_module=project["top-module"],
                 yosys_synth_extra_options=apio_ctx.project.get(
@@ -322,7 +322,7 @@ class SCons:
                 ),
             )
         )
-        assert result.project.IsInitialized(), result
+        assert result.apio_env_params.IsInitialized(), result
 
         # -- Populate the optional command specific params.
         if target_params:
@@ -386,7 +386,9 @@ class SCons:
         start_time = time.time()
 
         # -- Board name string in color
-        styled_board_id = cstyle(scons_params.project.board_id, style=EMPH1)
+        styled_board_id = cstyle(
+            scons_params.apio_env_params.board_id, style=EMPH1
+        )
 
         # -- Print information on the console
         cout(f"Processing board {styled_board_id}")

--- a/apio/scons/apio_env.py
+++ b/apio/scons/apio_env.py
@@ -36,7 +36,7 @@ class ApioEnv:
         self.scons_env = SConsEnvironment(ENV=os.environ, tools=[])
 
         # -- Since we ae not using the default environment, make sure it was
-        # -- not used unintentionally, e.v. in tests that run create multiple
+        # -- not used unintentionally, e.g. in tests that run create multiple
         # -- scons env in the same session.
         # --
         assert (

--- a/apio/scons/plugin_base.py
+++ b/apio/scons/plugin_base.py
@@ -66,7 +66,7 @@ class PluginBase:
             self._constrain_file = get_constraint_file(
                 apio_env,
                 self.plugin_info().constrains_file_ext,
-                params.project.top_module,
+                params.apio_env_params.top_module,
             )
         return self._constrain_file
 
@@ -121,7 +121,7 @@ class PluginBase:
         top_module = (
             graph_params.top_module
             if graph_params.top_module
-            else params.project.top_module
+            else params.apio_env_params.top_module
         )
 
         return Builder(

--- a/apio/scons/plugin_ecp5.py
+++ b/apio/scons/plugin_ecp5.py
@@ -68,8 +68,8 @@ class PluginEcp5(PluginBase):
                 'yosys -p "synth_ecp5 -top {0} {1} -json $TARGET" {2} '
                 "$SOURCES"
             ).format(
-                params.project.top_module,
-                params.project.yosys_synth_extra_options,
+                params.apio_env_params.top_module,
+                params.apio_env_params.yosys_synth_extra_options,
                 "" if params.verbosity.all or params.verbosity.synth else "-q",
             ),
             suffix=".json",

--- a/apio/scons/plugin_gowin.py
+++ b/apio/scons/plugin_gowin.py
@@ -65,8 +65,8 @@ class PluginGowin(PluginBase):
                 'yosys -p "synth_gowin -top {0} {1} -json $TARGET" {2} '
                 "$SOURCES"
             ).format(
-                params.project.top_module,
-                params.project.yosys_synth_extra_options,
+                params.apio_env_params.top_module,
+                params.apio_env_params.yosys_synth_extra_options,
                 "" if params.verbosity.all or params.verbosity.synth else "-q",
             ),
             suffix=".json",

--- a/apio/scons/plugin_ice40.py
+++ b/apio/scons/plugin_ice40.py
@@ -65,8 +65,8 @@ class PluginIce40(PluginBase):
                 'yosys -p "synth_ice40 -top {0} {1} -json $TARGET" {2} '
                 "$SOURCES"
             ).format(
-                params.project.top_module,
-                params.project.yosys_synth_extra_options,
+                params.apio_env_params.top_module,
+                params.apio_env_params.yosys_synth_extra_options,
                 "" if params.verbosity.all or params.verbosity.synth else "-q",
             ),
             suffix=".json",

--- a/apio/scons/plugin_util.py
+++ b/apio/scons/plugin_util.py
@@ -34,7 +34,7 @@ from apio.common.apio_console import cout, cerror, cwarning, cprint
 from apio.common.apio_styles import INFO, BORDER, EMPH1, EMPH2, EMPH3
 
 
-# -- A list with the file extensions of the verilog source files.
+# -- A list with the file extensions of the source files.
 SRC_SUFFIXES = [".v", ".sv"]
 
 TESTBENCH_HINT = "Testbench file names must end with '_tb.v' or '_tb.sv'."
@@ -111,7 +111,7 @@ def verilog_src_scanner(apio_env: ApioEnv) -> Scanner.Base:
     #   Captures:  'v771499.list'
     icestudio_list_re = re.compile(r"[\n|\s][^\/]?\"(.*\.list?)\"", re.M)
 
-    # A regex to match a verilog include.
+    # A regex to match a verilog include directive.
     # Example
     #   Text:     `include "apio_testing.vh"
     #   Capture:  'apio_testing.vh'
@@ -137,10 +137,10 @@ def verilog_src_scanner(apio_env: ApioEnv) -> Scanner.Base:
     def verilog_src_scanner_func(
         file_node: File, env: SConsEnvironment, ignored_path
     ) -> List[str]:
-        """Given a Verilog file, scan it and return a list of references
-        to other files it depends on. It's not require to report dependency
-        on another .v file in the project since scons loads anyway
-        all the .v files in the project.
+        """Given a [System]Verilog file, scan it and return a list of
+        references to other files it depends on. It's not require to report
+        dependency on another source file in the project since scons loads
+        anyway all the source files in the project.
 
         Returns a list of files. Dependencies that don't have an existing
         file are ignored and not returned. This is to avoid references in
@@ -150,7 +150,7 @@ def verilog_src_scanner(apio_env: ApioEnv) -> Scanner.Base:
 
         # Sanity check. Should be called only to scan verilog files. If
         # this fails, this is a programming error rather than a user error.
-        assert is_verilog_src(
+        assert is_source_file(
             file_node.name
         ), f"Not a src file: {file_node.name}"
 
@@ -326,7 +326,7 @@ def waves_target(
 def check_valid_testbench_name(testbench: str) -> None:
     """Check if a testbench name is valid. If not, print an error message
     and exit."""
-    if not is_verilog_src(testbench) or not has_testbench_name(testbench):
+    if not is_source_file(testbench) or not has_testbench_name(testbench):
         cerror(f"'{testbench}' is not a valid testbench file name.")
         cout(TESTBENCH_HINT, style=INFO)
         sys.exit(1)
@@ -428,7 +428,7 @@ def get_tests_configs(
     return configs
 
 
-def is_verilog_src(file_name: str) -> bool:
+def is_source_file(file_name: str) -> bool:
     """Given a file name, determine by its extension if it's a verilog
     source file (testbenches included)."""
     _, ext = os.path.splitext(file_name)
@@ -437,8 +437,8 @@ def is_verilog_src(file_name: str) -> bool:
 
 def has_testbench_name(file_name: str) -> bool:
     """Given a file name, return true if it's base name indicates a
-    testbench. It can be for example abc_tb.v or _build/abc_tb.out.
-    The file extension is ignored.
+    testbench. For example abc_tb.v or _build/abc_tb.out. The file extension
+    is ignored.
     """
     name, _ = os.path.splitext(file_name)
     return name.lower().endswith("_tb")
@@ -464,7 +464,7 @@ def source_file_issue_action() -> FunctionAction:
 
             # -- For now we report issues only in testbenches so skip
             # -- otherwise.
-            if not is_verilog_src(file.name) or not has_testbench_name(
+            if not is_source_file(file.name) or not has_testbench_name(
                 file.name
             ):
                 continue
@@ -488,22 +488,18 @@ def source_file_issue_action() -> FunctionAction:
 # Remove apio_env ark is not needed anymore.
 # pylint: disable=unused-argument
 def source_files(apio_env: ApioEnv) -> Tuple[List[str], List[str]]:
-    """Get the list of *.v|sv files in the directory tree under the current
+    """Get the list of source files in the directory tree under the current
     directory, splitted into synth and testbench lists.
     If source file has the suffix _tb it's is classified st a testbench,
     otherwise as a synthesis file.
     """
-    # -- Get a list of all *.v and .sv files in the project dir.
+    # -- Get a list of all source files in the project dir.
     # -- Ideally we should use the scons env.Glob() method but it doesn't
     # -- work with the recursive=True option. So we use the glob() function
     # -- instead.
-    files: List[str] = glob("**/*.sv", recursive=True)
-    if files:
-        cwarning(
-            "Project contains .sv files, system-verilog support "
-            "is experimental."
-        )
-    files = files + glob("**/*.v", recursive=True)
+    files: List[str] = []
+    for ext in SRC_SUFFIXES:
+        files.extend(glob(f"**/*{ext}", recursive=True))
 
     # -- Sort the files by directory and then by file name.
     files = sort_files(files)
@@ -703,8 +699,7 @@ def iverilog_action(
     escaped_vcd_output_name = vcd_output_name.replace("\\", "\\\\")
 
     # -- Construct the action string.
-    # -- The -g2012 is for system-verilog support and we use it here as an
-    # -- experimental feature.
+    # -- The -g2012 is for system-verilog support.
     action = (
         "iverilog -g2012 {0} -o $TARGET {1} {2} {3} {4} {5} $SOURCES"
     ).format(

--- a/apio/scons/plugin_util.py
+++ b/apio/scons/plugin_util.py
@@ -246,7 +246,7 @@ def verilator_lint_action(
     top_module = (
         lint_params.top_module
         if lint_params.top_module
-        else params.project.top_module
+        else params.apio_env_params.top_module
     )
 
     # -- Construct the action

--- a/apio/scons/scons_handler.py
+++ b/apio/scons/scons_handler.py
@@ -402,8 +402,8 @@ class SconsHandler:
 
         apio_env = self.apio_env
 
-        # -- Collect a list of the synthesizable files (e.g. "main.v") and a
-        # -- list of the testbench files (e.g. "main_tb.v")
+        # -- Collect the lists of the synthesizable files (e.g. "main.v") and a
+        # -- testbench files (e.g. "main_tb.v")
         synth_srcs, test_srcs = source_files(apio_env)
 
         # -- A cleanup request is passed as scons -c option rather than as

--- a/test/commands/test_apio_build.py
+++ b/test/commands/test_apio_build.py
@@ -23,20 +23,33 @@ def test_build_with_apio_init(apio_runner: ApioRunner):
     with apio_runner.in_sandbox() as sb:
 
         # -- Run "apio build" with a missing board var.
-        sb.write_apio_ini({"top-module": "main"})
+        sb.write_apio_ini({"[env]": {"top-module": "main"}})
         result = sb.invoke_apio_cmd(apio, "build")
         assert result.exit_code == 1, result.output
         assert "Error: Missing option 'board'" in result.output
 
         # -- Run "apio build" with an invalid board
-        sb.write_apio_ini({"board": "no-such-board", "top-module": "main"})
+        sb.write_apio_ini(
+            {
+                "[env]": {
+                    "board": "no-such-board",
+                    "top-module": "main",
+                }
+            }
+        )
         result = sb.invoke_apio_cmd(apio, "build")
         assert result.exit_code == 1, result.output
         assert "no such board 'no-such-board'" in result.output.lower()
 
         # -- Run "apio build" with an unknown option.
         sb.write_apio_ini(
-            {"board": "alhambra-ii", "top-module": "main", "unknown": "xyz"}
+            {
+                "[env]": {
+                    "board": "alhambra-ii",
+                    "top-module": "main",
+                    "unknown": "xyz",
+                }
+            }
         )
         result = sb.invoke_apio_cmd(apio, "build")
         assert result.exit_code == 1, result.output

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -227,28 +227,43 @@ class ApioSandbox:
         # -- All done
         return text
 
-    def write_apio_ini(self, properties: Dict[str, str]):
+    def write_apio_ini(
+        self,
+        sections: Dict[str, Dict[str, str]] = None,
+    ):
         """Write in the current directory an apio.ini file with given
-        values. If an apio.ini file already exists, it is overwritten."""
+        section. If an apio.ini file already exists, overwrite it."""
 
-        assert isinstance(properties, dict), "Not a dict."
+        assert isinstance(sections, dict)
 
+        # -- Construct output file path.
         path = Path("apio.ini")
 
-        # -- Requested to write. Construct the lines.
-        lines = ["[env]"]
-        for name, value in properties.items():
-            lines.append(f"{name} = {value}")
+        # -- List with text of each section.
+        sections_texts: List[str] = []
 
-        # -- Write the file.
-        self.write_file(path, lines, exists_ok=True)
+        # -- Add the apio section if specified.
+        for section_header, section_options in sections.items():
+            lines = [section_header]
+            for name, value in section_options.items():
+                lines.append(f"{name} = {value}")
+            sections_texts.append("\n".join(lines))
+
+        # -- Join the sections with a blank line.
+        file_text = "\n\n".join(sections_texts)
+
+        # # -- Write the file.
+        self.write_file(path, file_text, exists_ok=True)
 
     def write_default_apio_ini(self):
         """Write in the local directory an apio.ini file with default values
         for testing. If the file exists, it's overwritten."""
+
         default_apio_ini = {
-            "board": "alhambra-ii",
-            "top-module": "main",
+            "[env]": {
+                "board": "alhambra-ii",
+                "top-module": "main",
+            }
         }
         self.write_apio_ini(default_apio_ini)
 
@@ -256,6 +271,7 @@ class ApioSandbox:
     def offline_flag(self):
         """Returns True if pytest was invoked with --offline to skip
         tests that require internet connectivity and are slower in general."""
+
         assert not self.expired, "Trying to use an expired sandbox"
         return self._apio_runner.offline_flag
 

--- a/test/integration/test_commands.py
+++ b/test/integration/test_commands.py
@@ -41,7 +41,14 @@ def test_boards_custom_board(apio_runner: ApioRunner):
     with apio_runner.in_sandbox(shared_home=True) as sb:
 
         # -- Write an apio.ini file.
-        sb.write_apio_ini({"board": "my_custom_board", "top-module": "main"})
+        sb.write_apio_ini(
+            {
+                "[env]": {
+                    "board": "my_custom_board",
+                    "top-module": "main",
+                }
+            }
+        )
 
         # -- Write a custom boards.jsonc file in the project's directory.
         sb.write_file("boards.jsonc", CUSTOM_BOARDS)
@@ -140,7 +147,14 @@ def test_project_with_legacy_board_name(apio_runner: ApioRunner):
         sb.assert_ok(result)
 
         # -- Modify the apio.ini to have the legacy board name
-        sb.write_apio_ini({"board": "iCE40-HX8K", "top-module": "leds"})
+        sb.write_apio_ini(
+            {
+                "[env]": {
+                    "board": "iCE40-HX8K",
+                    "top-module": "leds",
+                }
+            }
+        )
 
         # -- Run 'apio clean'
         result = sb.invoke_apio_cmd(apio, "clean")

--- a/test/managers/test_programmers.py
+++ b/test/managers/test_programmers.py
@@ -14,7 +14,14 @@ def test_construct_programmer_cmd_template(apio_runner: ApioRunner):
     with apio_runner.in_sandbox() as sb:
 
         # -- Construct an apio context.
-        sb.write_apio_ini({"board": "alhambra-ii", "top-module": "my_module"})
+        sb.write_apio_ini(
+            {
+                "[env]": {
+                    "board": "alhambra-ii",
+                    "top-module": "my_module",
+                }
+            }
+        )
         apio_ctx = ApioContext(scope=ApioContextScope.PROJECT_REQUIRED)
         board_info = apio_ctx.boards.get(apio_ctx.project.get("board"))
         assert board_info["programmer"]["type"] == "iceprog"
@@ -39,7 +46,14 @@ def test_construct_programmer_cmd_template_sram_ok(apio_runner: ApioRunner):
     with apio_runner.in_sandbox() as sb:
 
         # -- Construct an apio context.
-        sb.write_apio_ini({"board": "alhambra-ii", "top-module": "my_module"})
+        sb.write_apio_ini(
+            {
+                "[env]": {
+                    "board": "alhambra-ii",
+                    "top-module": "my_module",
+                }
+            }
+        )
         apio_ctx = ApioContext(scope=ApioContextScope.PROJECT_REQUIRED)
         board_info = apio_ctx.boards.get(apio_ctx.project.get("board"))
         assert board_info["programmer"]["type"] == "iceprog"
@@ -68,7 +82,12 @@ def test_construct_programmer_cmd_template_sram_error(
         # -- Construct an apio context with a board that does not
         # -- support the flag --sram.
         sb.write_apio_ini(
-            {"board": "colorlight-5a-75b-v7", "top-module": "my_module"}
+            {
+                "[env]": {
+                    "board": "colorlight-5a-75b-v7",
+                    "top-module": "my_module",
+                }
+            }
         )
         apio_ctx = ApioContext(scope=ApioContextScope.PROJECT_REQUIRED)
         board_info = apio_ctx.boards.get(apio_ctx.project.get("board"))

--- a/test/managers/test_project.py
+++ b/test/managers/test_project.py
@@ -16,12 +16,14 @@ def test_required_and_optionals(apio_runner: ApioRunner):
         # -- Create an apio.ini.
         sb.write_apio_ini(
             {
-                # -- Required.
-                "board": "alhambra-ii",
-                # -- Optional.
-                "top-module": "my_module",
-                "format-verible-options": "\n  --aaa bbb\n  --ccc ddd",
-                "yosys-synth-extra-options": "-dsp -xyz",
+                "[env]": {
+                    # -- Required.
+                    "board": "alhambra-ii",
+                    # -- Optional.
+                    "top-module": "my_module",
+                    "format-verible-options": "\n  --aaa bbb\n  --ccc ddd",
+                    "yosys-synth-extra-options": "-dsp -xyz",
+                }
             }
         )
 
@@ -56,7 +58,9 @@ def test_required_only(apio_runner: ApioRunner):
         # -- Create an apio.ini.
         sb.write_apio_ini(
             {
-                "board": "alhambra-ii",
+                "[env]": {
+                    "board": "alhambra-ii",
+                }
             }
         )
 

--- a/test/managers/test_scons.py
+++ b/test/managers/test_scons.py
@@ -15,12 +15,14 @@ from apio.managers.scons import SCons
 
 
 TEST_APIO_INI_DICT = {
-    # -- Required.
-    "board": "alhambra-ii",
-    # -- Optional.
-    "top-module": "my_module",
-    "format-verible-options": "\n  --aaa bbb\n  --ccc ddd",
-    "yosys-synth-extra-options": "-dsp -xyz",
+    "[env]": {
+        # -- Required.
+        "board": "alhambra-ii",
+        # -- Optional.
+        "top-module": "my_module",
+        "format-verible-options": "\n  --aaa bbb\n  --ccc ddd",
+        "yosys-synth-extra-options": "-dsp -xyz",
+    }
 }
 
 # -- The non determinisitc values marked with TBD are patched by the test

--- a/test/managers/test_scons.py
+++ b/test/managers/test_scons.py
@@ -48,7 +48,7 @@ environment {
   yosys_path: "TBD"
   trellis_path: "TBD"
 }
-project {
+apio_env_params {
   board_id: "alhambra-ii"
   top_module: "my_module"
   yosys_synth_extra_options: "-dsp -xyz"
@@ -82,7 +82,7 @@ environment {
   yosys_path: "TBD"
   trellis_path: "TBD"
 }
-project {
+apio_env_params {
   board_id: "alhambra-ii"
   top_module: "my_module"
   yosys_synth_extra_options: "-dsp -xyz"

--- a/test/scons/test_plugin_util.py
+++ b/test/scons/test_plugin_util.py
@@ -15,7 +15,7 @@ from apio.common.proto.apio_pb2 import TargetParams, UploadParams
 from apio.scons.plugin_util import (
     get_constraint_file,
     verilog_src_scanner,
-    is_verilog_src,
+    is_source_file,
     has_testbench_name,
     source_files,
     get_programmer_cmd,
@@ -131,23 +131,23 @@ def test_verilog_src_scanner(apio_runner: ApioRunner):
         assert file_names == sorted(core_dependencies + file_dependencies)
 
 
-def test_is_verilog_src():
-    """Tests the is_verilog_src() function."""
+def test_is_source_file():
+    """Tests the is_source_file() function."""
 
     # -- Verilog and system-verilog source names,
-    assert is_verilog_src("aaa.v")
-    assert is_verilog_src("bbb/aaa.v")
-    assert is_verilog_src("bbb\\aaa.v")
-    assert is_verilog_src("aaatb.v")
-    assert is_verilog_src("aaa_tb.v")
-    assert is_verilog_src("aaa.sv")
-    assert is_verilog_src("bbb\\aaa.sv")
-    assert is_verilog_src("aaa_tb.sv")
+    assert is_source_file("aaa.v")
+    assert is_source_file("bbb/aaa.v")
+    assert is_source_file("bbb\\aaa.v")
+    assert is_source_file("aaatb.v")
+    assert is_source_file("aaa_tb.v")
+    assert is_source_file("aaa.sv")
+    assert is_source_file("bbb\\aaa.sv")
+    assert is_source_file("aaa_tb.sv")
 
     # -- Non verilog source names, system-verilog included.
-    assert not is_verilog_src("aaatb.vv")
-    assert not is_verilog_src("aaatb.V")
-    assert not is_verilog_src("aaa_tb.vh")
+    assert not is_source_file("aaatb.vv")
+    assert not is_source_file("aaatb.V")
+    assert not is_source_file("aaa_tb.vh")
 
 
 def test_has_testbench_name():

--- a/test/scons/testing.py
+++ b/test/scons/testing.py
@@ -35,7 +35,7 @@ environment {
   yosys_path: "/Users/user/.apio/packages/oss-cad-suite/share/yosys"
   trellis_path: "/Users/user/.apio/packages/oss-cad-suite/share/trellis"
 }
-project {
+apio_env_params {
   board_id: "alhambra-ii"
   top_module: "main"
 }


### PR DESCRIPTION
Updated help text and user messages to remove the qualification of System Verilog as an experimental feature of Apio. It is now a standard feature same as Verilog.

Related to https://github.com/FPGAwars/apio/issues/391

@cavearr, please take a look.