### PR TITLE
Added support for multiple envs in apio.ini

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,6 +5,17 @@
 # Do not warn about too few public methods in a class.
 disable=fixme,too-few-public-methods
 
+# Warn about unnecessary pylint disable=x directives.
+enable=useless-suppression
+
+
 [SIMILARITIES]
 # Reducing the sensitivity of duplicate code (default is 4)
 min-similarity-lines=15
+
+
+[TYPECHECK]
+# This prevents false proto buffers related warnings.
+# It tells pylint to use the definitions in the .pyi stubs instead of the
+# cryptic protocol buffers .py files.
+prefer-stubs=yes

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,8 @@
 
 [MESSAGES CONTROL]
 # Do not warn about TODOs.
-disable=fixme
+# Do not warn about too few public methods in a class.
+disable=fixme,too-few-public-methods
 
 [SIMILARITIES]
 # Reducing the sensitivity of duplicate code (default is 4)

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -204,6 +204,7 @@ Usage: apio build [OPTIONS]
 
   Examples:
     apio build                   # Typical usage
+    apio build -e debug          # Set the apio.ini env.
     apio build -v                # Verbose info (all)
     apio build --verbose-synth   # Verbose synthesis info
     apio build --verbose-pnr     # Verbose place and route info
@@ -216,6 +217,7 @@ Usage: apio build [OPTIONS]
   * To force a rebuild from scratch use the command 'apio clean' first.
 
 Options:
+  -e, --env name          Set the apio.ini env.
   -p, --project-dir path  Set the root directory for the project.
   -v, --verbose           Show detailed output.
   --verbose-synth         Show detailed synth stage output.
@@ -238,6 +240,7 @@ Usage: apio clean [OPTIONS]
     apio clean
 
 Options:
+  -e, --env name          Set the apio.ini env.
   -p, --project-dir path  Set the root directory for the project.
   -h, --help              Show this message and exit.
 
@@ -618,6 +621,7 @@ Usage: apio format [OPTIONS] [FILES]...
   --helpful'.
 
 Options:
+  -e, --env name          Set the apio.ini env.
   -p, --project-dir path  Set the root directory for the project.
   -v, --verbose           Show detailed output.
   -h, --help              Show this message and exit.
@@ -673,6 +677,7 @@ Options:
   --svg                   Generate a svg file (default).
   --png                   Generate a png file.
   --pdf                   Generate a pdf file.
+  -e, --env name          Set the apio.ini env.
   -p, --project-dir path  Set the root directory for the project.
   -t, --top-module name   Set the name of the top module to graph.
   -v, --verbose           Show detailed output.
@@ -1074,6 +1079,7 @@ Usage: apio report [OPTIONS]
     apio report --verbose  # Print extra information.
 
 Options:
+  -e, --env name          Set the apio.ini env.
   -p, --project-dir path  Set the root directory for the project.
   -v, --verbose           Show detailed output.
   -h, --help              Show this message and exit.
@@ -1122,6 +1128,7 @@ Usage: apio sim [OPTIONS] [TESTBENCH]
 
 Options:
   -f, --force             Force simulation.
+  -e, --env name          Set the apio.ini env.
   -p, --project-dir path  Set the root directory for the project.
   -h, --help              Show this message and exit.
 
@@ -1160,6 +1167,7 @@ Usage: apio test [OPTIONS] [TESTBENCH_FILE]
   signals, refer to the 'apio sim' command.
 
 Options:
+  -e, --env name          Set the apio.ini env.
   -p, --project-dir path  Set the root directory for the project.
   -h, --help              Show this message and exit.
 
@@ -1224,6 +1232,7 @@ Options:
   --serial-port serial-port  Set the serial port.
   --ftdi-idx ftdi-idx        Consider only FTDI device with given index.
   -s, --sram                 Perform SRAM programming (see restrictions).
+  -e, --env name             Set the apio.ini env.
   -p, --project-dir path     Set the root directory for the project.
   -h, --help                 Show this message and exit.
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -25,10 +25,10 @@
   * [apio fpgas](#apio-fpgas) - List available FPGA definitions.
   * [apio graph](#apio-graph) - Generate a visual graph of the code.
   * [apio info](#apio-info) - Apio's info and info.
+    * [apio info apio.ini](#apio-info-apio.ini) - Apio.ini options.
     * [apio info cli](#apio-info-cli) - Command line conventions.
     * [apio info colors](#apio-info-colors) - Colors table.
     * [apio info files](#apio-info-files) - Apio project files types.
-    * [apio info options](#apio-info-options) - Apio.ini options.
     * [apio info platforms](#apio-info-platforms) - Supported platforms.
     * [apio info resources](#apio-info-resources) - Additional resources.
     * [apio info system](#apio-info-system) - Show system information.
@@ -695,7 +695,7 @@ Options:
   -h, --help  Show this message and exit.
 
 Documentation:
-  apio info options    Apio.ini options.
+  apio info apio.ini   Apio.ini options.
   apio info cli        Command line conventions.
   apio info files      Apio project files types.
   apio info resources  Additional resources.
@@ -704,6 +704,25 @@ Information:
   apio info platforms  Supported platforms.
   apio info system     Show system information.
   apio info colors     Colors table.
+
+```
+
+<br>
+
+### apio info apio.ini
+
+```
+Usage: apio info apio.ini [OPTIONS] [OPTION]
+
+  The command 'apio info apio.ini' provides information about the
+  required project file 'apio.ini'.
+
+  Examples:
+    apio info apio.ini              # List an overview and all options.
+    apio info apio.ini top-module   # List a single option.
+
+Options:
+  -h, --help  Show this message and exit.
 
 ```
 
@@ -760,30 +779,11 @@ Options:
 ```
 Usage: apio info files [OPTIONS]
 
-  The command 'apio info options' provides information about the various
+  The command 'apio info files' provides information about the various
   files types used in an Apio project.
 
   Examples:
     apio info files
-
-Options:
-  -h, --help  Show this message and exit.
-
-```
-
-<br>
-
-### apio info options
-
-```
-Usage: apio info options [OPTIONS] [OPTION]
-
-  The command 'apio info options' provides information about the
-  required project file 'apio.ini'.
-
-  Examples:
-    apio info options              # List an overview and all options.
-    apio info options top-module   # List a single option.
 
 Options:
   -h, --help  Show this message and exit.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -882,6 +882,7 @@ Options:
   -a, --all               Enable all warnings, including code style warnings.
   -t, --top-module name   Restrict linting to this module and its
                           dependencies.
+  -e, --env name          Set the apio.ini env.
   -p, --project-dir path  Set the root directory for the project.
   -h, --help              Show this message and exit.
 

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -561,7 +561,6 @@ class ApioContext:
 
 
 class _ProjectResolverImpl(ProjectResolver):
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, apio_context: ApioContext):
         """When ApioContext instances this object, ApioContext is fully

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -92,6 +92,7 @@ class ApioContext:
         *,
         scope: ApioContextScope,
         project_dir_arg: Optional[Path] = None,
+        env_arg: Optional[str] = None,
     ):
         """Initializes the ApioContext object.
 
@@ -100,6 +101,9 @@ class ApioContext:
 
         'project_dir_arg' is an optional user specification of the project dir.
         Must be None if scope is NO_PROJECT.
+
+        'env_arg' is an optional command line option value that select the
+        apio.ini env if the project is loaded.
 
         """
 
@@ -206,7 +210,9 @@ class ApioContext:
         self._project: Optional[Project] = None
         if self._project_dir:
             resolver = _ProjectResolverImpl(self)
-            self._project = load_project_from_file(self._project_dir, resolver)
+            self._project = load_project_from_file(
+                self._project_dir, env_arg, resolver
+            )
             assert self.has_project, "init(): project not loaded"
         else:
             assert not self.has_project, "init(): project loaded"

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -103,8 +103,8 @@ class ApioContext:
         Must be None if scope is NO_PROJECT.
 
         'env_arg' is an optional command line option value that select the
-        apio.ini env if the project is loaded.
-
+        apio.ini env if the project is loaded. it makes sense only when scope
+        is PROJECT_REQUIRED (enforced by an assertion).
         """
 
         # -- Inform as soon as possible about the list of apio env options
@@ -125,6 +125,11 @@ class ApioContext:
         # -- Store the scope
         assert isinstance(scope, ApioContextScope), "Not an ApioContextScope"
         self.scope = scope
+
+        # -- Sanity check, env_arg makes sense only when scope is
+        # -- PROJECT_REQUIRED.
+        if env_arg is not None:
+            assert scope == ApioContextScope.PROJECT_REQUIRED
 
         # -- A flag to indicate if the system env was already set in this
         # -- apio session. Used to avoid multiple repeated settings that

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -17,11 +17,7 @@ from apio.common.apio_console import cout, cerror, cwarning
 from apio.common.apio_styles import INFO
 from apio.profile import Profile
 from apio.utils import jsonc, util, env_options
-from apio.managers.project import (
-    Project,
-    ProjectResolver,
-    load_project_from_file,
-)
+from apio.managers.project import Project, load_project_from_file
 
 
 # ---------- RESOURCES
@@ -214,63 +210,12 @@ class ApioContext:
         # -- apio.ini data.
         self._project: Optional[Project] = None
         if self._project_dir:
-            resolver = _ProjectResolverImpl(self)
             self._project = load_project_from_file(
-                self._project_dir, env_arg, resolver
+                self._project_dir, env_arg, self.boards
             )
             assert self.has_project, "init(): project not loaded"
         else:
             assert not self.has_project, "init(): project loaded"
-
-    def lookup_board_name(
-        self,
-        board: str,
-        *,
-        accept_legacy_names: bool,
-        warn_if_legacy_name: bool,
-        exit_if_not_found: bool,
-    ) -> Optional[str]:
-        """Lookup and return the board's canonical board name which is its key
-        in boards.jsonc.  'board' can be the canonical name itself or a
-        legacy id of the board as defined in boards.jsonc.  The method prints
-        a warning if 'board' is a legacy board name that is mapped to its
-        canonical name and 'warn' is True. If the  board is not found, the
-        method returns None if 'strict' is False or exit the program with a
-        message if 'strict' is True."""
-        # -- If this fails, it's a programming error.
-        assert board is not None
-
-        # -- The result. The board's key in boards.jsonc.
-        canonical_name = None
-
-        if board in self.boards:
-            # -- Here when board is already the canonical name.
-            canonical_name = board
-        elif accept_legacy_names:
-            # -- Look up for a board with 'board' as its legacy name.
-            for board_name, board_info in self.boards.items():
-                if board == board_info.get("legacy_name", None):
-                    canonical_name = board_name
-                    break
-
-        # -- Fatal error if unknown board.
-        if exit_if_not_found and canonical_name is None:
-            cerror(f"No such board '{board}'")
-            cout(
-                "Run 'apio boards' for the list of board names.",
-                style=INFO,
-            )
-            sys.exit(1)
-
-        # -- Warning if caller used a legacy board name.
-        if warn_if_legacy_name and canonical_name and board != canonical_name:
-            cwarning(
-                f"'{board}' board name was changed. "
-                f"Please use '{canonical_name}' instead."
-            )
-
-        # -- Return the canonical board name.
-        return canonical_name
 
     @property
     def packages_dir(self):
@@ -569,28 +514,3 @@ class ApioContext:
     def is_windows(self) -> bool:
         """Returns True iff platform_id indicates windows."""
         return "windows" in self.platform_id
-
-
-class _ProjectResolverImpl(ProjectResolver):
-
-    def __init__(self, apio_context: ApioContext):
-        """When ApioContext instances this object, ApioContext is fully
-        constructed, except for the project field."""
-        self._apio_context = apio_context
-
-    # @override
-    def lookup_board_name(
-        self,
-        board: str,
-        *,
-        accept_legacy_names: bool,
-        warn_if_legacy_name: bool,
-        exit_if_not_found: bool,
-    ) -> Optional[str]:
-        """Implementation of lookup_board_name."""
-        return self._apio_context.lookup_board_name(
-            board,
-            accept_legacy_names=accept_legacy_names,
-            warn_if_legacy_name=warn_if_legacy_name,
-            exit_if_not_found=exit_if_not_found,
-        )

--- a/apio/commands/apio_boards.py
+++ b/apio/commands/apio_boards.py
@@ -10,7 +10,7 @@
 import sys
 from pathlib import Path
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List, Dict, Optional
 import click
 from rich.table import Table
 from rich import box
@@ -180,7 +180,7 @@ Examples:[code]
 def cli(
     # Options
     verbose: bool,
-    project_dir: Path,
+    project_dir: Optional[Path],
 ):
     """Implements the 'boards' command which lists available board
     definitions."""

--- a/apio/commands/apio_build.py
+++ b/apio/commands/apio_build.py
@@ -57,7 +57,7 @@ def cli(
     _: click.Context,
     # Options
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
     verbose: bool,
     verbose_synth: bool,
     verbose_pnr: bool,

--- a/apio/commands/apio_build.py
+++ b/apio/commands/apio_build.py
@@ -8,8 +8,10 @@
 """Implementation of 'apio build' command"""
 
 import sys
+from typing import Optional
 from pathlib import Path
 import click
+
 from apio.utils import cmd_util
 from apio.managers.scons import SCons
 from apio.commands import options
@@ -25,6 +27,7 @@ generates a bitstream file, which can then be uploaded to your FPGA.
 
 Examples:[code]
   apio build                   # Typical usage
+  apio build -e debug          # Set the apio.ini env.
   apio build -v                # Verbose info (all)
   apio build --verbose-synth   # Verbose synthesis info
   apio build --verbose-pnr     # Verbose place and route info[/code]
@@ -45,6 +48,7 @@ NOTES:
     help=APIO_BUILD_HELP,
 )
 @click.pass_context
+@options.env_option
 @options.project_dir_option
 @options.verbose_option
 @options.verbose_synth_option
@@ -52,6 +56,7 @@ NOTES:
 def cli(
     _: click.Context,
     # Options
+    env: Optional[str],
     project_dir: Path,
     verbose: bool,
     verbose_synth: bool,
@@ -65,6 +70,7 @@ def cli(
     apio_ctx = ApioContext(
         scope=ApioContextScope.PROJECT_REQUIRED,
         project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Create the scons manager.

--- a/apio/commands/apio_clean.py
+++ b/apio/commands/apio_clean.py
@@ -8,6 +8,7 @@
 """Implementation of 'apio clean' command"""
 
 import sys
+from typing import Optional
 from pathlib import Path
 import click
 from apio.managers.scons import SCons
@@ -35,10 +36,12 @@ Example:[code]
     help=APIO_CLEAN_HELP,
 )
 @click.pass_context
+@options.env_option
 @options.project_dir_option
 def cli(
     _: click.Context,
     # Options
+    env: Optional[str],
     project_dir: Path,
 ):
     """Implements the apio clean command. It deletes temporary files generated
@@ -49,6 +52,7 @@ def cli(
     apio_ctx = ApioContext(
         scope=ApioContextScope.PROJECT_REQUIRED,
         project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Create the scons manager.

--- a/apio/commands/apio_clean.py
+++ b/apio/commands/apio_clean.py
@@ -42,7 +42,7 @@ def cli(
     _: click.Context,
     # Options
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
 ):
     """Implements the apio clean command. It deletes temporary files generated
     by apio commands.

--- a/apio/commands/apio_create.py
+++ b/apio/commands/apio_create.py
@@ -75,7 +75,12 @@ def cli(
     apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
 
     # -- Map to canonical board name. This fails if the board is unknown.
-    board_name = apio_ctx.lookup_board_name(board)
+    board_name = apio_ctx.lookup_board_name(
+        board,
+        accept_legacy_names=False,
+        warn_if_legacy_name=False,
+        exit_if_not_found=True,
+    )
 
     # -- Determine the new project directory. Create if needed.
     project_dir: Path = util.user_directory_or_cwd(

--- a/apio/commands/apio_create.py
+++ b/apio/commands/apio_create.py
@@ -7,6 +7,7 @@
 # -- License GPLv2
 """Implementation of 'apio create' command"""
 
+from typing import Optional
 from pathlib import Path
 import click
 from apio.utils import util, cmd_util
@@ -61,7 +62,7 @@ def cli(
     # Options
     board: str,
     top_module: str,
-    project_dir: Path,
+    project_dir: Optional[Path],
 ):
     """Create a project file."""
 

--- a/apio/commands/apio_create.py
+++ b/apio/commands/apio_create.py
@@ -7,9 +7,11 @@
 # -- License GPLv2
 """Implementation of 'apio create' command"""
 
+import sys
 from typing import Optional
 from pathlib import Path
 import click
+from apio.common.apio_console import cerror
 from apio.utils import util, cmd_util
 from apio.commands import options
 from apio.apio_context import ApioContext, ApioContextScope
@@ -75,13 +77,10 @@ def cli(
     # -- Create the apio context.
     apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
 
-    # -- Map to canonical board name. This fails if the board is unknown.
-    board_name = apio_ctx.lookup_board_name(
-        board,
-        accept_legacy_names=False,
-        warn_if_legacy_name=False,
-        exit_if_not_found=True,
-    )
+    # -- Make sure the board exist.
+    if board not in apio_ctx.boards:
+        cerror(f"Unknown board name '{board}'.")
+        sys.exit(1)
 
     # -- Determine the new project directory. Create if needed.
     project_dir: Path = util.user_directory_or_cwd(
@@ -91,6 +90,6 @@ def cli(
     # Create the apio.ini file. It exists with an error status if any error.
     create_project_file(
         project_dir,
-        board_name,
+        board,
         top_module,
     )

--- a/apio/commands/apio_examples.py
+++ b/apio/commands/apio_examples.py
@@ -212,7 +212,12 @@ def _fetch_board_cli(
     apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
 
     # -- This fails with an error message if there is no such board.
-    apio_ctx.lookup_board_name(board)
+    apio_ctx.lookup_board_name(
+        board,
+        accept_legacy_names=False,
+        warn_if_legacy_name=False,
+        exit_if_not_found=True,
+    )
 
     # -- Create the examples manager.
     examples = Examples(apio_ctx)

--- a/apio/commands/apio_examples.py
+++ b/apio/commands/apio_examples.py
@@ -7,11 +7,13 @@
 # -- License GPLv2
 """Implementation of 'apio examples' command"""
 
+import sys
 from pathlib import Path
 from typing import List, Any, Optional
 import click
 from rich.table import Table
 from rich import box
+from apio.common.apio_console import cerror
 from apio.common import apio_console
 from apio.common.apio_console import cout, cprint
 from apio.common.apio_styles import INFO, BORDER, EMPH1
@@ -211,13 +213,10 @@ def _fetch_board_cli(
     # -- Create the apio context.
     apio_ctx = ApioContext(scope=ApioContextScope.NO_PROJECT)
 
-    # -- This fails with an error message if there is no such board.
-    apio_ctx.lookup_board_name(
-        board,
-        accept_legacy_names=False,
-        warn_if_legacy_name=False,
-        exit_if_not_found=True,
-    )
+    # -- Make sure the board exist.
+    if board not in apio_ctx.boards:
+        cerror(f"Unknown board name '{board}.")
+        sys.exit(1)
 
     # -- Create the examples manager.
     examples = Examples(apio_ctx)

--- a/apio/commands/apio_examples.py
+++ b/apio/commands/apio_examples.py
@@ -8,7 +8,7 @@
 """Implementation of 'apio examples' command"""
 
 from pathlib import Path
-from typing import List, Any
+from typing import List, Any, Optional
 import click
 from rich.table import Table
 from rich import box
@@ -157,7 +157,7 @@ def _fetch_cli(
     # Arguments
     example: str,
     # Options
-    dst: Path,
+    dst: Optional[Path],
 ):
     """Implements the 'apio examples fetch' command."""
 
@@ -204,7 +204,7 @@ def _fetch_board_cli(
     # Arguments
     board: str,
     # Options
-    dst: Path,
+    dst: Optional[Path],
 ):
     """Implements the 'apio examples fetch-board' command."""
 

--- a/apio/commands/apio_format.py
+++ b/apio/commands/apio_format.py
@@ -79,7 +79,7 @@ def cli(
     # Arguments
     files: Tuple[str],
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
     verbose: bool,
 ):
     """Implements the format command which formats given or all source

--- a/apio/commands/apio_format.py
+++ b/apio/commands/apio_format.py
@@ -11,7 +11,7 @@ import sys
 import os
 from pathlib import Path
 from glob import glob
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 import click
 from apio.common.apio_console import cout, cerror, cstyle
 from apio.common.apio_styles import EMPH3, SUCCESS, INFO
@@ -72,11 +72,13 @@ _FILE_TYPES = [".v", ".sv", ".vh", ".svh"]
     help=APIO_FORMAT_HELP,
 )
 @click.argument("files", nargs=-1, required=False)
+@options.env_option
 @options.project_dir_option
 @options.verbose_option
 def cli(
     # Arguments
     files: Tuple[str],
+    env: Optional[str],
     project_dir: Path,
     verbose: bool,
 ):
@@ -86,7 +88,9 @@ def cli(
 
     # -- Create an apio context with a project object.
     apio_ctx = ApioContext(
-        scope=ApioContextScope.PROJECT_REQUIRED, project_dir_arg=project_dir
+        scope=ApioContextScope.PROJECT_REQUIRED,
+        project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Get the optional formatter options from apio.ini

--- a/apio/commands/apio_fpgas.py
+++ b/apio/commands/apio_fpgas.py
@@ -10,7 +10,7 @@
 import sys
 from pathlib import Path
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List, Dict, Optional
 import click
 from rich.table import Table
 from rich import box
@@ -169,7 +169,7 @@ Examples:[code]
 def cli(
     # Options
     verbose: bool,
-    project_dir: Path,
+    project_dir: Optional[Path],
 ):
     """Implements the 'fpgas' command which lists available fpga
     definitions.

--- a/apio/commands/apio_graph.py
+++ b/apio/commands/apio_graph.py
@@ -82,7 +82,7 @@ def cli(
     png: bool,
     pdf: bool,
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
     verbose: bool,
     top_module: str,
 ):

--- a/apio/commands/apio_graph.py
+++ b/apio/commands/apio_graph.py
@@ -8,6 +8,7 @@
 """Implementation of 'apio graph' command"""
 
 import sys
+from typing import Optional
 from pathlib import Path
 import click
 from apio.managers.scons import SCons
@@ -70,6 +71,7 @@ graph, and on Mac OS type 'open _build/hardware.svg'.
 @svg_option
 @png_option
 @pdf_option
+@options.env_option
 @options.project_dir_option
 @options.top_module_option_gen(help="Set the name of the top module to graph.")
 @options.verbose_option
@@ -79,6 +81,7 @@ def cli(
     svg: bool,
     png: bool,
     pdf: bool,
+    env: Optional[str],
     project_dir: Path,
     verbose: bool,
     top_module: str,
@@ -96,7 +99,9 @@ def cli(
 
     # -- Create the apio context.
     apio_ctx = ApioContext(
-        scope=ApioContextScope.PROJECT_REQUIRED, project_dir_arg=project_dir
+        scope=ApioContextScope.PROJECT_REQUIRED,
+        project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Create the scons manager.

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -177,11 +177,11 @@ At runtime, apio select the environment to use based on this rules in \
 
 When apio determines the environment to use, it collects its options from the \
 \\[common] and the env section, with options in the env section having higher \
-priority, and executes the command with these resolved environment options.
+priority, and executes the command with these expanded environment options.
 
 Following is a list of the options that can appear in the \\[common] and \
 the \\[env:*] section. The terms 'required' and 'optional' refers to the \
-presence of the options in the options resolved from the \\[common] and the \
+presence of the options in the options expanded from the \\[common] and the \
 \\[env:name] sections.
 """
 

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -159,7 +159,7 @@ def _options_cli(
 
     # -- If option was specified, validate it.
     if option:
-        if option not in project.OPTIONS:
+        if option not in project.ENV_OPTIONS:
             cerror(f"No such api.ini option: '{option}'")
             cout(
                 "For the list of all apio.ini options, type "
@@ -173,20 +173,20 @@ def _options_cli(
         docs_text(APIO_INI_DOC)
 
     # -- Determine options to print
-    options = [option] if option else project.OPTIONS.keys()
+    options = [option] if option else project.ENV_OPTIONS.keys()
 
     # -- Print the initial separator line.
     docs_rule()
     for opt in options:
         # -- Print option's title.
-        is_required = opt in project.REQUIRED_OPTIONS
+        is_required = opt in project.ENV_REQUIRED_OPTIONS
         req = "REQUIRED" if is_required else "OPTIONAL"
         styled_option = cstyle(opt.upper(), style=TITLE)
         cout()
         cout(f"{styled_option} ({req})")
 
         # -- Print the option's text.
-        text = project.OPTIONS[opt]
+        text = project.ENV_OPTIONS[opt]
         docs_text(text)
         docs_rule()
 

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -116,46 +116,88 @@ def _cli_cli():
         cout()
 
 
-# -- apio info options
+# -- apio info apio.ini
 
 # -- Text in the rich-text format of the python rich library.
-APIO_INFO_OPTIONS_HELP = """
-The command 'apio info options' provides information about the required \
+APIO_INFO_APIO_INO_HELP = """
+The command 'apio info apio.ini' provides information about the required \
 project file 'apio.ini'.
 
 Examples:[code]
-  apio info options              # List an overview and all options.
-  apio info options top-module   # List a single option.[/code]
+  apio info apio.ini              # List an overview and all options.
+  apio info apio.ini top-module   # List a single option.[/code]
 """
 
 # -- Text in the rich-text format of the python rich library.
-APIO_INI_DOC = """
-Every Apio project is required to have an 'apio.ini' project configuration \
-file. These are properties text files with '#' comments and a single section \
-called '\\[env]' that contains the required and optional options for this \
-project.
+APIO_INI_DOC = f"""
+[{TITLE}]APIO PROJECT CONFIGURATION FILE[/]
+
+Every Apio project is required to have in its root directory a text file \
+named [b]apio.ini[/] that contains the project  configuration. At minimum, \
+the file looks like the example below with a single 'env' section that with \
+the require configuration options.
 
 Example:[code]
-  \\[env]
+  \\[env:default]
   board = alhambra-ii   # Board id
   top-module = my_main  # Top module name[/code]
 
-Following is a list of the apio.ini options and their descriptions.
+The apio.ini file can contains multiple named env sections, a common section \
+with options that are shared between envs and a section called apio which \
+allow to define the default env.
+
+Example:[code]
+  # Optional \\[apio] section.
+  \\[apio]
+  default-env = env2
+
+  # Optional \\[common] section.
+  \\[common]
+  board = alhambra-ii
+  top-module = main
+
+  # Required first env section.
+  \\[env:env1]
+  default-testbench = main_tb.v
+
+  # Optional additional env section(s).
+  \\[env:env2]
+  default-testbench = io_module_tb.v[/code]
+
+The above example defines two environments, called 'env1' and 'env2' \
+(default), each with the options in the \\[common] section and the additional \
+options from their respective sections.
+
+At runtime, apio select the environment to use based on this rules in \
+[b]decreasing[/b] levels of priorities:
+
+- User specified environment name using the --env command line option.
+- The value of default-env if exists in the \\[apio] section.
+- The first env section that is listed in apio.ini.
+
+When apio determines the environment to use, it collects its options from the \
+\\[common] and the env section, with options in the env section having higher \
+priority, and executes the command with these resolved environment options.
+
+Following is a list of the options that can appear in the \\[common] and \
+the \\[env:*] section. The terms 'required' and 'optional' refers to the \
+presence of the options in the options resolved from the \\[common] and the \
+\\[env:name] sections.
 """
 
 
 @click.command(
-    name="options",
+    name="apio.ini",
     cls=cmd_util.ApioCommand,
     short_help="Apio.ini options.",
-    help=APIO_INFO_OPTIONS_HELP,
+    help=APIO_INFO_APIO_INO_HELP,
 )
 @click.argument("option", nargs=1, required=False)
-def _options_cli(
+def _apio_ini_cli(
     # Argument
     option: str,
 ):
-    """Implements the 'apio info options' command."""
+    """Implements the 'apio info apio.ini' command."""
 
     # -- If option was specified, validate it.
     if option:
@@ -163,7 +205,7 @@ def _options_cli(
             cerror(f"No such api.ini option: '{option}'")
             cout(
                 "For the list of all apio.ini options, type "
-                "'apio info options'.",
+                "'apio info apio.ini'.",
                 style=INFO,
             )
             sys.exit(1)
@@ -183,7 +225,7 @@ def _options_cli(
         req = "REQUIRED" if is_required else "OPTIONAL"
         styled_option = cstyle(opt.upper(), style=TITLE)
         cout()
-        cout(f"{styled_option} ({req})")
+        cout(f"{styled_option} option ({req})")
 
         # -- Print the option's text.
         text = project.ENV_OPTIONS[opt]
@@ -195,7 +237,7 @@ def _options_cli(
 
 # -- Text in the rich-text format of the python rich library.
 APIO_INFO_FILES_HELP = """
-The command 'apio info options' provides information about the various \
+The command 'apio info files' provides information about the various \
 files types used in an Apio project.
 
 Examples:[code]
@@ -208,7 +250,7 @@ Following are apio conventions for project file names. The list does not \
 include files that are specific to a particular architecture or toolchain.
 
 [b]apio.ini[/] - This is a required project configuration configuration. \
-Run 'apio info options' for the list of supported options.
+Run 'apio info apio.ini' for the list of supported options.
 
 [b]*.v, *.sv[/] - Verilog and System Verilog synthesis sources files \
 (unless they match the testbench patterns below).
@@ -577,7 +619,7 @@ SUBGROUPS = [
     ApioSubgroup(
         "Documentation",
         [
-            _options_cli,
+            _apio_ini_cli,
             _cli_cli,
             _files_cli,
             _resources_cli,

--- a/apio/commands/apio_lint.py
+++ b/apio/commands/apio_lint.py
@@ -7,6 +7,7 @@
 # -- License GPLv2
 """Implementation of 'apio lint' command"""
 import sys
+from typing import Optional
 from pathlib import Path
 import click
 from apio.managers.scons import SCons
@@ -83,6 +84,7 @@ Examples:[code]
 @options.top_module_option_gen(
     help="Restrict linting to this module and its dependencies."
 )
+@options.env_option
 @options.project_dir_option
 def cli(
     _: click.Context,
@@ -92,6 +94,7 @@ def cli(
     warn: str,
     all_: bool,
     top_module: str,
+    env: Optional[str],
     project_dir: Path,
 ):
     """Lint the source code."""
@@ -103,6 +106,7 @@ def cli(
     apio_ctx = ApioContext(
         scope=ApioContextScope.PROJECT_REQUIRED,
         project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Create the scons manager.

--- a/apio/commands/apio_lint.py
+++ b/apio/commands/apio_lint.py
@@ -95,7 +95,7 @@ def cli(
     all_: bool,
     top_module: str,
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
 ):
     """Lint the source code."""
 

--- a/apio/commands/apio_report.py
+++ b/apio/commands/apio_report.py
@@ -8,6 +8,7 @@
 """Implementation of 'apio' report' command"""
 
 import sys
+from typing import Optional
 from pathlib import Path
 import click
 from apio.managers.scons import SCons
@@ -38,11 +39,13 @@ Examples:[code]
     help=APIO_REPORT_HELP,
 )
 @click.pass_context
+@options.env_option
 @options.project_dir_option
 @options.verbose_option
 def cli(
     _: click.Context,
     # Options
+    env: Optional[str],
     project_dir: Path,
     verbose: bool,
 ):
@@ -52,6 +55,7 @@ def cli(
     apio_ctx = ApioContext(
         scope=ApioContextScope.PROJECT_REQUIRED,
         project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Create the scons manager.

--- a/apio/commands/apio_report.py
+++ b/apio/commands/apio_report.py
@@ -46,7 +46,7 @@ def cli(
     _: click.Context,
     # Options
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
     verbose: bool,
 ):
     """Analyze the design and report timing."""

--- a/apio/commands/apio_sim.py
+++ b/apio/commands/apio_sim.py
@@ -77,7 +77,7 @@ def cli(
     # Options
     force: bool,
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
 ):
     """Implements the apio sim command. It simulates a single testbench
     file and shows graphically the signal graphs.

--- a/apio/commands/apio_sim.py
+++ b/apio/commands/apio_sim.py
@@ -8,6 +8,7 @@
 """Implementation of 'apio sim' command"""
 
 import sys
+from typing import Optional
 from pathlib import Path
 import click
 from apio.common.apio_console import cout
@@ -67,6 +68,7 @@ simulation.
 @click.pass_context
 @click.argument("testbench", nargs=1, required=False)
 @options.force_option_gen(help="Force simulation.")
+@options.env_option
 @options.project_dir_option
 def cli(
     _: click.Context,
@@ -74,6 +76,7 @@ def cli(
     testbench: str,
     # Options
     force: bool,
+    env: Optional[str],
     project_dir: Path,
 ):
     """Implements the apio sim command. It simulates a single testbench
@@ -84,6 +87,7 @@ def cli(
     apio_ctx = ApioContext(
         scope=ApioContextScope.PROJECT_REQUIRED,
         project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Create the scons manager.

--- a/apio/commands/apio_test.py
+++ b/apio/commands/apio_test.py
@@ -8,6 +8,7 @@
 """Implementation of 'apio test' command"""
 
 import sys
+from typing import Optional
 from pathlib import Path
 import click
 from apio.managers.scons import SCons
@@ -54,6 +55,7 @@ of the signals, refer to the 'apio sim' command.
 )
 @click.pass_context
 @click.argument("testbench_file", nargs=1, required=False)
+@options.env_option
 @options.project_dir_option
 # @options.testbench
 def cli(
@@ -61,13 +63,16 @@ def cli(
     # Arguments
     testbench_file: str,
     # Options
+    env: Optional[str],
     project_dir: Path,
 ):
     """Implements the test command."""
 
     # -- Create the apio context.
     apio_ctx = ApioContext(
-        scope=ApioContextScope.PROJECT_REQUIRED, project_dir_arg=project_dir
+        scope=ApioContextScope.PROJECT_REQUIRED,
+        project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Create the scons manager.

--- a/apio/commands/apio_test.py
+++ b/apio/commands/apio_test.py
@@ -64,7 +64,7 @@ def cli(
     testbench_file: str,
     # Options
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
 ):
     """Implements the test command."""
 

--- a/apio/commands/apio_upload.py
+++ b/apio/commands/apio_upload.py
@@ -103,7 +103,7 @@ def cli(
     ftdi_idx: int,
     sram: bool,
     env: Optional[str],
-    project_dir: Path,
+    project_dir: Optional[Path],
 ):
     """Implements the upload command."""
 

--- a/apio/commands/apio_upload.py
+++ b/apio/commands/apio_upload.py
@@ -8,6 +8,7 @@
 """Implementation of 'apio upload' command"""
 
 import sys
+from typing import Optional
 from pathlib import Path
 import click
 from apio.managers.scons import SCons
@@ -93,6 +94,7 @@ to grant the necessary permissions to access USB devices.
 @serial_port_option
 @ftdi_idx_option
 @sram_option
+@options.env_option
 @options.project_dir_option
 def cli(
     _: click.Context,
@@ -100,13 +102,16 @@ def cli(
     serial_port: str,
     ftdi_idx: int,
     sram: bool,
+    env: Optional[str],
     project_dir: Path,
 ):
     """Implements the upload command."""
 
     # -- Create a apio context.
     apio_ctx = ApioContext(
-        scope=ApioContextScope.PROJECT_REQUIRED, project_dir_arg=project_dir
+        scope=ApioContextScope.PROJECT_REQUIRED,
+        project_dir_arg=project_dir,
+        env_arg=env,
     )
 
     # -- Create the drivers manager.

--- a/apio/commands/options.py
+++ b/apio/commands/options.py
@@ -101,6 +101,16 @@ def dst_option_gen(*, help: str):
 # -- Static options
 # ---------------------------
 
+env_option = click.option(
+    "env",  # Var name.
+    "-e",
+    "--env",
+    type=str,
+    default=None,
+    metavar="name",
+    help="Set the apio.ini env.",
+    cls=cmd_util.ApioOption,
+)
 
 project_dir_option = click.option(
     "project_dir",  # Var name.

--- a/apio/common/proto/apio.proto
+++ b/apio/common/proto/apio.proto
@@ -95,10 +95,14 @@ message Environment {
 
 // Information about the resolved active env from apio.ini.
 message ApioEnvParams {
-  required string board_id = 1;
-  required string top_module = 2;
-  // The value of 'yosys-synth-extra-options' from apio.ini.
-  optional string yosys_synth_extra_options = 3 [default = ""];
+  // The name of the apio.ini env used.
+  required string env_name = 1;
+  // The board id. E.g. 'alhambra-ii'.
+  required string board_id = 2;
+  // The name of the top verilog module, e.g. 'main'.
+  required string top_module = 3;
+  // This is the value of 'yosys-synth-extra-options' from apio.ini.
+  optional string yosys_synth_extra_options = 4 [default = ""];
 }
 
 // Lint target specific params.

--- a/apio/common/proto/apio.proto
+++ b/apio/common/proto/apio.proto
@@ -93,7 +93,7 @@ message Environment {
   required string trellis_path = 7;
 }
 
-// Information about the resolved active env from apio.ini.
+// Information about the expanded active env from apio.ini.
 message ApioEnvParams {
   // The name of the apio.ini env used.
   required string env_name = 1;

--- a/apio/common/proto/apio_pb2.py
+++ b/apio/common/proto/apio_pb2.py
@@ -30,19 +30,19 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\napio.proto\x12\x11\x61pio.common.proto\"+\n\rIce40FpgaInfo\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0c\n\x04pack\x18\x02 \x02(\t\"9\n\x0c\x45\x63p5FpgaInfo\x12\x0c\n\x04type\x18\x04 \x02(\t\x12\x0c\n\x04pack\x18\x05 \x02(\t\x12\r\n\x05speed\x18\x06 \x02(\t\"\x1f\n\rGowinFpgaInfo\x12\x0e\n\x06\x66\x61mily\x18\x04 \x02(\t\"\xda\x01\n\x08\x46pgaInfo\x12\x0f\n\x07\x66pga_id\x18\x01 \x02(\t\x12\x10\n\x08part_num\x18\x02 \x02(\t\x12\x0c\n\x04size\x18\x03 \x02(\t\x12\x31\n\x05ice40\x18\n \x01(\x0b\x32 .apio.common.proto.Ice40FpgaInfoH\x00\x12/\n\x04\x65\x63p5\x18\x0b \x01(\x0b\x32\x1f.apio.common.proto.Ecp5FpgaInfoH\x00\x12\x31\n\x05gowin\x18\x0c \x01(\x0b\x32 .apio.common.proto.GowinFpgaInfoH\x00\x42\x06\n\x04\x61rch\"I\n\tVerbosity\x12\x12\n\x03\x61ll\x18\x01 \x01(\x08:\x05\x66\x61lse\x12\x14\n\x05synth\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x12\n\x03pnr\x18\x03 \x01(\x08:\x05\x66\x61lse\"\xc5\x01\n\x0b\x45nvironment\x12\x13\n\x0bplatform_id\x18\x01 \x02(\t\x12\x12\n\nis_windows\x18\x02 \x02(\x08\x12\x36\n\rterminal_mode\x18\x03 \x02(\x0e\x32\x1f.apio.common.proto.TerminalMode\x12\x12\n\ntheme_name\x18\x04 \x02(\t\x12\x17\n\x08is_debug\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x12\n\nyosys_path\x18\x06 \x02(\t\x12\x14\n\x0ctrellis_path\x18\x07 \x02(\t\"Z\n\rApioEnvParams\x12\x10\n\x08\x62oard_id\x18\x01 \x02(\t\x12\x12\n\ntop_module\x18\x02 \x02(\t\x12#\n\x19yosys_synth_extra_options\x18\x03 \x01(\t:\x00\"\x98\x01\n\nLintParams\x12\x14\n\ntop_module\x18\x01 \x01(\t:\x00\x12\x1c\n\rverilator_all\x18\x02 \x01(\x08:\x05\x66\x61lse\x12!\n\x12verilator_no_style\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x1a\n\x12verilator_no_warns\x18\x04 \x03(\t\x12\x17\n\x0fverilator_warns\x18\x05 \x03(\t\"Z\n\x0bGraphParams\x12\x37\n\x0boutput_type\x18\x01 \x02(\x0e\x32\".apio.common.proto.GraphOutputType\x12\x12\n\ntop_module\x18\x02 \x01(\t\"3\n\tSimParams\x12\x13\n\ttestbench\x18\x01 \x01(\t:\x00\x12\x11\n\tforce_sim\x18\x02 \x02(\x08\"%\n\x0e\x41pioTestParams\x12\x13\n\ttestbench\x18\x01 \x01(\t:\x00\"&\n\x0cUploadParams\x12\x16\n\x0eprogrammer_cmd\x18\x01 \x01(\t\"\x8b\x02\n\x0cTargetParams\x12-\n\x04lint\x18\n \x01(\x0b\x32\x1d.apio.common.proto.LintParamsH\x00\x12/\n\x05graph\x18\x0b \x01(\x0b\x32\x1e.apio.common.proto.GraphParamsH\x00\x12+\n\x03sim\x18\x0c \x01(\x0b\x32\x1c.apio.common.proto.SimParamsH\x00\x12\x31\n\x04test\x18\r \x01(\x0b\x32!.apio.common.proto.ApioTestParamsH\x00\x12\x31\n\x06upload\x18\x0e \x01(\x0b\x32\x1f.apio.common.proto.UploadParamsH\x00\x42\x08\n\x06target\"5\n\x14RichLibWindowsParams\x12\n\n\x02vt\x18\x01 \x02(\x08\x12\x11\n\ttruecolor\x18\x02 \x02(\x08\"\x97\x03\n\x0bSconsParams\x12\x11\n\ttimestamp\x18\x01 \x02(\t\x12)\n\x04\x61rch\x18\x02 \x02(\x0e\x32\x1b.apio.common.proto.ApioArch\x12.\n\tfpga_info\x18\x03 \x02(\x0b\x32\x1b.apio.common.proto.FpgaInfo\x12/\n\tverbosity\x18\x04 \x01(\x0b\x32\x1c.apio.common.proto.Verbosity\x12\x33\n\x0b\x65nvironment\x18\x05 \x02(\x0b\x32\x1e.apio.common.proto.Environment\x12\x39\n\x0f\x61pio_env_params\x18\x06 \x02(\x0b\x32 .apio.common.proto.ApioEnvParams\x12/\n\x06target\x18\x07 \x01(\x0b\x32\x1f.apio.common.proto.TargetParams\x12H\n\x17rich_lib_windows_params\x18\x08 \x01(\x0b\x32\'.apio.common.proto.RichLibWindowsParams*@\n\x08\x41pioArch\x12\x14\n\x10\x41RCH_UNSPECIFIED\x10\x00\x12\t\n\x05ICE40\x10\x01\x12\x08\n\x04\x45\x43P5\x10\x02\x12\t\n\x05GOWIN\x10\x03*_\n\x0cTerminalMode\x12\x18\n\x14TERMINAL_UNSPECIFIED\x10\x00\x12\x11\n\rAUTO_TERMINAL\x10\x01\x12\x12\n\x0e\x46ORCE_TERMINAL\x10\x02\x12\x0e\n\nFORCE_PIPE\x10\x03*B\n\x0fGraphOutputType\x12\x14\n\x10TYPE_UNSPECIFIED\x10\x00\x12\x07\n\x03SVG\x10\x01\x12\x07\n\x03PNG\x10\x02\x12\x07\n\x03PDF\x10\x03')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\napio.proto\x12\x11\x61pio.common.proto\"+\n\rIce40FpgaInfo\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0c\n\x04pack\x18\x02 \x02(\t\"9\n\x0c\x45\x63p5FpgaInfo\x12\x0c\n\x04type\x18\x04 \x02(\t\x12\x0c\n\x04pack\x18\x05 \x02(\t\x12\r\n\x05speed\x18\x06 \x02(\t\"\x1f\n\rGowinFpgaInfo\x12\x0e\n\x06\x66\x61mily\x18\x04 \x02(\t\"\xda\x01\n\x08\x46pgaInfo\x12\x0f\n\x07\x66pga_id\x18\x01 \x02(\t\x12\x10\n\x08part_num\x18\x02 \x02(\t\x12\x0c\n\x04size\x18\x03 \x02(\t\x12\x31\n\x05ice40\x18\n \x01(\x0b\x32 .apio.common.proto.Ice40FpgaInfoH\x00\x12/\n\x04\x65\x63p5\x18\x0b \x01(\x0b\x32\x1f.apio.common.proto.Ecp5FpgaInfoH\x00\x12\x31\n\x05gowin\x18\x0c \x01(\x0b\x32 .apio.common.proto.GowinFpgaInfoH\x00\x42\x06\n\x04\x61rch\"I\n\tVerbosity\x12\x12\n\x03\x61ll\x18\x01 \x01(\x08:\x05\x66\x61lse\x12\x14\n\x05synth\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x12\n\x03pnr\x18\x03 \x01(\x08:\x05\x66\x61lse\"\xc5\x01\n\x0b\x45nvironment\x12\x13\n\x0bplatform_id\x18\x01 \x02(\t\x12\x12\n\nis_windows\x18\x02 \x02(\x08\x12\x36\n\rterminal_mode\x18\x03 \x02(\x0e\x32\x1f.apio.common.proto.TerminalMode\x12\x12\n\ntheme_name\x18\x04 \x02(\t\x12\x17\n\x08is_debug\x18\x05 \x01(\x08:\x05\x66\x61lse\x12\x12\n\nyosys_path\x18\x06 \x02(\t\x12\x14\n\x0ctrellis_path\x18\x07 \x02(\t\"l\n\rApioEnvParams\x12\x10\n\x08\x65nv_name\x18\x01 \x02(\t\x12\x10\n\x08\x62oard_id\x18\x02 \x02(\t\x12\x12\n\ntop_module\x18\x03 \x02(\t\x12#\n\x19yosys_synth_extra_options\x18\x04 \x01(\t:\x00\"\x98\x01\n\nLintParams\x12\x14\n\ntop_module\x18\x01 \x01(\t:\x00\x12\x1c\n\rverilator_all\x18\x02 \x01(\x08:\x05\x66\x61lse\x12!\n\x12verilator_no_style\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x1a\n\x12verilator_no_warns\x18\x04 \x03(\t\x12\x17\n\x0fverilator_warns\x18\x05 \x03(\t\"Z\n\x0bGraphParams\x12\x37\n\x0boutput_type\x18\x01 \x02(\x0e\x32\".apio.common.proto.GraphOutputType\x12\x12\n\ntop_module\x18\x02 \x01(\t\"3\n\tSimParams\x12\x13\n\ttestbench\x18\x01 \x01(\t:\x00\x12\x11\n\tforce_sim\x18\x02 \x02(\x08\"%\n\x0e\x41pioTestParams\x12\x13\n\ttestbench\x18\x01 \x01(\t:\x00\"&\n\x0cUploadParams\x12\x16\n\x0eprogrammer_cmd\x18\x01 \x01(\t\"\x8b\x02\n\x0cTargetParams\x12-\n\x04lint\x18\n \x01(\x0b\x32\x1d.apio.common.proto.LintParamsH\x00\x12/\n\x05graph\x18\x0b \x01(\x0b\x32\x1e.apio.common.proto.GraphParamsH\x00\x12+\n\x03sim\x18\x0c \x01(\x0b\x32\x1c.apio.common.proto.SimParamsH\x00\x12\x31\n\x04test\x18\r \x01(\x0b\x32!.apio.common.proto.ApioTestParamsH\x00\x12\x31\n\x06upload\x18\x0e \x01(\x0b\x32\x1f.apio.common.proto.UploadParamsH\x00\x42\x08\n\x06target\"5\n\x14RichLibWindowsParams\x12\n\n\x02vt\x18\x01 \x02(\x08\x12\x11\n\ttruecolor\x18\x02 \x02(\x08\"\x97\x03\n\x0bSconsParams\x12\x11\n\ttimestamp\x18\x01 \x02(\t\x12)\n\x04\x61rch\x18\x02 \x02(\x0e\x32\x1b.apio.common.proto.ApioArch\x12.\n\tfpga_info\x18\x03 \x02(\x0b\x32\x1b.apio.common.proto.FpgaInfo\x12/\n\tverbosity\x18\x04 \x01(\x0b\x32\x1c.apio.common.proto.Verbosity\x12\x33\n\x0b\x65nvironment\x18\x05 \x02(\x0b\x32\x1e.apio.common.proto.Environment\x12\x39\n\x0f\x61pio_env_params\x18\x06 \x02(\x0b\x32 .apio.common.proto.ApioEnvParams\x12/\n\x06target\x18\x07 \x01(\x0b\x32\x1f.apio.common.proto.TargetParams\x12H\n\x17rich_lib_windows_params\x18\x08 \x01(\x0b\x32\'.apio.common.proto.RichLibWindowsParams*@\n\x08\x41pioArch\x12\x14\n\x10\x41RCH_UNSPECIFIED\x10\x00\x12\t\n\x05ICE40\x10\x01\x12\x08\n\x04\x45\x43P5\x10\x02\x12\t\n\x05GOWIN\x10\x03*_\n\x0cTerminalMode\x12\x18\n\x14TERMINAL_UNSPECIFIED\x10\x00\x12\x11\n\rAUTO_TERMINAL\x10\x01\x12\x12\n\x0e\x46ORCE_TERMINAL\x10\x02\x12\x0e\n\nFORCE_PIPE\x10\x03*B\n\x0fGraphOutputType\x12\x14\n\x10TYPE_UNSPECIFIED\x10\x00\x12\x07\n\x03SVG\x10\x01\x12\x07\n\x03PNG\x10\x02\x12\x07\n\x03PDF\x10\x03')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'apio_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_APIOARCH']._serialized_start=1872
-  _globals['_APIOARCH']._serialized_end=1936
-  _globals['_TERMINALMODE']._serialized_start=1938
-  _globals['_TERMINALMODE']._serialized_end=2033
-  _globals['_GRAPHOUTPUTTYPE']._serialized_start=2035
-  _globals['_GRAPHOUTPUTTYPE']._serialized_end=2101
+  _globals['_APIOARCH']._serialized_start=1890
+  _globals['_APIOARCH']._serialized_end=1954
+  _globals['_TERMINALMODE']._serialized_start=1956
+  _globals['_TERMINALMODE']._serialized_end=2051
+  _globals['_GRAPHOUTPUTTYPE']._serialized_start=2053
+  _globals['_GRAPHOUTPUTTYPE']._serialized_end=2119
   _globals['_ICE40FPGAINFO']._serialized_start=33
   _globals['_ICE40FPGAINFO']._serialized_end=76
   _globals['_ECP5FPGAINFO']._serialized_start=78
@@ -56,21 +56,21 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_ENVIRONMENT']._serialized_start=467
   _globals['_ENVIRONMENT']._serialized_end=664
   _globals['_APIOENVPARAMS']._serialized_start=666
-  _globals['_APIOENVPARAMS']._serialized_end=756
-  _globals['_LINTPARAMS']._serialized_start=759
-  _globals['_LINTPARAMS']._serialized_end=911
-  _globals['_GRAPHPARAMS']._serialized_start=913
-  _globals['_GRAPHPARAMS']._serialized_end=1003
-  _globals['_SIMPARAMS']._serialized_start=1005
-  _globals['_SIMPARAMS']._serialized_end=1056
-  _globals['_APIOTESTPARAMS']._serialized_start=1058
-  _globals['_APIOTESTPARAMS']._serialized_end=1095
-  _globals['_UPLOADPARAMS']._serialized_start=1097
-  _globals['_UPLOADPARAMS']._serialized_end=1135
-  _globals['_TARGETPARAMS']._serialized_start=1138
-  _globals['_TARGETPARAMS']._serialized_end=1405
-  _globals['_RICHLIBWINDOWSPARAMS']._serialized_start=1407
-  _globals['_RICHLIBWINDOWSPARAMS']._serialized_end=1460
-  _globals['_SCONSPARAMS']._serialized_start=1463
-  _globals['_SCONSPARAMS']._serialized_end=1870
+  _globals['_APIOENVPARAMS']._serialized_end=774
+  _globals['_LINTPARAMS']._serialized_start=777
+  _globals['_LINTPARAMS']._serialized_end=929
+  _globals['_GRAPHPARAMS']._serialized_start=931
+  _globals['_GRAPHPARAMS']._serialized_end=1021
+  _globals['_SIMPARAMS']._serialized_start=1023
+  _globals['_SIMPARAMS']._serialized_end=1074
+  _globals['_APIOTESTPARAMS']._serialized_start=1076
+  _globals['_APIOTESTPARAMS']._serialized_end=1113
+  _globals['_UPLOADPARAMS']._serialized_start=1115
+  _globals['_UPLOADPARAMS']._serialized_end=1153
+  _globals['_TARGETPARAMS']._serialized_start=1156
+  _globals['_TARGETPARAMS']._serialized_end=1423
+  _globals['_RICHLIBWINDOWSPARAMS']._serialized_start=1425
+  _globals['_RICHLIBWINDOWSPARAMS']._serialized_end=1478
+  _globals['_SCONSPARAMS']._serialized_start=1481
+  _globals['_SCONSPARAMS']._serialized_end=1888
 # @@protoc_insertion_point(module_scope)

--- a/apio/common/proto/apio_pb2.pyi
+++ b/apio/common/proto/apio_pb2.pyi
@@ -114,14 +114,16 @@ class Environment(_message.Message):
     def __init__(self, platform_id: _Optional[str] = ..., is_windows: bool = ..., terminal_mode: _Optional[_Union[TerminalMode, str]] = ..., theme_name: _Optional[str] = ..., is_debug: bool = ..., yosys_path: _Optional[str] = ..., trellis_path: _Optional[str] = ...) -> None: ...
 
 class ApioEnvParams(_message.Message):
-    __slots__ = ("board_id", "top_module", "yosys_synth_extra_options")
+    __slots__ = ("env_name", "board_id", "top_module", "yosys_synth_extra_options")
+    ENV_NAME_FIELD_NUMBER: _ClassVar[int]
     BOARD_ID_FIELD_NUMBER: _ClassVar[int]
     TOP_MODULE_FIELD_NUMBER: _ClassVar[int]
     YOSYS_SYNTH_EXTRA_OPTIONS_FIELD_NUMBER: _ClassVar[int]
+    env_name: str
     board_id: str
     top_module: str
     yosys_synth_extra_options: str
-    def __init__(self, board_id: _Optional[str] = ..., top_module: _Optional[str] = ..., yosys_synth_extra_options: _Optional[str] = ...) -> None: ...
+    def __init__(self, env_name: _Optional[str] = ..., board_id: _Optional[str] = ..., top_module: _Optional[str] = ..., yosys_synth_extra_options: _Optional[str] = ...) -> None: ...
 
 class LintParams(_message.Message):
     __slots__ = ("top_module", "verilator_all", "verilator_no_style", "verilator_no_warns", "verilator_warns")

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -11,26 +11,69 @@
 
 import sys
 from abc import ABC, abstractmethod
-
-from configparser import ConfigParser
+import re
+import configparser
+from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, Optional, Union, Any, List
+from typing import Dict, Optional, Union, Any, List, Tuple
 from configobj import ConfigObj
-from apio.common.apio_console import cout, cerror
+from apio.utils import util
+from apio.common.apio_console import cout, cerror, cwarning
 from apio.common.apio_styles import INFO, SUCCESS
 
 
 DEFAULT_TOP_MODULE = "main"
+
+ENV_NAME_REGEX = re.compile(r"^[a-z][a-z0-9-]*$")
+
+ENV_NAME_HINT = (
+    "Env names should start with a-z, "
+    "followed by any number of a-z, 0-9, and '-'."
+)
 
 TOP_COMMENT = """\
 APIO project configuration file. For details see
 https://github.com/FPGAwars/apio/wiki/Project-configuration-file
 """
 
+# -- Apio options. These are the options that appear in the [apio] section.
+# -- They are not subject to inheritance and resolution.
+
 # -- The options docs here are formatted in the rich-text format of the
 # -- python rich library. See apio_info.py to see how they are
 # -- used.
-BOARD_OPTION_DOC = """
+APIO_DEFAULT_ENV_DOC = """
+The option 'default-env' selects the default env to use if --env is not \
+specified on the command line. Without it, the first env in apio.ini is \
+used as the default. This option is useful when apio.ini has more than one \
+env.
+
+Example:[code]
+  [apio]
+  default-env = bar
+
+  [env:foo]
+  ...
+
+  [env:bar]
+  ...[/code]
+"""
+
+APIO_OPTIONS = {
+    # -- Selecting the env to use if not overridden in command line. Otherwise
+    # -- the first env is the default.
+    "default-env": APIO_DEFAULT_ENV_DOC,
+}
+
+
+# -- Env options. These are options that appear in the [common] and [env:*]
+# -- sections of apio.ini. The 'require' attribute refers to their apperance
+# -- in the env options after resolving the inheritance.
+
+# -- The options docs here are formatted in the rich-text format of the
+# -- python rich library. See apio_info.py to see how they are
+# -- used.
+ENV_BOARD_OPTION_DOC = """
 The option 'board' specifies the board definition that is used by the \
 project. The board ID must be one of the board IDs, such as 'alhambra-ii', \
 that is listed by the command 'apio boards'.
@@ -47,7 +90,7 @@ If the project requires custom definitions, you can add custom \
 directory, and Apio will use them instead.
 """
 
-TOP_MODULE_OPTION_DOC = """
+ENV_TOP_MODULE_OPTION_DOC = """
 The option 'top-module' specifies the name of the top module of the design. \
 If 'top-module' is not specified, Apio assumes the default name 'main'; \
 however, it is a good practice to always explicitly specify the top module.
@@ -56,7 +99,7 @@ Example:[code]
   top-module = my_main[/code]
 """
 
-DEFAULT_TESTBENCH_DOC = """
+ENV_DEFAULT_TESTBENCH_DOC = """
 The option 'default-testbench' is useful in projects that have more than \
 a single testbench file, because it allows specifying the default testbench \
 that will be simulated when the command 'apio sim' is run without a testbench \
@@ -71,7 +114,7 @@ Example:[code]
   default-testbench = my_module_tb.sv[/code]
 """
 
-FORMAT_VERIBLE_OPTIONS_DOC = """
+ENV_FORMAT_VERIBLE_OPTIONS_DOC = """
 The option 'format-verible-options' allows controlling the operation of the \
 'apio format' command by specifying additional options to the underlying \
 'verible' formatter.
@@ -85,7 +128,7 @@ For the list of the Verible formatter options, run the command \
 'apio raw -- verible-verilog-format --helpfull'
 """
 
-YOSYS_SYNTH_EXTRA_OPTIONS_DOC = """
+ENV_YOSYS_SYNTH_EXTRA_OPTIONS_DOC = """
 The option 'yosys-synth-extra-options' allows adding options to the \
 yosys synth command. In the example below, it adds the option '-dsp', \
 which enables for some FPGAs the use of DSP cells to implement multiply \
@@ -96,21 +139,21 @@ Example:[code]
   yosys-synth-extra-options = -dsp[/code]
 """
 
-OPTIONS = {
+ENV_OPTIONS = {
     # -- The board name.
-    "board": BOARD_OPTION_DOC,
+    "board": ENV_BOARD_OPTION_DOC,
     # -- The top module name. Default is 'main'.
-    "top-module": TOP_MODULE_OPTION_DOC,
+    "top-module": ENV_TOP_MODULE_OPTION_DOC,
     # -- The default testbench name for 'apio sim'.
-    "default-testbench": DEFAULT_TESTBENCH_DOC,
+    "default-testbench": ENV_DEFAULT_TESTBENCH_DOC,
     # -- Multi line list of verible options for 'apio format'
-    "format-verible-options": FORMAT_VERIBLE_OPTIONS_DOC,
+    "format-verible-options": ENV_FORMAT_VERIBLE_OPTIONS_DOC,
     # -- Additional option for the yosys synth command (inside the -p arg).
-    "yosys-synth-extra-options": YOSYS_SYNTH_EXTRA_OPTIONS_DOC,
+    "yosys-synth-extra-options": ENV_YOSYS_SYNTH_EXTRA_OPTIONS_DOC,
 }
 
 # -- The subset of the options in OPTIONS that are required.
-REQUIRED_OPTIONS = {
+ENV_REQUIRED_OPTIONS = {
     "board",
 }
 
@@ -133,70 +176,236 @@ class Project:
     apio.ini file.
     """
 
-    def __init__(self, options: Dict[str, str], resolver: ProjectResolver):
-        """Construct with given {name, value} options dict. To validate the
-        option call validate()."""
-        self._options = options
-        self._validate(resolver)
+    def __init__(
+        self,
+        *,
+        apio_section: Optional[Dict[str, str]],
+        common_section: Optional[Dict[str, str]],
+        env_sections: Dict[str, Dict[str, str]],
+        resolver: ProjectResolver,
+    ):
+        """Construct a Project object with given options sections and a
+        resolver with context information."""
 
-    def __str__(self):
-        """For debugging."""
-        lines = ["Project options:"]
-        for name, val in self._options.items():
-            lines.append(f"  {name} = {val}")
-        return "\n".join(lines)
+        if util.is_debug():
+            print(f"Parsed [apio] section:\n  {apio_section}")
+            print(f"Parsed [common] section:\n  {common_section}")
+            print(f"Parsed [env:*] sections:\n  {env_sections}")
 
-    def _validate(self, resolver: ProjectResolver):
-        """Validates the options. Exists with an error message on any problem.
-        'resolver' is an object that allows to validate the board name and
-        to set the board option to a new board name if a legacy one was
-        specified.
-        """
+        # -- Validate the sections.
+        Project.validate_sections(
+            apio_section=apio_section,
+            common_section=common_section,
+            env_sections=env_sections,
+            resolver=resolver,
+        )
 
-        # -- Check that all the required options are present.
-        for option in REQUIRED_OPTIONS:
-            if option not in self._options:
-                cerror(f"Missing option '{option}' in apio.ini.")
+        # -- Determine active env name and options.
+        self._env_name = Project.resolve_default_env_name(
+            apio_section, env_sections
+        )
+        self._env_options = Project.resolve_env_options(
+            self._env_name, common_section, env_sections
+        )
+        if util.is_debug():
+            print(f"Resolved env name: {self._env_name}")
+            print(f"Resolved env options: {self._env_options}")
+
+        # TODO: Debug code. Remove.
+        # print()
+        # print(f"Parsed [apio] section: {apio_section}")
+        # print(f"Parsed [common] section: {common_section}")
+        # print(f"Parsed [env:*] sections: {env_sections}")
+        # print(f"Resolved env name: {self._env_name}")
+        # print(f"Resolved env options: {self._env_options}")
+        # print()
+
+        # -- Validate the resolved env. This is where we check for required
+        # -- options.
+        Project.validate_resolved_env(
+            self._env_name, self._env_options, resolver
+        )
+
+    @staticmethod
+    def validate_apio_ini_env_name(env_name: str):
+        """Validate the given env name. Use only for env names found in
+        apio.ini, not from command lines or other sources."""
+        if not ENV_NAME_REGEX.match(env_name):
+            cerror(f"Invalid apio env name '{env_name}' in apio.ini.")
+            cout(ENV_NAME_HINT, style=INFO)
+            sys.exit(1)
+
+    @staticmethod
+    def validate_sections(
+        apio_section: Optional[Dict[str, str]],
+        common_section: Optional[Dict[str, str]],
+        env_sections: Dict[str, Dict[str, str]],
+        resolver: ProjectResolver,
+    ):
+        """Validate the parsed apio.ini sections."""
+
+        # -- Validate the apio section.
+        Project.validate_apio_section(apio_section, env_sections)
+
+        # -- Validate the common section.
+        Project.validate_env_section("[common]", common_section, resolver)
+
+        # -- Validate the env sections.
+        for env_name, section_options in env_sections.items():
+            Project.validate_apio_ini_env_name(env_name)
+            Project.validate_env_section(
+                f"[env:{env_name}]", section_options, resolver
+            )
+
+    @staticmethod
+    def validate_apio_section(
+        apio_section: Dict[str, str], env_sections: Dict[str, Dict[str, str]]
+    ):
+        """Validate the [apio] section."""
+
+        # -- Look for unknown options.
+        for option in apio_section:
+            if option not in APIO_OPTIONS:
+                cerror(
+                    f"Unknown option '{option} in [apio] section of apio.ini'"
+                )
                 sys.exit(1)
+
+        # -- If 'board' option exists, verify the board exists.
+        default_env_name = apio_section.get("default-env", None)
+        if default_env_name:
+            Project.validate_apio_ini_env_name(default_env_name)
+            if default_env_name not in env_sections:
+                cerror(f"Env '{default_env_name}' not found in apio.ini.")
+                cout(
+                    f"Expecting an env section '{default_env_name}' "
+                    "in apio.ini",
+                    style=INFO,
+                )
+                sys.exit(1)
+
+    @staticmethod
+    def validate_env_section(
+        section_title: str, section_options: Dict[str, str], resolver
+    ):
+        """Validate the options of a section that contains env options. This
+        includes the sections [env:*] and [common]."""
 
         # -- Check that there are no unknown options.
-        for option in self._options:
-            if option not in OPTIONS:
-                cerror(f"Unknown project option '{option}'")
+        for option in section_options:
+            if option not in ENV_OPTIONS:
+                cerror(
+                    f"Unknown option '{option}' in {section_title} "
+                    "section of apio.ini."
+                )
                 sys.exit(1)
+
+        # -- If 'board' option exists, verify the board exists.
+        if "board" in section_options:
+            # -- This exits with an error if board does not exist.
+            resolver.lookup_board_name(section_options["board"])
+
+    @staticmethod
+    def resolve_default_env_name(
+        apio_section: Dict[str, str], env_sections: Dict[str, Dict[str, str]]
+    ) -> str:
+        """Determines the active env name. Sections are assumed to be
+        validated."""
+        # -- Priority #1 (highest): The optional default-env option in the
+        # -- [apio] section.
+        env_name = apio_section.get("default-env", None)
+
+        # -- Priority #2 (lowest): Picking the first env defined in apio.ini.
+        # -- Note that the envs order is preserved in env_sections.
+        if env_name is None:
+            # -- The env sections preserve the order in apio.ini.
+            env_name = list(env_sections.keys())[0]
+
+        # -- Error if the env doesn't exist.
+        if env_name not in env_sections:
+            cerror(f"Env '{env_name}' not found in apio.ini.")
+            cout(
+                f"Expecting an env section '[env:{env_name}] in apio.ini",
+                style=INFO,
+            )
+            sys.exit(1)
+
+        # -- All done.
+        return env_name
+
+    @staticmethod
+    def resolve_env_options(
+        env_name,
+        common_section: Dict[str, str],
+        env_sections: Dict[str, Dict[str, str]],
+    ) -> Tuple[str, Dict[str, str]]:
+        """Returns env name and options. Sections are prevalidated"""
+
+        # -- Get the options of selected env.
+        env_section: Dict[str, str] = env_sections[env_name]
+
+        # -- Merge the options while preserving their order in apio.ini.
+        env_options = {}
+        # -- Add common options that are not in env section
+        for name, val in common_section.items():
+            if name not in env_section:
+                env_options[name] = val
+        # -- Add all the options from the env section.
+        for name, val in env_section.items():
+            env_options[name] = val
+
+        # -- All done.
+        return env_options
+
+    @staticmethod
+    def validate_resolved_env(
+        env_name: str, env_options: Dict[str, str], resolver: ProjectResolver
+    ):
+        """Validate the resolved env options. These are the option after
+        selecting the active env and resolving the options inheritance."""
+
+        # -- Check that all the required options are present.
+        for option in ENV_REQUIRED_OPTIONS:
+            if option not in env_options:
+                cerror(
+                    f"Missing option '{option}' "
+                    f"after resolving env {env_name}."
+                )
+                sys.exit(1)
+
+        # -- We already validated the sections for unknown options so don't
+        # -- need to check here.
 
         # -- Force 'board' to have the canonical name of the board.
         # -- This exists with an error message if the board is unknown.
-        self._options["board"] = resolver.lookup_board_name(
-            self._options["board"]
-        )
+        env_options["board"] = resolver.lookup_board_name(env_options["board"])
 
         # -- If top-module was not specified, fill in the default value.
-        if "top-module" not in self._options:
-            self._options["top-module"] = DEFAULT_TOP_MODULE
+        if "top-module" not in env_options:
+            env_options["top-module"] = DEFAULT_TOP_MODULE
             cout(
-                "Project file has no 'top-module', "
-                f"assuming '{DEFAULT_TOP_MODULE}'.",
+                "Option 'top-module' is missing, "
+                f"using '{DEFAULT_TOP_MODULE}'.",
                 style=INFO,
             )
 
     def get(self, option: str, default: Any = None) -> Union[str, Any]:
-        """Lookup an option value by name. Returns default if not found."""
+        """Lookup an env option value by name. Returns default if not found."""
         # -- If this fails, this is a programming error.
-        assert option in OPTIONS, f"Invalid project option: [{option}]"
+        assert option in ENV_OPTIONS, f"Invalid env option: [{option}]"
 
         # -- Lookup with default
-        return self._options.get(option, default)
+        return self._env_options.get(option, default)
 
     def __getitem__(self, option: str) -> Optional[str]:
-        """Lookup an option value by name using the [] operator. Returns
+        """Lookup an env option value by name using the [] operator. Returns
         None if not found."""
         return self.get(option, None)
 
     def get_as_lines_list(
         self, option: str, default: Any = None
     ) -> Union[List[str], Any]:
-        """Lookup an option value that has a line list format. Returns
+        """Lookup an env option value that has a line list format. Returns
         the list of non empty lines or default if no value. Option
         must be in OPTIONS."""
 
@@ -235,26 +444,75 @@ def load_project_from_file(
         sys.exit(1)
 
     # -- Read and parse the file.
-    parser = ConfigParser()
-    parser.read(file_path)
-
-    # -- Should contain an [env] section.
-    if "env" not in parser.sections():
-        cerror("The file apio.ini has no [env] section.")
+    # -- By using OrderedDict we cause the parser to preserve the order of
+    # -- options in a section. The order of sections is already preserved by
+    # -- default.
+    parser = configparser.ConfigParser(dict_type=OrderedDict)
+    try:
+        parser.read(file_path)
+    except configparser.Error as e:
+        cerror(e)
         sys.exit(1)
 
-    # -- Should not contain any other section.
-    if len(parser.sections()) > 1:
-        cerror("The file apio.ini should contain only an [env] section.")
-        sys.exit(1)
+    # -- Iterate and collect the sections in the order they appear in
+    # -- the apio.ini file. Section names are guaranteed to be unique with
+    # -- no duplicates.
+    sections_names = parser.sections()
 
-    # -- Collect the name/value pairs.
-    options = {}
-    for name, val in parser.items("env"):
-        options[name] = val
+    apio_section = None
+    common_section = None
+    env_sections = {}
+
+    for section_name in sections_names:
+        # -- Handle the [apio[ section.]]
+        if section_name == "apio":
+            if common_section or env_sections:
+                cerror("The [apio] section must be the first section.")
+                sys.exit(1)
+            apio_section = dict(parser.items(section_name))
+            continue
+
+        # -- Handle the [common] section.
+        if section_name == "common":
+            if env_sections:
+                cerror("The [common] section must be before [env:] sections.")
+                sys.exit(1)
+            common_section = dict(parser.items(section_name))
+            continue
+
+        # TODO: Remove this option after this is released.
+        # -- Handle the legacy [env] section.
+        if section_name == "env" and len(sections_names) == 1:
+            # env_sections["default"] = parser.items(section_name)
+            cwarning(
+                "Apio.ini has a legacy [env] section. "
+                "Please rename it to [env:default]."
+            )
+            env_sections["default"] = dict(parser.items(section_name))
+            continue
+
+        # -- Handle the [env:env-name] sections.
+        tokes = section_name.split(":")
+        if len(tokes) == 2 and tokes[0] == "env":
+            env_name = tokes[1]
+            env_sections[env_name] = dict(parser.items(section_name))
+            continue
+
+        # -- Handle unknown section name.
+        cerror(f"Invalid section name '{section_name}' in apio.ini.")
+        cout(
+            "The valid section names are [apio], [common], and [env:env-name]",
+            style=INFO,
+        )
+        sys.exit(1)
 
     # -- Construct the Project object. Its constructor validates the options.
-    return Project(options, resolver)
+    return Project(
+        apio_section=apio_section or {},
+        common_section=common_section or {},
+        env_sections=env_sections,
+        resolver=resolver,
+    )
 
 
 def create_project_file(
@@ -262,7 +520,7 @@ def create_project_file(
     board_name: str,
     top_module: str,
 ):
-    """Creates a new apio project file. Exits on any error."""
+    """Creates a new basic apio project file. Exits on any error."""
 
     # -- Construct the path
     ini_path = project_dir / "apio.ini"

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -39,31 +39,12 @@ https://github.com/FPGAwars/apio/wiki/Project-configuration-file
 # -- Apio options. These are the options that appear in the [apio] section.
 # -- They are not subject to inheritance and resolution.
 
-# -- The options docs here are formatted in the rich-text format of the
-# -- python rich library. See apio_info.py to see how they are
-# -- used.
-APIO_DEFAULT_ENV_DOC = """
-The option 'default-env' selects the default env to use if --env is not \
-specified on the command line. Without it, the first env in apio.ini is \
-used as the default. This option is useful when apio.ini has more than one \
-env.
 
-Example:[code]
-  [apio]
-  default-env = bar
-
-  [env:foo]
-  ...
-
-  [env:bar]
-  ...[/code]
-"""
-
-APIO_OPTIONS = {
+APIO_OPTIONS = [
     # -- Selecting the env to use if not overridden in command line. Otherwise
     # -- the first env is the default.
-    "default-env": APIO_DEFAULT_ENV_DOC,
-}
+    "default-env",
+]
 
 
 # -- Env options. These are options that appear in the [common] and [env:*]

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -235,9 +235,6 @@ class Project:
     ):
         """Validate the parsed apio.ini sections."""
 
-        # -- Validate the apio section.
-        Project.validate_apio_section(apio_section, env_sections)
-
         # -- Validate the common section.
         Project.validate_env_section("[common]", common_section, resolver)
 
@@ -253,11 +250,16 @@ class Project:
                 f"[env:{env_name}]", section_options, resolver
             )
 
+        # -- Validate the apio section. At this point the env_sections are
+        # -- already validated.
+        Project.validate_apio_section(apio_section, env_sections)
+
     @staticmethod
     def validate_apio_section(
         apio_section: Dict[str, str], env_sections: Dict[str, Dict[str, str]]
     ):
-        """Validate the [apio] section."""
+        """Validate the [apio] section. 'env_sections' are assumed to be
+        validated."""
 
         # -- Look for unknown options.
         for option in apio_section:

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -146,8 +146,6 @@ class ProjectResolver(ABC):
     and we use it to avoid a cyclic import between Project and ApioContext.
     """
 
-    # pylint: disable=too-few-public-methods
-
     @abstractmethod
     def lookup_board_name(
         self,

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -188,36 +188,36 @@ class Project:
         )
 
         # -- Determine active env name and options.
-        self._env_name = Project.resolve_default_env_name(
+        self.env_name = Project.resolve_default_env_name(
             apio_section, env_sections
         )
-        self._env_options = Project.resolve_env_options(
-            common_section, env_sections[self._env_name]
+        self.env_options = Project.resolve_env_options(
+            common_section, env_sections[self.env_name]
         )
         if util.is_debug():
-            print(f"Resolved env name: {self._env_name}")
-            print(f"Resolved env options: {self._env_options}")
+            print(f"Resolved env name: {self.env_name}")
+            print(f"Resolved env options: {self.env_options}")
 
         # TODO: Debug code. Remove.
         print()
         print(f"Parsed [apio] section: {apio_section}")
         print(f"Parsed [common] section: {common_section}")
         print(f"Parsed [env:*] sections: {env_sections}")
-        print(f"Resolved env name: {self._env_name}")
-        print(f"Resolved env options: {self._env_options}")
+        print(f"Resolved env name: {self.env_name}")
+        print(f"Resolved env options: {self.env_options}")
         print()
 
         # -- Validate the resolved env. This is where we check for required
         # -- options.
-        Project.validate_resolved_env(self._env_options, self._env_name)
+        Project.validate_resolved_env(self.env_options, self.env_name)
 
         # -- Patch board and top-module options in the resolved options.
-        Project.patch_resolved_options(self._env_options, resolver)
+        Project.patch_resolved_options(self.env_options, resolver)
 
-        print(f"Patched env options: {self._env_options}")
+        print(f"Patched env options: {self.env_options}")
 
         if util.is_debug():
-            print(f"Patched env options: {self._env_options}")
+            print(f"Patched env options: {self.env_options}")
 
     @staticmethod
     def validate_sections(
@@ -411,7 +411,7 @@ class Project:
         assert option in ENV_OPTIONS, f"Invalid env option: [{option}]"
 
         # -- Lookup with default
-        return self._env_options.get(option, default)
+        return self.env_options.get(option, default)
 
     def __getitem__(self, option: str) -> Optional[str]:
         """Lookup an env option value by name using the [] operator. Returns

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -19,7 +19,7 @@ from typing import Dict, Optional, Union, Any, List, Tuple
 from configobj import ConfigObj
 from apio.utils import util
 from apio.common.apio_console import cout, cerror, cwarning
-from apio.common.apio_styles import INFO, SUCCESS
+from apio.common.apio_styles import INFO, SUCCESS, EMPH2
 
 
 DEFAULT_TOP_MODULE = "main"
@@ -178,9 +178,14 @@ class Project:
         # pylint: disable=too-many-arguments
 
         if util.is_debug():
-            print(f"Parsed [apio] section:\n  {apio_section}")
-            print(f"Parsed [common] section:\n  {common_section}")
-            print(f"Parsed [env:*] sections:\n  {env_sections}")
+            cout()
+            cout("Parsed [apio] section:", style=EMPH2)
+            cout(f"  {apio_section}\n")
+            cout("Parsed [common] section:", style=EMPH2)
+            cout(f"  {common_section}\n")
+            for env_name, section_options in env_sections.items():
+                cout(f"Parsed [env:{env_name}] section:", style=EMPH2)
+                cout(f"{section_options}\n")
 
         # -- Validate the env_arg format
         if env_arg is not None:
@@ -205,8 +210,10 @@ class Project:
             common_section, env_sections[self.env_name]
         )
         if util.is_debug():
-            print(f"Resolved env name: {self.env_name}")
-            print(f"Resolved env options: {self.env_options}")
+            cout("Resolved env name:", style=EMPH2)
+            cout(f"  {self.env_name}\n")
+            cout("Resolved env options:", style=EMPH2)
+            cout(f"  {self.env_options}\n")
 
         # -- Validate the resolved env. This is where we check for required
         # -- options.
@@ -216,7 +223,8 @@ class Project:
         Project.patch_resolved_options(self.env_options, resolver)
 
         if util.is_debug():
-            print(f"Patched env options: {self.env_options}")
+            cout("Patched env options:", style=EMPH2)
+            cout(f"  {self.env_options}\n")
 
     @staticmethod
     def validate_sections(

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -383,8 +383,8 @@ class Project:
         for option in ENV_REQUIRED_OPTIONS:
             if option not in result:
                 cerror(
-                    f"Missing option '{option}' "
-                    f"after resolving env {env_name}."
+                    f"Missing required option '{option}' "
+                    f"for env '{env_name}'."
                 )
                 sys.exit(1)
 

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -208,23 +208,12 @@ class Project:
             print(f"Resolved env name: {self.env_name}")
             print(f"Resolved env options: {self.env_options}")
 
-        # TODO: Debug code. Remove.
-        print()
-        print(f"Parsed [apio] section: {apio_section}")
-        print(f"Parsed [common] section: {common_section}")
-        print(f"Parsed [env:*] sections: {env_sections}")
-        print(f"Resolved env name: {self.env_name}")
-        print(f"Resolved env options: {self.env_options}")
-        print()
-
         # -- Validate the resolved env. This is where we check for required
         # -- options.
         Project.validate_resolved_env(self.env_options, self.env_name)
 
         # -- Patch board and top-module options in the resolved options.
         Project.patch_resolved_options(self.env_options, resolver)
-
-        print(f"Patched env options: {self.env_options}")
 
         if util.is_debug():
             print(f"Patched env options: {self.env_options}")

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -533,11 +533,13 @@ def create_project_file(
     # -- Construct and write the apio.ini file..
     cout(f"Creating {ini_path} file ...")
 
+    section_name = "env:default"
+
     config = ConfigObj(str(ini_path))
     config.initial_comment = TOP_COMMENT.split("\n")
-    config["env"] = {}
-    config["env"]["board"] = board_name
-    config["env"]["top-module"] = top_module
+    config[section_name] = {}
+    config[section_name]["board"] = board_name
+    config[section_name]["top-module"] = top_module
 
     config.write()
     cout(f"The file '{ini_path}' was created successfully.", style=SUCCESS)

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -222,15 +222,6 @@ class Project:
             print(f"Patched env options: {self._env_options}")
 
     @staticmethod
-    def validate_apio_ini_env_name(env_name: str):
-        """Validate the given env name. Use only for env names found in
-        apio.ini, not from command lines or other sources."""
-        if not ENV_NAME_REGEX.match(env_name):
-            cerror(f"Invalid apio env name '{env_name}' in apio.ini.")
-            cout(ENV_NAME_HINT, style=INFO)
-            sys.exit(1)
-
-    @staticmethod
     def validate_sections(
         apio_section: Optional[Dict[str, str]],
         common_section: Optional[Dict[str, str]],
@@ -247,7 +238,12 @@ class Project:
 
         # -- Validate the env sections.
         for env_name, section_options in env_sections.items():
-            Project.validate_apio_ini_env_name(env_name)
+            # -- Validate env name format.
+            if not ENV_NAME_REGEX.match(env_name):
+                cerror(f"Invalid env name '{env_name}' in apio.ini.")
+                cout(ENV_NAME_HINT, style=INFO)
+                sys.exit(1)
+            # -- Validate env section options.
             Project.validate_env_section(
                 f"[env:{env_name}]", section_options, resolver
             )
@@ -266,10 +262,19 @@ class Project:
                 )
                 sys.exit(1)
 
-        # -- If 'board' option exists, verify the board exists.
+        # -- If 'default-env' option exists, verify the env name is valid and
+        # -- and the name exists.
         default_env_name = apio_section.get("default-env", None)
         if default_env_name:
-            Project.validate_apio_ini_env_name(default_env_name)
+            # -- Validate env name format.
+            if not ENV_NAME_REGEX.match(default_env_name):
+                cerror(
+                    f"Invalid default env name '{default_env_name}' "
+                    "in apio.ini."
+                )
+                cout(ENV_NAME_HINT, style=INFO)
+                sys.exit(1)
+            # -- Make sure the env exists.
             if default_env_name not in env_sections:
                 cerror(f"Env '{default_env_name}' not found in apio.ini.")
                 cout(

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -315,6 +315,7 @@ class SCons:
         # -- Populate the Project params.
         result.apio_env_params.MergeFrom(
             ApioEnvParams(
+                env_name=apio_ctx.project.env_name,
                 board_id=project["board"],
                 top_module=project["top-module"],
                 yosys_synth_extra_options=apio_ctx.project.get(
@@ -385,13 +386,18 @@ class SCons:
         # -- to execute the apio command)
         start_time = time.time()
 
+        # -- Env name string in color
+        styled_env_name = cstyle(
+            scons_params.apio_env_params.env_name, style=EMPH1
+        )
+
         # -- Board name string in color
         styled_board_id = cstyle(
             scons_params.apio_env_params.board_id, style=EMPH1
         )
 
         # -- Print information on the console
-        cout(f"Processing board {styled_board_id}")
+        cout(f"Processing env {styled_env_name}, board {styled_board_id}")
 
         # -- Print a horizontal line
         cout("-" * terminal_width)

--- a/apio/managers/scons.py
+++ b/apio/managers/scons.py
@@ -397,7 +397,9 @@ class SCons:
         )
 
         # -- Print information on the console
-        cout(f"Processing env {styled_env_name}, board {styled_board_id}")
+        cout(
+            f"Processing apio env {styled_env_name} (board {styled_board_id})"
+        )
 
         # -- Print a horizontal line
         cout("-" * terminal_width)

--- a/apio/managers/unpacker.py
+++ b/apio/managers/unpacker.py
@@ -93,8 +93,6 @@ class ZIPArchive(ArchiveBase):
         self.preserve_permissions(item, dest_dir)
 
 
-# R0903: Too few public methods (1/2) (too-few-public-methods)
-# pylint: disable=R0903
 class FileUnpacker:
     """Class for unpacking compressed files"""
 

--- a/apio/utils/pkg_util.py
+++ b/apio/utils/pkg_util.py
@@ -142,7 +142,7 @@ def set_env_for_packages(
         _apply_env_mutations(mutations)
         apio_ctx.env_was_already_set = True
         if not verbose and not quiet:
-            cout("Setting the environment.")
+            cout("Setting shell vars.")
 
 
 @dataclass

--- a/test-examples/ecp5/colorlight-5a-75b-v8/blinky/apio.ini
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/blinky/apio.ini
@@ -1,4 +1,4 @@
-[env]
+[env:default]
 board = colorlight-5a-75b-v8
 top-module = Test
 

--- a/test-examples/ecp5/colorlight-5a-75b-v8/icestudio-button/apio.ini
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/icestudio-button/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = colorlight-5a-75b-v8
 top-module = main

--- a/test-examples/ecp5/colorlight-5a-75b-v8/parity/apio.ini
+++ b/test-examples/ecp5/colorlight-5a-75b-v8/parity/apio.ini
@@ -1,4 +1,4 @@
-[env]
+[env:default]
 board = colorlight-5a-75b-v8
 top-module = parity
 

--- a/test-examples/ecp5/cynthion-r1-4/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ecp5/cynthion-r1-4/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = cynthion-r1-4
 top-module = main

--- a/test-examples/ecp5/mimas-ecp5-mini/blinky/apio.ini
+++ b/test-examples/ecp5/mimas-ecp5-mini/blinky/apio.ini
@@ -1,4 +1,4 @@
-[env]
+[env:default]
 board = mimas-ecp5-mini
 top-module = Test
 

--- a/test-examples/ecp5/ulx3s-12f/icestudio-jumping-led/apio.ini
+++ b/test-examples/ecp5/ulx3s-12f/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = ulx3s-12f
 top-module = main

--- a/test-examples/ecp5/ulx3s-12f/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ecp5/ulx3s-12f/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = ulx3s-12f
 top-module = main

--- a/test-examples/ecp5/ulx3s-12f/icestudio-riscv-stop-watch/apio.ini
+++ b/test-examples/ecp5/ulx3s-12f/icestudio-riscv-stop-watch/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = ulx3s-12f
 top-module = main

--- a/test-examples/gowin/sipeed-tang-nano-9k/blinky/apio.ini
+++ b/test-examples/gowin/sipeed-tang-nano-9k/blinky/apio.ini
@@ -1,5 +1,5 @@
 
-[env]
+[env:default]
 board = sipeed-tang-nano-9k
 top-module = blinky
 

--- a/test-examples/gowin/sipeed-tang-nano-9k/parity/apio.ini
+++ b/test-examples/gowin/sipeed-tang-nano-9k/parity/apio.ini
@@ -1,5 +1,5 @@
 
-[env]
+[env:default]
 board = sipeed-tang-nano-9k
 top-module = parity
 

--- a/test-examples/ice40/alhambra-ii/bcd-counter/apio.ini
+++ b/test-examples/ice40/alhambra-ii/bcd-counter/apio.ini
@@ -1,4 +1,4 @@
-[env]
+[env:default]
 board = alhambra-ii
 top-module = main
 

--- a/test-examples/ice40/alhambra-ii/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/alhambra-ii/icestudio-jumping-led/apio.ini
@@ -1,4 +1,4 @@
-[env]
+[env:default]
 board = alhambra-ii
 top-module = main
 

--- a/test-examples/ice40/alhambra-ii/icestudio-ledon/apio.ini
+++ b/test-examples/ice40/alhambra-ii/icestudio-ledon/apio.ini
@@ -1,4 +1,4 @@
-[env]
+[env:default]
 board = alhambra-ii
 top-module = main
 

--- a/test-examples/ice40/alhambra-ii/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ice40/alhambra-ii/icestudio-leds-buttons/apio.ini
@@ -1,4 +1,4 @@
-[env]
+[env:default]
 board = alhambra-ii
 top-module = main
 

--- a/test-examples/ice40/alhambra-ii/icestudio-riscv-stop-watch/apio.ini
+++ b/test-examples/ice40/alhambra-ii/icestudio-riscv-stop-watch/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = alhambra-ii
 top-module = main

--- a/test-examples/ice40/alhambra-ii/icestudio-tff/apio.ini
+++ b/test-examples/ice40/alhambra-ii/icestudio-tff/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = alhambra-ii
 top-module = main

--- a/test-examples/ice40/blackice/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/blackice/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = blackice
 top-module = main

--- a/test-examples/ice40/blackice/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ice40/blackice/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = blackice
 top-module = main

--- a/test-examples/ice40/edu-ciaa-fpga/and-gate/apio.ini
+++ b/test-examples/ice40/edu-ciaa-fpga/and-gate/apio.ini
@@ -1,7 +1,7 @@
 # APIO project configuration file. For details see
 # https://github.com/FPGAwars/apio/wiki/Project-configuration-file
 
-[env]
+[env:default]
 board = edu-ciaa-fpga
 top-module = and_gate
 

--- a/test-examples/ice40/edu-ciaa-fpga/fdd/apio.ini
+++ b/test-examples/ice40/edu-ciaa-fpga/fdd/apio.ini
@@ -1,6 +1,6 @@
 # APIO project configuration file. For details see
 # https://github.com/FPGAwars/apio/wiki/Project-configuration-file
 
-[env]
+[env:default]
 board = edu-ciaa-fpga
 top-module = ffd

--- a/test-examples/ice40/fomu/dsp/apio.ini
+++ b/test-examples/ice40/fomu/dsp/apio.ini
@@ -1,4 +1,4 @@
-[env]
+[env:default]
 board = fomu
 top-module = top
 

--- a/test-examples/ice40/fomu/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/fomu/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = fomu
 top-module = main

--- a/test-examples/ice40/fomu/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ice40/fomu/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = fomu
 top-module = main

--- a/test-examples/ice40/go-board/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/go-board/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = go-board
 top-module = main

--- a/test-examples/ice40/go-board/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ice40/go-board/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = go-board
 top-module = main

--- a/test-examples/ice40/ice40-hx8k/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/ice40-hx8k/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = ice40-hx8k
 top-module = main

--- a/test-examples/ice40/ice40-hx8k/icestudio-leds/apio.ini
+++ b/test-examples/ice40/ice40-hx8k/icestudio-leds/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = ice40-hx8k
 top-module = main

--- a/test-examples/ice40/ice40-up5k/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/ice40-up5k/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = ice40-up5k
 top-module = main

--- a/test-examples/ice40/ice40-up5k/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ice40/ice40-up5k/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = ice40-up5k
 top-module = main

--- a/test-examples/ice40/ice40-up5k/icestudio-riscv-stop-watch/apio.ini
+++ b/test-examples/ice40/ice40-up5k/icestudio-riscv-stop-watch/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = ice40-up5k
 top-module = main

--- a/test-examples/ice40/icebreaker/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/icebreaker/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icebreaker
 top-module = main

--- a/test-examples/ice40/icebreaker/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ice40/icebreaker/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icebreaker
 top-module = main

--- a/test-examples/ice40/icebreaker/icestudio-riscv-stop-watch/apio.ini
+++ b/test-examples/ice40/icebreaker/icestudio-riscv-stop-watch/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icebreaker
 top-module = main

--- a/test-examples/ice40/icestick/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/icestick/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icestick
 top-module = main

--- a/test-examples/ice40/icestick/icestudio-leds/apio.ini
+++ b/test-examples/ice40/icestick/icestudio-leds/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icestick
 top-module = main

--- a/test-examples/ice40/icestick/icestudio-riscv-stop-watch/apio.ini
+++ b/test-examples/ice40/icestick/icestudio-riscv-stop-watch/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icestick
 top-module = main

--- a/test-examples/ice40/icesugar-1-5/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/icesugar-1-5/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icesugar-1-5
 top-module = main

--- a/test-examples/ice40/icesugar-1-5/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ice40/icesugar-1-5/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icesugar-1-5
 top-module = main

--- a/test-examples/ice40/icesugar-1-5/icestudion-riscv-stop-watch/apio.ini
+++ b/test-examples/ice40/icesugar-1-5/icestudion-riscv-stop-watch/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icesugar-1-5
 top-module = main

--- a/test-examples/ice40/icezum/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/icezum/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icezum
 top-module = main

--- a/test-examples/ice40/icezum/icestudio-leds-buttons/apio.ini
+++ b/test-examples/ice40/icezum/icestudio-leds-buttons/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icezum
 top-module = main

--- a/test-examples/ice40/icezum/icestudio-riscv-stop-watch/apio.ini
+++ b/test-examples/ice40/icezum/icestudio-riscv-stop-watch/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = icezum
 top-module = main

--- a/test-examples/ice40/tinyfpga-bx/icestudio-jumping-led/apio.ini
+++ b/test-examples/ice40/tinyfpga-bx/icestudio-jumping-led/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = tinyfpga-bx
 top-module = main

--- a/test-examples/ice40/tinyfpga-bx/icestudio-led-on/apio.ini
+++ b/test-examples/ice40/tinyfpga-bx/icestudio-led-on/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = tinyfpga-bx
 top-module = main

--- a/test-examples/ice40/tinyfpga-bx/icestudio-riscv-stop-watch/apio.ini
+++ b/test-examples/ice40/tinyfpga-bx/icestudio-riscv-stop-watch/apio.ini
@@ -1,3 +1,3 @@
-[env]
+[env:default]
 board = tinyfpga-bx
 top-module = main

--- a/test/commands/test_apio_build.py
+++ b/test/commands/test_apio_build.py
@@ -53,4 +53,7 @@ def test_build_with_apio_init(apio_runner: ApioRunner):
         )
         result = sb.invoke_apio_cmd(apio, "build")
         assert result.exit_code == 1, result.output
-        assert "Error: Unknown project option 'unknown'" in result.output
+        assert (
+            "Error: Unknown option 'unknown' in [env:default] section "
+            "of apio.ini" in result.output
+        )

--- a/test/commands/test_apio_build.py
+++ b/test/commands/test_apio_build.py
@@ -26,7 +26,10 @@ def test_build_with_apio_init(apio_runner: ApioRunner):
         sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
         result = sb.invoke_apio_cmd(apio, "build")
         assert result.exit_code == 1, result.output
-        assert "Error: Missing option 'board'" in result.output
+        assert (
+            "Error: Missing required option 'board' for env 'default'"
+            in result.output
+        )
 
         # -- Run "apio build" with an invalid board
         sb.write_apio_ini(

--- a/test/commands/test_apio_build.py
+++ b/test/commands/test_apio_build.py
@@ -4,7 +4,7 @@ from test.conftest import ApioRunner
 from apio.commands.apio import cli as apio
 
 
-def test_build_without_apio_init(apio_runner: ApioRunner):
+def test_build_without_apio_ini(apio_runner: ApioRunner):
     """Tests build with various valid and invalid apio variation, all tests
     are offline and without any apio package installed."""
 
@@ -16,7 +16,7 @@ def test_build_without_apio_init(apio_runner: ApioRunner):
         assert "Error: Missing project file apio.ini" in result.output
 
 
-def test_build_with_apio_init(apio_runner: ApioRunner):
+def test_build_with_apio_ini(apio_runner: ApioRunner):
     """Tests build with various valid and invalid apio variation, all tests
     are offline and without any apio package installed."""
 
@@ -59,4 +59,20 @@ def test_build_with_apio_init(apio_runner: ApioRunner):
         assert (
             "Error: Unknown option 'unknown' in [env:default] section "
             "of apio.ini" in result.output
+        )
+
+
+def test_build_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio build --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "build", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
         )

--- a/test/commands/test_apio_build.py
+++ b/test/commands/test_apio_build.py
@@ -42,7 +42,10 @@ def test_build_with_apio_ini(apio_runner: ApioRunner):
         )
         result = sb.invoke_apio_cmd(apio, "build")
         assert result.exit_code == 1, result.output
-        assert "no such board 'no-such-board'" in result.output.lower()
+        assert (
+            "Error: Unknown board name 'no-such-board' in apio.ini"
+            in result.output
+        )
 
         # -- Run "apio build" with an unknown option.
         sb.write_apio_ini(

--- a/test/commands/test_apio_build.py
+++ b/test/commands/test_apio_build.py
@@ -23,7 +23,7 @@ def test_build_with_apio_init(apio_runner: ApioRunner):
     with apio_runner.in_sandbox() as sb:
 
         # -- Run "apio build" with a missing board var.
-        sb.write_apio_ini({"[env]": {"top-module": "main"}})
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
         result = sb.invoke_apio_cmd(apio, "build")
         assert result.exit_code == 1, result.output
         assert "Error: Missing option 'board'" in result.output
@@ -31,7 +31,7 @@ def test_build_with_apio_init(apio_runner: ApioRunner):
         # -- Run "apio build" with an invalid board
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     "board": "no-such-board",
                     "top-module": "main",
                 }
@@ -44,7 +44,7 @@ def test_build_with_apio_init(apio_runner: ApioRunner):
         # -- Run "apio build" with an unknown option.
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     "board": "alhambra-ii",
                     "top-module": "main",
                     "unknown": "xyz",

--- a/test/commands/test_apio_clean.py
+++ b/test/commands/test_apio_clean.py
@@ -42,3 +42,19 @@ def test_clean_with_apio_ini(apio_runner: ApioRunner):
         assert not Path(".sconsign.dblite").exists()
         assert not Path("_build/hardware.out").exists()
         assert not Path("_build").exists()
+
+
+def test_clean_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio clean --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "clean", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
+        )

--- a/test/commands/test_apio_create.py
+++ b/test/commands/test_apio_create.py
@@ -16,7 +16,7 @@ def _check_ini_file(apio_ini: Path, expected_vars: Dict[str, str]) -> None:
     # Check the expected comment at the top.
     assert "# APIO project configuration file" in conf.initial_comment[0]
     # Check the expected vars.
-    assert conf.dict() == {"env": expected_vars}
+    assert conf.dict() == {"env:default": expected_vars}
 
 
 def test_create(apio_runner: ApioRunner):

--- a/test/commands/test_apio_create.py
+++ b/test/commands/test_apio_create.py
@@ -33,10 +33,10 @@ def test_create(apio_runner: ApioRunner):
         assert "Error: Missing option" in result.output
         assert not exists(apio_ini)
 
-        # -- Execute "apio create --board missed_board"
-        result = sb.invoke_apio_cmd(apio, "create", "--board", "missed_board")
+        # -- Execute "apio create --board no-such-board"
+        result = sb.invoke_apio_cmd(apio, "create", "--board", "no-such-board")
         assert result.exit_code == 1, result.output
-        assert "Error: No such board" in result.output
+        assert "Error: Unknown board name 'no-such-board'" in result.output
         assert not exists(apio_ini)
 
         # -- Execute "apio create --board alhambra-ii"

--- a/test/commands/test_apio_format.py
+++ b/test/commands/test_apio_format.py
@@ -13,3 +13,19 @@ def test_format_without_apio_ini(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio, "format")
         assert result.exit_code != 0, result.output
         assert "Error: Missing project file apio.ini" in result.output
+
+
+def test_format_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio format --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "format", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
+        )

--- a/test/commands/test_apio_graph.py
+++ b/test/commands/test_apio_graph.py
@@ -13,3 +13,19 @@ def test_graph_no_apio_ini(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio, "graph")
         assert result.exit_code == 1, result.output
         assert "Error: Missing project file apio.ini" in result.output
+
+
+def test_graph_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio graph --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "graph", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
+        )

--- a/test/commands/test_apio_info.py
+++ b/test/commands/test_apio_info.py
@@ -50,20 +50,20 @@ def test_apio_info(apio_runner: ApioRunner):
         assert "This page describes the conventions" in cunstyle(result.output)
         assert result.output != cunstyle(result.output)  # Colored.
 
-        # -- Execute "apio info options"
-        result = sb.invoke_apio_cmd(apio, "info", "options")
+        # -- Execute "apio info apio.ini"
+        result = sb.invoke_apio_cmd(apio, "info", "apio.ini")
         assert result.exit_code == 0
-        assert "BOARD (REQUIRED)" in cunstyle(result.output)
-        assert "YOSYS-SYNTH-EXTRA-OPTIONS (OPTIONAL)" in cunstyle(
+        assert "BOARD option (REQUIRED)" in cunstyle(result.output)
+        assert "YOSYS-SYNTH-EXTRA-OPTIONS option (OPTIONAL)" in cunstyle(
             result.output
         )
         assert result.output != cunstyle(result.output)  # Colored.
 
-        # -- Execute "apio info options board"
-        result = sb.invoke_apio_cmd(apio, "info", "options", "board")
+        # -- Execute "apio info apio.ini board"
+        result = sb.invoke_apio_cmd(apio, "info", "apio.ini", "board")
         assert result.exit_code == 0
-        assert "BOARD (REQUIRED)" in cunstyle(result.output)
-        assert "YOSYS-SYNTH-EXTRA-OPTIONS (OPTIONAL)" not in cunstyle(
+        assert "BOARD option (REQUIRED)" in cunstyle(result.output)
+        assert "YOSYS-SYNTH-EXTRA-OPTIONS option (OPTIONAL)" not in cunstyle(
             result.output
         )
         assert result.output != cunstyle(result.output)  # Colored.

--- a/test/commands/test_apio_lint.py
+++ b/test/commands/test_apio_lint.py
@@ -13,3 +13,19 @@ def test_lint_apio_init(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio, "lint")
         assert result.exit_code == 1, result.output
         assert "Error: Missing project file apio.ini" in result.output
+
+
+def test_lint_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio lint --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "lint", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
+        )

--- a/test/commands/test_apio_report.py
+++ b/test/commands/test_apio_report.py
@@ -13,3 +13,19 @@ def test_report_no_apio(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio, "report")
         assert result.exit_code != 0, result.output
         assert "Error: Missing project file apio.ini" in result.output
+
+
+def test_report_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio report --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "report", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
+        )

--- a/test/commands/test_apio_sim.py
+++ b/test/commands/test_apio_sim.py
@@ -16,3 +16,19 @@ def test_sim(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio, "sim")
         assert result.exit_code != 0, result.output
         # -- TODO
+
+
+def test_sim_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio sim --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "sim", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
+        )

--- a/test/commands/test_apio_test.py
+++ b/test/commands/test_apio_test.py
@@ -16,3 +16,19 @@ def test_test(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio, "test")
         assert result.exit_code != 0, result.output
         assert "Error: Missing project file apio.ini" in result.output
+
+
+def test_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio test --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "test", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
+        )

--- a/test/commands/test_apio_upload.py
+++ b/test/commands/test_apio_upload.py
@@ -18,3 +18,19 @@ def test_upload_without_apio_ini(apio_runner: ApioRunner):
         # -- Check the result
         assert result.exit_code == 1, result.output
         assert "Error: Missing project file apio.ini" in result.output
+
+
+def test_upload_with_env_arg_error(apio_runner: ApioRunner):
+    """Tests the command with an invalid --env value. This error message
+    confirms that the --env arg was propagated to the apio.ini loading
+    logic."""
+
+    with apio_runner.in_sandbox() as sb:
+
+        # -- Run "apio upload --env no-such-env"
+        sb.write_apio_ini({"[env:default]": {"top-module": "main"}})
+        result = sb.invoke_apio_cmd(apio, "upload", "--env", "no-such-env")
+        assert result.exit_code == 1, result.output
+        assert (
+            "Error: Env 'no-such-env' not found in apio.ini" in result.output
+        )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -260,7 +260,7 @@ class ApioSandbox:
         for testing. If the file exists, it's overwritten."""
 
         default_apio_ini = {
-            "[env]": {
+            "[env:default]": {
                 "board": "alhambra-ii",
                 "top-module": "main",
             }

--- a/test/integration/test_commands.py
+++ b/test/integration/test_commands.py
@@ -43,7 +43,7 @@ def test_boards_custom_board(apio_runner: ApioRunner):
         # -- Write an apio.ini file.
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     "board": "my_custom_board",
                     "top-module": "main",
                 }
@@ -149,7 +149,7 @@ def test_project_with_legacy_board_name(apio_runner: ApioRunner):
         # -- Modify the apio.ini to have the legacy board name
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     "board": "iCE40-HX8K",
                     "top-module": "leds",
                 }

--- a/test/managers/test_programmers.py
+++ b/test/managers/test_programmers.py
@@ -16,7 +16,7 @@ def test_construct_programmer_cmd_template(apio_runner: ApioRunner):
         # -- Construct an apio context.
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     "board": "alhambra-ii",
                     "top-module": "my_module",
                 }
@@ -48,7 +48,7 @@ def test_construct_programmer_cmd_template_sram_ok(apio_runner: ApioRunner):
         # -- Construct an apio context.
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     "board": "alhambra-ii",
                     "top-module": "my_module",
                 }
@@ -83,7 +83,7 @@ def test_construct_programmer_cmd_template_sram_error(
         # -- support the flag --sram.
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     "board": "colorlight-5a-75b-v7",
                     "top-module": "my_module",
                 }

--- a/test/managers/test_project.py
+++ b/test/managers/test_project.py
@@ -127,8 +127,8 @@ def test_legacy_board_name(apio_runner: ApioRunner, capsys: LogCaptureFixture):
         "top-module": "my_top_module",
     }
     assert (
-        "Warning: 'iCE40-HX8K' board name was changed. "
-        "Please use 'ice40-hx8k' instead" in stdout
+        "Warning: 'Board iCE40-HX8K' was renamed to 'ice40-hx8k'. "
+        "Please update apio.ini" in stdout
     )
 
 
@@ -300,7 +300,7 @@ def test_validation_errors(apio_runner: ApioRunner, capsys: LogCaptureFixture):
                 "board": "no-such-board",
             }
         },
-        expected_error="Error: No such board 'no-such-board'",
+        expected_error="Error: Unknown board name 'no-such-board' in apio.ini",
         apio_runner=apio_runner,
         capsys=capsys,
     )

--- a/test/managers/test_project.py
+++ b/test/managers/test_project.py
@@ -2,97 +2,263 @@
 Tests of project.py
 """
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 from test.conftest import ApioRunner
 from pytest import LogCaptureFixture
 import pytest
+from apio.managers.project import Project, ENV_OPTIONS
 from apio.common.apio_console import cunstyle
 from apio.apio_context import ApioContext, ApioContextScope
 
 # TODO: Add more tests.
 
 
-def test_all_options_env(apio_runner: ApioRunner):
+def load_apio_ini(
+    apio_ini: Dict[str, Dict[str, str]],
+    env_arg: Optional[str],
+    apio_runner: ApioRunner,
+    capsys: LogCaptureFixture,
+) -> Tuple[Project, str]:
+    """A helper function load apio.ini.  Returns (project, stdout)"""
+
+    with apio_runner.in_sandbox() as sb:
+        # -- Create the apio.ini file
+        sb.write_apio_ini(apio_ini)
+
+        # -- Try to create the context with the project info.
+        capsys.readouterr()  # Reset capture
+        apio_ctx = ApioContext(
+            scope=ApioContextScope.PROJECT_REQUIRED,
+            env_arg=env_arg,
+        )
+
+        # -- Return the values.
+        return (
+            apio_ctx.project,
+            cunstyle(capsys.readouterr().out),
+        )
+
+
+def test_all_options_env(apio_runner: ApioRunner, capsys: LogCaptureFixture):
     """Tests an apio.ini with all options"""
 
-    with apio_runner.in_sandbox() as sb:
+    apio_ini = {
+        "[env:default]": {
+            # -- Required.
+            "board": "alhambra-ii",
+            # -- Optional.
+            "top-module": "my_module",
+            "default-testbench": "main_tb.v",
+            "format-verible-options": "\n  --aaa bbb\n  --ccc ddd",
+            "yosys-synth-extra-options": "-dsp -xyz",
+        }
+    }
 
-        # -- Create an apio.ini.
-        sb.write_apio_ini(
-            {
-                "[env:default]": {
-                    # -- Required.
-                    "board": "alhambra-ii",
-                    # -- Optional.
-                    "top-module": "my_module",
-                    "format-verible-options": "\n  --aaa bbb\n  --ccc ddd",
-                    "yosys-synth-extra-options": "-dsp -xyz",
-                }
-            }
-        )
+    # -- Make sure we covered all the options.
+    assert len(apio_ini["[env:default]"]) == len(ENV_OPTIONS)
 
-        # -- We use ApioContext to instantiate the Project object.
-        apio_ctx = ApioContext(
-            scope=ApioContextScope.PROJECT_REQUIRED,
-            project_dir_arg=sb.proj_dir,
-        )
-        project = apio_ctx.project
+    project, _ = load_apio_ini(
+        apio_ini=apio_ini,
+        env_arg=None,
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
 
-        # -- Verify the required args.
-        assert project.get("board") == "alhambra-ii"
+    assert project.env_name == "default"
+    assert project.env_options == {
+        "board": "alhambra-ii",
+        "top-module": "my_module",
+        "default-testbench": "main_tb.v",
+        "format-verible-options": "\n--aaa bbb\n--ccc ddd",
+        "yosys-synth-extra-options": "-dsp -xyz",
+    }
 
-        # -- Verify the optional args.
-        assert project.get("top-module") == "my_module"
-        assert project.get_as_lines_list("format-verible-options") == [
-            "--aaa bbb",
-            "--ccc ddd",
-        ]
-        assert project.get("yosys-synth-extra-options") == "-dsp -xyz"
-
-        # -- Try a few as dict lookup.
-        assert project["board"] == "alhambra-ii"
-        assert project["top-module"] == "my_module"
+    # -- Try a few as dict lookup on the project object.
+    assert project["board"] == "alhambra-ii"
+    assert project["top-module"] == "my_module"
 
 
-def test_required_options_only_env(apio_runner: ApioRunner):
+def test_required_options_only_env(
+    apio_runner: ApioRunner, capsys: LogCaptureFixture
+):
     """Tests a minimal apio.ini with required only options."""
 
-    with apio_runner.in_sandbox() as sb:
-
-        # -- Create an apio.ini.
-        sb.write_apio_ini(
-            {
-                "[env:default]": {
-                    "board": "alhambra-ii",
-                }
+    project, stdout = load_apio_ini(
+        apio_ini={
+            "[env:default]": {
+                "board": "alhambra-ii",
             }
-        )
+        },
+        env_arg=None,
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
 
-        # -- We use ApioContext to instantiate the Project object.
-        apio_ctx = ApioContext(
-            scope=ApioContextScope.PROJECT_REQUIRED,
-            project_dir_arg=sb.proj_dir,
-        )
-        project = apio_ctx.project
+    assert project.env_name == "default"
+    assert project.env_options == {
+        "board": "alhambra-ii",
+        "top-module": "main",
+    }
+    assert (
+        "Option 'top-module' is missing for env default, assuming 'main'"
+        in stdout
+    )
 
-        # -- Verify the required args.
-        assert project.get("board") == "alhambra-ii"
 
-        # -- Verify the optional args
-        assert project.get("top-module") == "main"
-        assert project.get_as_lines_list("format-verible-options") is None
-        assert project.get("yosys-synth-extra-options") is None
+def test_legacy_board_name(apio_runner: ApioRunner, capsys: LogCaptureFixture):
+    """Tests with 'board' option having a legacy board name. It should
+    be converted to the canonical board name"""
 
-        # -- Verify optionals while specifying explicit defaults.
-        assert (
-            project.get_as_lines_list("format-verible-options", default=[])
-            == []
-        )
-        assert project.get("yosys-synth-extra-options", "") == ""
+    project, stdout = load_apio_ini(
+        apio_ini={
+            "[env:default]": {
+                "board": "iCE40-HX8K",
+                "top-module": "my_top_module",
+            }
+        },
+        env_arg=None,
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
 
-        # -- Try a few as dict lookup.
-        assert project["board"] == "alhambra-ii"
-        assert project["top-module"] == "main"
+    assert project.env_name == "default"
+    assert project.env_options == {
+        "board": "ice40-hx8k",
+        "top-module": "my_top_module",
+    }
+    assert (
+        "Warning: 'iCE40-HX8K' board name was changed. "
+        "Please use 'ice40-hx8k' instead" in stdout
+    )
+
+
+def test_legacy_apio_ini(apio_runner: ApioRunner, capsys: LogCaptureFixture):
+    """Tests with an old style apio.ini that has a single [env] section."""
+
+    project, stdout = load_apio_ini(
+        apio_ini={
+            "[env]": {
+                "board": "alhambra-ii",
+            }
+        },
+        env_arg=None,
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    assert project.env_name == "default"
+    assert project.env_options == {
+        "board": "alhambra-ii",
+        "top-module": "main",
+    }
+    assert (
+        "Warning: Apio.ini has a legacy [env] section. "
+        "Please rename it to [env:default]" in stdout
+    )
+
+
+def test_first_env_is_default(
+    apio_runner: ApioRunner, capsys: LogCaptureFixture
+):
+    """Tests that with no --env and no default-env, the first env in
+    apio.ini is selected"""
+
+    project, _ = load_apio_ini(
+        apio_ini={
+            "[common]": {
+                "default-testbench": "main_tb.v",
+            },
+            "[env:env1]": {
+                "board": "alhambra-ii",
+                "top-module": "module1",
+            },
+            "[env:env2]": {
+                "board": "ice40-hx8k",
+                "top-module": "module2",
+            },
+        },
+        env_arg=None,
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    assert project.env_name == "env1"
+    assert project.env_options == {
+        "default-testbench": "main_tb.v",
+        "board": "alhambra-ii",
+        "top-module": "module1",
+    }
+
+
+def test_env_selection_from_apio_ini(
+    apio_runner: ApioRunner, capsys: LogCaptureFixture
+):
+    """Tests that with no --env, and with default env defined in apio.ini
+    using default-env option."""
+
+    project, _ = load_apio_ini(
+        apio_ini={
+            "[apio]": {
+                "default-env": "env2",
+            },
+            "[common]": {
+                "default-testbench": "main_tb.v",
+            },
+            "[env:env1]": {
+                "board": "alhambra-ii",
+                "top-module": "module1",
+            },
+            "[env:env2]": {
+                "board": "ice40-hx8k",
+                "top-module": "module2",
+            },
+        },
+        env_arg=None,
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    assert project.env_name == "env2"
+    assert project.env_options == {
+        "default-testbench": "main_tb.v",
+        "board": "ice40-hx8k",
+        "top-module": "module2",
+    }
+
+
+def test_env_selection_from_env_arg(
+    apio_runner: ApioRunner, capsys: LogCaptureFixture
+):
+    """Tests that with --env overriding default-env in apio.ini."""
+
+    project, _ = load_apio_ini(
+        apio_ini={
+            "[apio]": {
+                "default-env": "env1",
+            },
+            "[common]": {
+                "default-testbench": "main_tb.v",
+            },
+            "[env:env1]": {
+                "board": "alhambra-ii",
+                "top-module": "module1",
+            },
+            "[env:env2]": {
+                "board": "ice40-hx8k",
+                "top-module": "module2",
+            },
+        },
+        env_arg="env2",  # --env env2
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    assert project.env_name == "env2"
+    assert project.env_options == {
+        "default-testbench": "main_tb.v",
+        "board": "ice40-hx8k",
+        "top-module": "module2",
+    }
 
 
 def error_tester(
@@ -114,7 +280,6 @@ def error_tester(
         with pytest.raises(SystemExit) as e:
             ApioContext(
                 scope=ApioContextScope.PROJECT_REQUIRED,
-                project_dir_arg=sb.proj_dir,
                 env_arg=env_arg,
             )
 

--- a/test/managers/test_project.py
+++ b/test/managers/test_project.py
@@ -16,7 +16,7 @@ def test_required_and_optionals(apio_runner: ApioRunner):
         # -- Create an apio.ini.
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     # -- Required.
                     "board": "alhambra-ii",
                     # -- Optional.
@@ -58,7 +58,7 @@ def test_required_only(apio_runner: ApioRunner):
         # -- Create an apio.ini.
         sb.write_apio_ini(
             {
-                "[env]": {
+                "[env:default]": {
                     "board": "alhambra-ii",
                 }
             }

--- a/test/managers/test_project.py
+++ b/test/managers/test_project.py
@@ -2,14 +2,18 @@
 Tests of project.py
 """
 
+from typing import Dict, Optional
 from test.conftest import ApioRunner
+from pytest import LogCaptureFixture
+import pytest
+from apio.common.apio_console import cunstyle
 from apio.apio_context import ApioContext, ApioContextScope
 
 # TODO: Add more tests.
 
 
-def test_required_and_optionals(apio_runner: ApioRunner):
-    """Tests the required and optional options."""
+def test_all_options_env(apio_runner: ApioRunner):
+    """Tests an apio.ini with all options"""
 
     with apio_runner.in_sandbox() as sb:
 
@@ -50,8 +54,8 @@ def test_required_and_optionals(apio_runner: ApioRunner):
         assert project["top-module"] == "my_module"
 
 
-def test_required_only(apio_runner: ApioRunner):
-    """Tests the required only options."""
+def test_required_options_only_env(apio_runner: ApioRunner):
+    """Tests a minimal apio.ini with required only options."""
 
     with apio_runner.in_sandbox() as sb:
 
@@ -89,3 +93,126 @@ def test_required_only(apio_runner: ApioRunner):
         # -- Try a few as dict lookup.
         assert project["board"] == "alhambra-ii"
         assert project["top-module"] == "main"
+
+
+def error_tester(
+    env_arg: Optional[str],
+    apio_ini: Dict[str, Dict[str, str]],
+    expected_error: str,
+    apio_runner: ApioRunner,
+    capsys: LogCaptureFixture,
+):
+    """A helper function to tests apio.ini content that is expected to
+    exit with an error."""
+
+    with apio_runner.in_sandbox() as sb:
+        # -- Create the apio.ini file
+        sb.write_apio_ini(apio_ini)
+
+        # -- Try to create the context with the project info.
+        capsys.readouterr()  # Reset capture
+        with pytest.raises(SystemExit) as e:
+            ApioContext(
+                scope=ApioContextScope.PROJECT_REQUIRED,
+                project_dir_arg=sb.proj_dir,
+                env_arg=env_arg,
+            )
+
+        # -- Check the errors.
+        capture = cunstyle(capsys.readouterr().out)
+        assert e.value.code == 1
+        assert expected_error in capture
+
+
+def test_validation_errors(apio_runner: ApioRunner, capsys: LogCaptureFixture):
+    """Tests the validation of apio.ini errors."""
+
+    # -- Unknown board name.
+    error_tester(
+        env_arg=None,
+        apio_ini={
+            "[env:default]": {
+                "board": "no-such-board",
+            }
+        },
+        expected_error="Error: No such board 'no-such-board'",
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    # -- Env name has an invalid char (Uppercase).
+    error_tester(
+        env_arg=None,
+        apio_ini={
+            "[env:Default]": {
+                "board": "alhambra-ii",
+            }
+        },
+        expected_error="Error: Invalid env name 'Default'",
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    # -- Env name has an extra space.
+    error_tester(
+        env_arg=None,
+        apio_ini={
+            "[env: default]": {
+                "board": "alhambra-ii",
+            }
+        },
+        expected_error="Error: Invalid env name ' default'",
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    # -- default-env points to a non existing env.
+    error_tester(
+        env_arg=None,
+        apio_ini={
+            "[apio]": {
+                "default-env": "no-such-env",
+            },
+            "[env:default]": {
+                "board": "alhambra-ii",
+            },
+        },
+        expected_error="Error: Env 'no-such-env' not found in apio.ini",
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    # -- Missing required option.
+    error_tester(
+        env_arg=None,
+        apio_ini={
+            "[env:default]": {"top-module": "main"},
+        },
+        expected_error="Error: Missing required option 'board' for "
+        "env 'default'.",
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    # -- env_arg has a non existing env name.
+    error_tester(
+        env_arg="no-such-env",
+        apio_ini={
+            "[env:default]": {"board": "alhambra-ii"},
+        },
+        expected_error="Active env options [APIO_HOME].\nError: "
+        "Env 'no-such-env' not found in apio.ini",
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )
+
+    # -- env_arg has an env name with an invalid char (upper case).
+    error_tester(
+        env_arg="Default",
+        apio_ini={
+            "[env:default]": {"board": "alhambra-ii"},
+        },
+        expected_error="Error: Invalid --env value 'Default'",
+        apio_runner=apio_runner,
+        capsys=capsys,
+    )

--- a/test/managers/test_scons.py
+++ b/test/managers/test_scons.py
@@ -15,7 +15,7 @@ from apio.managers.scons import SCons
 
 
 TEST_APIO_INI_DICT = {
-    "[env]": {
+    "[env:default]": {
         # -- Required.
         "board": "alhambra-ii",
         # -- Optional.

--- a/test/managers/test_scons.py
+++ b/test/managers/test_scons.py
@@ -49,6 +49,7 @@ environment {
   trellis_path: "TBD"
 }
 apio_env_params {
+  env_name: "default"
   board_id: "alhambra-ii"
   top_module: "my_module"
   yosys_synth_extra_options: "-dsp -xyz"
@@ -83,6 +84,7 @@ environment {
   trellis_path: "TBD"
 }
 apio_env_params {
+  env_name: "default"
   board_id: "alhambra-ii"
   top_module: "my_module"
   yosys_synth_extra_options: "-dsp -xyz"

--- a/test/scons/testing.py
+++ b/test/scons/testing.py
@@ -36,6 +36,7 @@ environment {
   trellis_path: "/Users/user/.apio/packages/oss-cad-suite/share/trellis"
 }
 apio_env_params {
+  env_name: "default"
   board_id: "alhambra-ii"
   top_module: "main"
 }

--- a/tox.ini
+++ b/tox.ini
@@ -62,13 +62,11 @@ setenv=
 # When we generate the proto files at apio/proto, we also patch at the top
 # directives to suppress pylint warnings.
 #
-# The --prefer-stubs option is for the protocol buffers file, telling lint
-# to use the definitions in the .pyi stubs instead of the cryptic protocol
-# buffers .py files.
+# See .pylintrc for pylint's configuration.
 commands =
     black   {env:LINT_ITEMS}  --exclude apio/common/proto
     flake8  {env:LINT_ITEMS}  --exclude apio/common/proto
-    pylint  {env:LINT_ITEMS}  --enable=useless-suppression --prefer-stubs True 
+    pylint  {env:LINT_ITEMS}
 
 # ----------------------------------------------------
 


### PR DESCRIPTION
@cavearr, please review and merge.

Reference: https://github.com/FPGAwars/apio/issues/493

The full apio.ini looks like the example below. The section [apio], [common] are optional and at minimum apio.ini contains a single [env:*] section.  The active env is selected by (in decreasing importance):  1. an --env flag , 2. The default-env value in the [apio] section, 3. The first listed env.  The names env1, env2, env3 in the example are arbitrary.

There is also a backward compatibility logic that accepts legacy apio.ini with a single [env] section.

The options of each env is the union of the env and common section with higher priority for the env section.


```
[apio]
default-env = env2

[common]
...

[env:env1]
...

[env:env2]
...

[env:env3]
...

```

This PR doesn't include new options such as defining macros. That will come latter.