### PR TITLE
Assorted apio cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 [![build-and-release](https://github.com/FPGAwars/apio-examples/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/FPGAwars/apio-examples/actions/workflows/build-and-release.yaml)
 [![build-and-release](https://github.com/FPGAwars/tools-oss-cad-suite/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/FPGAwars/tools-oss-cad-suite/actions/workflows/build-and-release.yaml)
+[![build-and-release](https://github.com/FPGAwars/tools-verible/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/FPGAwars/tools-verible/actions/workflows/build-and-release.yaml)
+[![build-and-release](https://github.com/FPGAwars/tools-graphviz/actions/workflows/build-and-release.yml/badge.svg)](https://github.com/FPGAwars/tools-graphviz/actions/workflows/build-and-release.yml)
+[![build-and-release](https://github.com/FPGAwars/tools-drivers/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/FPGAwars/tools-drivers/actions/workflows/build-and-release.yaml)
 
 ![][linux-logo]&nbsp;&nbsp;&nbsp;![][macosx-logo]&nbsp;&nbsp;&nbsp;![][windows-logo]&nbsp;&nbsp;&nbsp;![][ubuntu-logo]&nbsp;&nbsp;&nbsp;![][raspbian-logo]
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [![test](https://github.com/FPGAwars/apio/actions/workflows/test.yaml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/test.yaml)
 [![build-all](https://github.com/FPGAwars/apio-dev-builds/actions/workflows/build-all.yaml/badge.svg)](https://github.com/FPGAwars/apio-dev-builds/actions/workflows/build-all.yaml)
+[![monitor-apio-prod](https://github.com/FPGAwars/apio/actions/workflows/monitor-apio-prod.yaml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/monitor-apio-prod.yaml)
+[![monitor-apio-latest](https://github.com/FPGAwars/apio/actions/workflows/monitor-apio-latest.yaml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/monitor-apio-latest.yaml)
 
 [![build-and-release](https://github.com/FPGAwars/apio-examples/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/FPGAwars/apio-examples/actions/workflows/build-and-release.yaml)
 [![build-and-release](https://github.com/FPGAwars/tools-oss-cad-suite/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/FPGAwars/tools-oss-cad-suite/actions/workflows/build-and-release.yaml)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 [![][apio-logo]][wiki]
 
-[![PyPI Version][pypi-image]][pypi-url]<br>
-[![License][license-image]][license-url]<br>
-[![Test](https://github.com/FPGAwars/apio/actions/workflows/test.yml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/test.yml)<br>
+[![PyPI Version][pypi-image]][pypi-url]
+[![License][license-image]][license-url]
+
+[![test](https://github.com/FPGAwars/apio/actions/workflows/test.yaml/badge.svg)](https://github.com/FPGAwars/apio/actions/workflows/test.yaml)
 [![build-all](https://github.com/FPGAwars/apio-dev-builds/actions/workflows/build-all.yaml/badge.svg)](https://github.com/FPGAwars/apio-dev-builds/actions/workflows/build-all.yaml)
+
+[![build-and-release](https://github.com/FPGAwars/apio-examples/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/FPGAwars/apio-examples/actions/workflows/build-and-release.yaml)
+[![build-and-release](https://github.com/FPGAwars/tools-oss-cad-suite/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/FPGAwars/tools-oss-cad-suite/actions/workflows/build-and-release.yaml)
 
 ![][linux-logo]&nbsp;&nbsp;&nbsp;![][macosx-logo]&nbsp;&nbsp;&nbsp;![][windows-logo]&nbsp;&nbsp;&nbsp;![][ubuntu-logo]&nbsp;&nbsp;&nbsp;![][raspbian-logo]
 

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -458,6 +458,9 @@ class ApioContext:
         else:
             platform_id = ApioContext._get_system_platform_id()
 
+        # Stick to the naming conventions we use for boards, fpgas, etc.
+        platform_id = platform_id.replace("_", "-")
+
         # -- Verify it's valid. This can be a user error if the override
         # -- is invalid.
         if platform_id not in platforms.keys():
@@ -517,8 +520,8 @@ class ApioContext:
     @staticmethod
     def _get_system_platform_id() -> str:
         """Return a String with the current platform:
-        ex. linux_x86_64
-        ex. windows_amd64"""
+        ex. linux-x86-64
+        ex. windows-amd64"""
 
         # -- Get the platform: linux, windows, darwin
         type_ = platform.system().lower()

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -342,12 +342,14 @@ def _platforms_cli():
         title_justify="left",
     )
 
-    table.add_column("PLATFORM ID", min_width=20, no_wrap=True)
-    table.add_column("DESCRIPTION", min_width=30, no_wrap=True)
+    table.add_column("  PLATFORM ID", no_wrap=True)
+    table.add_column("TYPE", no_wrap=True)
+    table.add_column("VARIANT", no_wrap=True)
 
     # -- Add rows.
     for platform_id, platform_info in apio_ctx.platforms.items():
-        description = platform_info.get("description")
+        platform_type = platform_info.get("type")
+        platform_variant = platform_info.get("variant")
 
         # -- Mark the current platform.
         if platform_id == apio_ctx.platform_id:
@@ -357,7 +359,12 @@ def _platforms_cli():
             style = None
             marker = "  "
 
-        table.add_row(f"{marker}{platform_id}", description, style=style)
+        table.add_row(
+            f"{marker}{platform_id}",
+            platform_type,
+            platform_variant,
+            style=style,
+        )
 
     # -- Render the table.
     cout()

--- a/apio/managers/downloader.py
+++ b/apio/managers/downloader.py
@@ -22,8 +22,8 @@ from apio.common.apio_console import cout, console
 from apio.common.apio_styles import ERROR
 
 # -- Timeout for getting a response from the server when downloading
-# -- a file (in seconds)
-TIMEOUT_SECS = 10
+# -- a file (in seconds). We had github tests failing with timeout=10
+TIMEOUT_SECS = 30
 
 
 class FileDownloader:

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -278,7 +278,7 @@ class Examples:
         ignore_callback = shutil.ignore_patterns("info")
 
         cout(
-            f"Found {util.plurality(board_examples, "example")} "
+            f'Found {util.plurality(board_examples, "example")} '
             f"for board '{board_name}'"
         )
 

--- a/apio/managers/examples.py
+++ b/apio/managers/examples.py
@@ -294,7 +294,7 @@ class Examples:
             )
 
         cout(
-            f"{util.plurality(board_examples, "Example", include_num=False)} "
+            f"{util.plurality(board_examples, 'Example', include_num=False)} "
             "fetched successfully.",
             style=SUCCESS,
         )

--- a/apio/managers/installer.py
+++ b/apio/managers/installer.py
@@ -26,13 +26,6 @@ def _construct_package_download_url(
 ) -> str:
     """Construct the download URL for the given package name and version."""
 
-    # -- Get platform ID.
-    platform_id = apio_ctx.platform_id
-
-    # -- Get the platform tag.
-    platform_info = apio_ctx.platforms[platform_id]
-    platform_tag = platform_info["platform-tag"]
-
     # -- Convert the version to "YYYY-MM-DD"
     # -- Move to a function in util.py.
     version_tokens = target_version.split(".")
@@ -47,7 +40,7 @@ def _construct_package_download_url(
 
     # -- Create vars mapping.
     url_vars = {
-        "${PLATFORM}": platform_tag,
+        "${PLATFORM}": apio_ctx.platform_id,
         "${YYYY-MM-DD}": yyyy_mm_dd,
         "${YYYYMMDD}": yyyy_mm_dd.replace("-", ""),
     }

--- a/apio/managers/installer.py
+++ b/apio/managers/installer.py
@@ -363,21 +363,21 @@ def _fix_packages(
     """If the package scan result contains errors, fix them."""
 
     for package_name in scan.bad_version_package_names:
-        cout(f"Uninstalling bad version of '{package_name}'", style=EMPH3)
+        cout(f"Uninstalling bad version of '{package_name}'")
         _delete_package_dir(apio_ctx, package_name, verbose=False)
         apio_ctx.profile.remove_package(package_name)
 
     for package_name in scan.broken_package_names:
-        cout(f"Uninstalling broken package '{package_name}'", style=EMPH3)
+        cout(f"Uninstalling broken package '{package_name}'")
         _delete_package_dir(apio_ctx, package_name, verbose=False)
         apio_ctx.profile.remove_package(package_name)
 
     for package_name in scan.orphan_package_names:
-        cout(f"Uninstalling unknown package '{package_name}'", style=EMPH3)
+        cout(f"Uninstalling unknown package '{package_name}'")
         apio_ctx.profile.remove_package(package_name)
 
     for dir_name in scan.orphan_dir_names:
-        cout(f"Deleting unknown package dir '{dir_name}'", style=EMPH3)
+        cout(f"Deleting unknown package dir '{dir_name}'")
         # -- Sanity check. Since apio_ctx.packages_dir is guaranteed to include
         # -- the word packages, this can fail only due to programming error.
         dir_path = apio_ctx.packages_dir / dir_name
@@ -386,7 +386,7 @@ def _fix_packages(
         shutil.rmtree(dir_path)
 
     for file_name in scan.orphan_file_names:
-        cout(f"Deleting unknown package file '{file_name}'", style=EMPH3)
+        cout(f"Deleting unknown package file '{file_name}'")
         # -- Sanity check. Since apio_ctx.packages_dir is guaranteed to
         # -- include the word packages, this can fail only due to programming
         # -- error.

--- a/apio/profile.py
+++ b/apio/profile.py
@@ -39,13 +39,13 @@ class Profile:
     """
 
     def __init__(self, home_dir: Path, remote_config_url_template: str):
-        """remote_config_url_template is a url string with a "${V}"
+        """remote_config_url_template is a url string with a "{V}"
         placeholder for the apio version such as "0.9.6."""
 
-        # -- Resolve and cache the remote config url. We replace any ${V} with
+        # -- Resolve and cache the remote config url. We replace any {V} with
         # -- the apio version such as "0.9.6".
         self.remote_config_url = remote_config_url_template.replace(
-            "${V}", util.get_apio_version()
+            "{V}", util.get_apio_version()
         )
 
         # -- Verify that we resolved all the placeholders.

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -1,15 +1,16 @@
 // General config parameters.
 //
 {
-  // URL of the apio remote config file. The placeholder ${V} is replaced with
-  // apio's version.
+  // URL of the apio remote config file. The placeholder ${V} is replaced at
+  // runtime with apio's version such as "0.9.7".
   //
-  // This value can be overridden for testing using the env var
-  // APIO_REMOTE_CONFIG_URL, including for reading from a local files.
+  // The value of the remote config field here can be overridden for testing
+  // using the env var APIO_REMOTE_CONFIG_URL, including for reading from
+  // a local file using the "file://" protocol spec.
 
-  // "remote-config": "https://github.com/FPGAwars/apio/raw/develop/remote-config/apio-${V}.jsonc"
+  "remote-config": "https://github.com/FPGAwars/apio/raw/develop/remote-config/apio-${V}.jsonc"
 
-  "remote-config": "https://github.com/zapta/apio-dev/raw/develop/remote-config/apio-${V}.jsonc"
+  // "remote-config": "https://github.com/zapta/apio-dev/raw/develop/remote-config/apio-${V}.jsonc"
 
-  // "remote-config": "file:///projects/apio-dev/repo/remote-config/apio-0.9.6.jsonc"
+  // "remote-config": "file:///projects/apio-dev/repo/remote-config/apio-0.9.7.jsonc"
 }

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -1,16 +1,16 @@
 // General config parameters.
 //
 {
-  // URL of the apio remote config file. The placeholder ${V} is replaced at
+  // URL of the apio remote config file. The placeholder {V} is replaced at
   // runtime with apio's version such as "0.9.7".
   //
   // The value of the remote config field here can be overridden for testing
   // using the env var APIO_REMOTE_CONFIG_URL, including for reading from
   // a local file using the "file://" protocol spec.
 
-  "remote-config": "https://github.com/FPGAwars/apio/raw/develop/remote-config/apio-${V}.jsonc"
+  "remote-config": "https://github.com/FPGAwars/apio/raw/develop/remote-config/apio-{V}.jsonc"
 
-  // "remote-config": "https://github.com/zapta/apio-dev/raw/develop/remote-config/apio-${V}.jsonc"
+  // "remote-config": "https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
 
-  // "remote-config": "file:///projects/apio-dev/repo/remote-config/apio-0.9.7.jsonc"
+  // "remote-config": "file:///projects/apio-dev/repo/remote-config/apio-{V}.jsonc"
 }

--- a/apio/resources/packages.jsonc
+++ b/apio/resources/packages.jsonc
@@ -30,7 +30,7 @@
   // "graphviz" package
   "graphviz": {
     "restricted-to-platforms": [
-      "windows_amd64"
+      "windows-amd64"
     ],
     "description": "Graphviz tool for Windows",
     "env": {
@@ -51,7 +51,7 @@
   // "drivers" package
   "drivers": {
     "restricted-to-platforms": [
-      "windows_amd64"
+      "windows-amd64"
     ],
     "description": "Drivers tools for Windows",
     "env": {

--- a/apio/resources/platforms.jsonc
+++ b/apio/resources/platforms.jsonc
@@ -1,18 +1,23 @@
 // List of computer platforms that are supported by apio.
 {
   "darwin-arm64": {
-    "description": "Mac OSX, ARM 64 bit (Apple Silicon)"
+    "type": "Mac OSX",
+    "variant": "ARM 64 bit (Apple Silicon)"
   },
   "darwin-x86-64": {
-    "description": "Mac OSX, x86 64 bit (Intel)"
+    "type": "Mac OSX",
+    "variant": "x86 64 bit (Intel)"
   },
   "linux-x86-64": {
-    "description": "Linux X86 64 bit"
+    "type": "Linux",
+    "variant": "X86 64 bit"
   },
   "linux-aarch64": {
-    "description": "Linux ARM 64 bit"
+    "type": "Linux",
+    "variant": "ARM 64 bit"
   },
   "windows-amd64": {
-    "description": "Windows x86 64 bit"
+    "type": "Windows",
+    "variant": "x86 64 bit"
   }
 }

--- a/apio/resources/platforms.jsonc
+++ b/apio/resources/platforms.jsonc
@@ -1,23 +1,18 @@
 // List of computer platforms that are supported by apio.
 {
   "darwin-arm64": {
-    "description": "Mac OSX, ARM 64 bit (Apple Silicon)",
-    "platform-tag": "darwin-arm64"
+    "description": "Mac OSX, ARM 64 bit (Apple Silicon)"
   },
   "darwin-x86-64": {
-    "description": "Mac OSX, x86 64 bit (Intel)",
-    "platform-tag": "darwin-x86-64"
+    "description": "Mac OSX, x86 64 bit (Intel)"
   },
   "linux-x86-64": {
-    "description": "Linux X86 64 bit",
-    "platform-tag": "linux-x86-64"
+    "description": "Linux X86 64 bit"
   },
   "linux-aarch64": {
-    "description": "Linux ARM 64 bit",
-    "platform-tag": "linux-aarch64"
+    "description": "Linux ARM 64 bit"
   },
   "windows-amd64": {
-    "description": "Windows x86 64 bit",
-    "platform-tag": "windows-amd64"
+    "description": "Windows x86 64 bit"
   }
 }

--- a/apio/resources/platforms.jsonc
+++ b/apio/resources/platforms.jsonc
@@ -1,22 +1,22 @@
 // List of computer platforms that are supported by apio.
 {
-  "darwin_arm64": {
+  "darwin-arm64": {
     "description": "Mac OSX, ARM 64 bit (Apple Silicon)",
     "platform-tag": "darwin-arm64"
   },
-  "darwin_x86_64": {
+  "darwin-x86-64": {
     "description": "Mac OSX, x86 64 bit (Intel)",
     "platform-tag": "darwin-x86-64"
   },
-  "linux_x86_64": {
+  "linux-x86-64": {
     "description": "Linux X86 64 bit",
     "platform-tag": "linux-x86-64"
   },
-  "linux_aarch64": {
+  "linux-aarch64": {
     "description": "Linux ARM 64 bit",
     "platform-tag": "linux-aarch64"
   },
-  "windows_amd64": {
+  "windows-amd64": {
     "description": "Windows x86 64 bit",
     "platform-tag": "windows-amd64"
   }

--- a/apio/utils/env_options.py
+++ b/apio/utils/env_options.py
@@ -42,8 +42,8 @@ APIO_DEBUG = "APIO_DEBUG"
 #
 # Examples:
 #   file:///projects/apio-dev/repo/remote-config/apio-0.9.6.jsonc
-#   file:///projects/apio-dev/repo/remote-config/apio-${V}.jsonc
-#   https://github.com/zapta/apio_dev/raw/develop/remote-config/apio-${V}.jsonc
+#   file:///projects/apio-dev/repo/remote-config/apio-{V}.jsonc
+#   https://github.com/zapta/apio_dev/raw/develop/remote-config/apio-{V}.jsonc
 #
 APIO_REMOTE_CONFIG_URL = "APIO_REMOTE_CONFIG_URL"
 

--- a/remote-config/apio-0.9.7.jsonc
+++ b/remote-config/apio-0.9.7.jsonc
@@ -1,6 +1,6 @@
 // Remote config file for Apio 0.9.6
 //
-// See installer.py for the vars ${P}, ${V}, ${T}.
+// Supported vars (see installer.py for details):
 //
 //   ${PLATFORM}         - platform tag (from platforms.jsonc)
 //   ${YYYY-MM-DD}       - version as YYYY-MM-DD

--- a/test/commands/test_apio_info.py
+++ b/test/commands/test_apio_info.py
@@ -35,7 +35,8 @@ def test_apio_info(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio, ["info", "platforms"])
         assert result.exit_code == 0, result.output
         assert "darwin-arm64" in result.output
-        assert "Mac OSX, ARM 64 bit (Apple Silicon)" in result.output
+        assert "Mac OSX" in result.output
+        assert "ARM 64 bit (Apple Silicon)" in result.output
 
         # -- Execute "apio info colors"
         result = sb.invoke_apio_cmd(apio, ["info", "colors"])

--- a/test/commands/test_apio_info.py
+++ b/test/commands/test_apio_info.py
@@ -34,7 +34,7 @@ def test_apio_info(apio_runner: ApioRunner):
         # -- Execute "apio info platforms"
         result = sb.invoke_apio_cmd(apio, ["info", "platforms"])
         assert result.exit_code == 0, result.output
-        assert "darwin_arm64" in result.output
+        assert "darwin-arm64" in result.output
         assert "Mac OSX, ARM 64 bit (Apple Silicon)" in result.output
 
         # -- Execute "apio info colors"

--- a/test/scons/test_apio_env.py
+++ b/test/scons/test_apio_env.py
@@ -22,11 +22,11 @@ def test_env_platform_id():
     """Tests the env handling of the platform_id param."""
 
     # -- Test with a non windows platform id.
-    env = make_test_apio_env(platform_id="darwin_arm64", is_windows=False)
+    env = make_test_apio_env(platform_id="darwin-arm64", is_windows=False)
     assert not env.is_windows
 
     # -- Test with a windows platform id.
-    env = make_test_apio_env(platform_id="windows_amd64", is_windows=True)
+    env = make_test_apio_env(platform_id="windows-amd64", is_windows=True)
     assert env.is_windows
 
 

--- a/test/scons/testing.py
+++ b/test/scons/testing.py
@@ -29,7 +29,7 @@ verbosity {
   pnr: false
 }
 environment {
-  platform_id: "darwin_arm64"
+  platform_id: "darwin-arm64"
   is_debug: true
   yosys_path: "/Users/user/.apio/packages/oss-cad-suite/share/yosys"
   trellis_path: "/Users/user/.apio/packages/oss-cad-suite/share/trellis"

--- a/test/test_profile.py
+++ b/test/test_profile.py
@@ -30,7 +30,7 @@ def test_profile_loading(apio_runner: ApioRunner):
         path = sb.home_dir / "profile.json"
         sb.write_file(path, json.dumps(TEST_DATA, indent=2))
 
-        # -- Read back the contnt.
+        # -- Read back the content.
         profile = Profile(sb.home_dir, "http://fake-domain.com/config")
 
         # -- Verify


### PR DESCRIPTION
@Obijuan, @cavearr, please review and approve.

* Added badges to the apio main page.
* Remove the concept of legacy platform tag, now using consistent platform ids everywhere. 
* Change the format of platform ids to use '-' instead of '_' to be consistent with our naming conventions for boards, fpgas, packages, and more.
* Added validation that packages versions are specified as 2025.06.13 rather than 2025.6.13 for consistency with the 2025-06-13 tags that are used in package names.
