### PR TITLE
Replaced the INTERACTIVE_SIM= macro with APIO_SIM=0|1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,6 +72,7 @@
         "iceprog",
         "ICESTORM",
         "Icestudio",
+        "ifndef",
         "issuecomment",
         "itercontent",
         "iverilog",

--- a/apio/commands/apio_sim.py
+++ b/apio/commands/apio_sim.py
@@ -46,13 +46,15 @@ the project directory, even if using the '--project-dir' option.
 testbenches, as this may override the default name and location Apio sets \
 for the generated .vcd file.
 
-The sim command defines the INTERACTIVE_SIM macro, which can be used in the \
-testbench to distinguish between 'apio test' and 'apio sim'. For example, \
-you can use this macro to ignore certain errors when running with 'apio sim' \
-and view the erroneous signals in GTKWave.
+The sim command defines the macro 'APIO_SIM=1' which can be used by \
+testbenches to skip `$fatal` statements to have the simulation continue and \
+generate signals for the GTKWave viewer.
 
-For a sample testbench that utilizes this macro, see the example at: \
-https://github.com/FPGAwars/apio-examples/tree/master/upduino31/testbench
+[code]# Instead of this
+$fatal;
+
+# Use this
+if (!`APIO_SIM) $fatal;[/code]
 
 [b][Hint][/b] When configuring the signals in GTKWave, save the \
 configuration so you don’t need to repeat it each time you run the \

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -12,5 +12,5 @@
 
   // "remote-config": "https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
 
-  // "remote-config": "file:///projects/apio-dev/repo/remote-config/apio-{V}.jsonc"
+  // export APIO_REMOTE_CONFIG_URL="file:///projects/apio-dev/repo/remote-config/apio-{V}.jsonc"
 }

--- a/docs/cmd-apio-sim.md
+++ b/docs/cmd-apio-sim.md
@@ -7,6 +7,18 @@ the default testbench using the `default-testbench` option in `apio.ini`.
 If this option is not set and there's only one testbench in the project,
 that file will be used.
 
+The `apio sim` command defines the macro `APIO_SIM=1`, which allows failed
+assertions to skip the `$fatal` call. This lets the simulation continue and
+display faulty signals in the GTKWave viewer.
+
+```
+# Instead of this
+$fatal;
+
+# Use this
+if (!`APIO_SIM) $fatal;
+```
+
 ## EXAMPLES
 
 ```
@@ -30,8 +42,6 @@ apio sim my_module_tb.sv   # Simulate the specified testbench
 - Avoid using the Verilog `$dumpfile()` function, as it can override the default name and location Apio assigns for the `.vcd` file.
 
 - Testbench paths must always be relative to the project directory, even when using `--project-dir`.
-
-- The `apio sim` command defines the `INTERACTIVE_SIM` macro, which can be used in your testbench to distinguish it from `apio test`. For instance, you might suppress certain errors during interactive simulation to inspect signals in GTKWave.
 
 - For a sample testbench that utilizes this macro, see the apio example `alhambra-ii/getting-started`.
 

--- a/docs/using-testbenches.md
+++ b/docs/using-testbenches.md
@@ -26,7 +26,7 @@ Apio testbench rules:
   
 * **Rule 3**: Compare expected values to actual values, and if they don't match, print an error message and call `$fatal` to exit.
   
-* **Rule 4**: Whenever you call `$fatal` in the testbench, first check the condition `ifndef INTERACTIVE_SIM` to skip `$fatal` if the condition is false.
+* **Rule 4**: Instead of `$fatal`, use ``if (!`APIO_SIM) $fatal``.
   
 * **Rule 5**: At the end of the testbench, print the message "End of simulation".
   
@@ -101,9 +101,7 @@ module Main_tb;
         $display("ERROR at toggle %0d: expected ROWS[1:0] = %b%b, got %b%b",
                  i, expected_toggle, ~expected_toggle, ROWS[1], ROWS[0]);
         tb_error = 1;
-`ifndef INTERACTIVE_SIM
-        $fatal;
-`endif
+        if (!`APIO_SIM) $fatal;
       end
       expected_toggle = ~expected_toggle;
       @(posedge CLK);

--- a/remote-config/apio-0.9.7.jsonc
+++ b/remote-config/apio-0.9.7.jsonc
@@ -17,7 +17,7 @@
         "name": "apio-examples"
       },
       "release": {
-        "version": "2025.06.13",
+        "version": "2025.06.19",
         "release-tag": "${YYYY-MM-DD}",
         "package-file": "apio-examples-${YYYYMMDD}.tgz"
       }

--- a/scripts/COMMANDS.txt
+++ b/scripts/COMMANDS.txt
@@ -947,14 +947,15 @@ Usage: apio sim [OPTIONS] [TESTBENCH]
   testbenches, as this may override the default name and location Apio
   sets for the generated .vcd file.
 
-  The sim command defines the INTERACTIVE_SIM macro, which can be used
-  in the testbench to distinguish between 'apio test' and 'apio sim'.
-  For example, you can use this macro to ignore certain errors when
-  running with 'apio sim' and view the erroneous signals in GTKWave.
+  The sim command defines the macro 'APIO_SIM=1' which can be used by
+  testbenches to skip `$fatal` statements to have the simulation
+  continue and generate signals for the GTKWave viewer.
 
-  For a sample testbench that utilizes this macro, see the example at:
-  https://github.com/FPGAwars/apio-examples/tree/master/upduino31/testbe
-  nch
+  # Instead of this
+  $fatal;
+
+  # Use this
+  if (!`APIO_SIM) $fatal;
 
   [Hint] When configuring the signals in GTKWave, save the configuration
   so you don’t need to repeat it each time you run the simulation.

--- a/test/example_projects/ecp5/colorlight-5a-75b-v8/parity/apio_testing.vh
+++ b/test/example_projects/ecp5/colorlight-5a-75b-v8/parity/apio_testing.vh
@@ -15,15 +15,12 @@
     end
 
 // Asserts that the value of 'signal' is 'value'. If not, it prints an error message and aborts
-// the simulation. When running under apio sim, the macro INTERACTIVE_SIM is defined
-// and the failed assertions does not exist to allow showing the sigmulation results
-// in the graphical window.
+// the simulation. When running under apio sim, skip $fatal so we can see the
+// faulty signals in GTKWave.
 `define EXPECT(signal, value) \
     if (signal !== (value)) begin \
         $display("*** ASSERTION FAILED in %m (clk_num=%0d): expected (signal == value), actual: 'h%h", (clk_num), (signal)); \
-        `ifndef INTERACTIVE_SIM \
-             $fatal; \
-        `endif \
+        if (!`APIO_SIM) $fatal; \
     end
 
 // Transition from clock low to clock high. Typically this is not

--- a/test/example_projects/gowin/sipeed-tang-nano-9k/blinky/apio_testing.vh
+++ b/test/example_projects/gowin/sipeed-tang-nano-9k/blinky/apio_testing.vh
@@ -15,15 +15,12 @@
     end
 
 // Asserts that the value of 'signal' is 'value'. If not, it prints an error message and aborts
-// the simulation. When running under apio sim, the macro INTERACTIVE_SIM is defined
-// and the failed assertions does not exist to allow showing the sigmulation results
-// in the graphical window.
+// the simulation. When running under apio sim, skip $fatal so we can see the
+// faulty signals in GTKWave.
 `define EXPECT(signal, value) \
     if (signal !== (value)) begin \
         $display("*** ASSERTION FAILED in %m (clk_num=%0d): expected (signal == value), actual: 'h%h", (clk_num), (signal)); \
-        `ifndef INTERACTIVE_SIM \
-             $fatal; \
-        `endif \
+        if (!`APIO_SIM) $fatal; \
     end
 
 // Transition from clock low to clock high. Typically this is not

--- a/test/example_projects/gowin/sipeed-tang-nano-9k/parity/apio_testing.vh
+++ b/test/example_projects/gowin/sipeed-tang-nano-9k/parity/apio_testing.vh
@@ -15,15 +15,12 @@
     end
 
 // Asserts that the value of 'signal' is 'value'. If not, it prints an error message and aborts
-// the simulation. When running under apio sim, the macro INTERACTIVE_SIM is defined
-// and the failed assertions does not exist to allow showing the sigmulation results
-// in the graphical window.
+// the simulation. When running under apio sim, skip $fatal so we can see the
+// faulty signals in GTKWave.
 `define EXPECT(signal, value) \
     if (signal !== (value)) begin \
         $display("*** ASSERTION FAILED in %m (clk_num=%0d): expected (signal == value), actual: 'h%h", (clk_num), (signal)); \
-        `ifndef INTERACTIVE_SIM \
-             $fatal; \
-        `endif \
+        if (!`APIO_SIM) $fatal; \
     end
 
 // Transition from clock low to clock high. Typically this is not

--- a/test/example_projects/ice40/alhambra-ii/bcd-counter/testing/apio_testing.vh
+++ b/test/example_projects/ice40/alhambra-ii/bcd-counter/testing/apio_testing.vh
@@ -15,15 +15,12 @@
     end
 
 // Asserts that the value of 'signal' is 'value'. If not, it prints an error message and aborts
-// the simulation. When running under apio sim, the macro INTERACTIVE_SIM is defined
-// and the failed assertions does not exist to allow showing the sigmulation results
-// in the graphical window.
+// the simulation. When running under apio sim, skip $fatal so we can see the
+// faulty signals in GTKWave.
 `define EXPECT(signal, value) \
     if (signal !== (value)) begin \
         $display("*** ASSERTION FAILED in %m (clk_num=%0d): expected (signal == value), actual: 'h%h", (clk_num), (signal)); \
-        `ifndef INTERACTIVE_SIM \
-             $fatal; \
-        `endif \
+        if (!`APIO_SIM) $fatal; \
     end
 
 // Transition from clock low to clock high. Typically this is not


### PR DESCRIPTION
Hi @cavearr, please review and accept.

See https://github.com/FPGAwars/apio/issues/638

Also, bumped examples package version to 2025-06-19 which is adapted for APIO_SIM.