### PR TITLE
Assorted cleanups.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -131,6 +131,7 @@
         "testbench",
         "testbenches",
         "testpypi",
+        "timedates",
         "tinyprog",
         "truecolor",
         "udevadm",

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -202,10 +202,14 @@ class ApioContext:
             default=self.config["remote-config-url"],
         )
         remote_config_ttl_days = self.config["remote-config-ttl-days"]
+        remote_config_retry_minutes = self.config[
+            "remote-config-retry-minutes"
+        ]
         self.profile = Profile(
             self.home_dir,
             remote_config_url,
             remote_config_ttl_days,
+            remote_config_retry_minutes,
             config_policy,
         )
 

--- a/apio/commands/apio.py
+++ b/apio/commands/apio.py
@@ -8,6 +8,7 @@
 
 
 import click
+from click.exceptions import NoArgsIsHelpError
 from apio.utils.cmd_util import ApioSubgroup, ApioGroup
 from apio.utils import util
 
@@ -88,6 +89,12 @@ def context_settings():
     the alias -h to --help. This applies also to all the sub
     commands such as apio build.
     """
+
+    # -- This causes no args help commands such as 'apio' to return
+    # -- error code 0 instead of 2.
+    # -- Per https://tinyurl.com/click-help-no-args-error
+    NoArgsIsHelpError.exit_code = 0
+
     # Per https://click.palletsprojects.com/en/8.1.x/documentation/
     #     #help-parameter-customization
     return {"help_option_names": ["-h", "--help"]}

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -18,6 +18,7 @@ from apio.utils import util
 from apio.apio_context import ApioContext, ApioContextScope, RemoteConfigPolicy
 from apio.utils.cmd_util import ApioGroup, ApioSubgroup, ApioCommand
 from apio.common.apio_themes import THEMES_TABLE, THEME_LIGHT
+from apio.profile import get_datetime_stamp, days_between_datetime_stamps
 from apio.common.apio_console import (
     PADDING,
     cout,
@@ -29,6 +30,38 @@ from apio.common.apio_console import (
 
 
 # ------ apio info system
+
+
+def construct_remote_config_status_str(apio_ctx: ApioContext) -> str:
+    """Query the apio profile and construct a short string indicating the
+    status of the cached remote config."""
+    config = apio_ctx.profile.remote_config
+    metadata = config.get("metadata", {})
+    timestamp_now = get_datetime_stamp()
+    config_status = []
+    # -- Handle the case of a having a cached config.
+    if config:
+        config_days = days_between_datetime_stamps(
+            metadata.get("loaded-at", ""), timestamp_now, None
+        )
+        # -- Determine cache age in days, if possible.
+        if config_days is not None:
+            config_status.append(
+                f"Cached {util.plurality(config_days, "day")} ago"
+            )
+        else:
+            config_status.append("Cached")
+        # -- Indicate if there is a sign of a failed refresh attempt.
+        if "refresh-failure-on" in metadata:
+            config_status.append("refresh failed.")
+    # -- Handle the case of not having a cached config.
+    else:
+        config_status.append("Not cached")
+
+    # -- Concatenate and return.
+    config_status = ", ".join(config_status)
+    return config_status
+
 
 # -- Text in the rich-text format of the python rich library.
 APIO_INFO_SYSTEM_HELP = """
@@ -55,10 +88,11 @@ environment variable 'APIO_HOME'.
 def _system_cli():
     """Implements the 'apio info system' command."""
 
-    # Create the apio context.
+    # -- Create the apio context. We use 'cached_ok' to cause the config
+    # -- to be loaded so we can report it.
     apio_ctx = ApioContext(
         scope=ApioContextScope.NO_PROJECT,
-        config_policy=RemoteConfigPolicy.NO_CONFIG,
+        config_policy=RemoteConfigPolicy.CACHED_OK,
     )
 
     # -- Define the table.
@@ -86,6 +120,9 @@ def _system_cli():
     table.add_row("Apio packages", str(apio_ctx.packages_dir))
     table.add_row("Remote config URL", apio_ctx.profile.remote_config_url)
     table.add_row(
+        "Remote config status", construct_remote_config_status_str(apio_ctx)
+    )
+    table.add_row(
         "Veriable formatter",
         str(apio_ctx.packages_dir / "verible/bin/verible-verilog-format"),
     )
@@ -97,6 +134,10 @@ def _system_cli():
     # -- Render the table.
     cout()
     ctable(table)
+    cout(
+        "To force a remote config refresh, run 'apio packages update'.",
+        style=INFO,
+    )
 
 
 # ------ apio info platforms

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -47,7 +47,7 @@ def construct_remote_config_status_str(apio_ctx: ApioContext) -> str:
         # -- Determine cache age in days, if possible.
         if config_days is not None:
             config_status.append(
-                f"Cached {util.plurality(config_days, "day")} ago"
+                f"Cached {util.plurality(config_days, 'day')} ago"
             )
         else:
             config_status.append("Cached")

--- a/apio/managers/project.py
+++ b/apio/managers/project.py
@@ -410,8 +410,10 @@ def load_project_from_file(
 
     # -- Currently, apio.ini is still optional so we just warn.
     if not file_path.exists():
-        cerror("Missing project file apio.ini.")
-        cout(f"Expected a file at '{file_path.absolute()}'", style=INFO)
+        cerror(
+            "Missing project file apio.ini.",
+            f"Expected a file at '{file_path.absolute()}'",
+        )
         sys.exit(1)
 
     # -- Read and parse the file.

--- a/apio/managers/scons_filter.py
+++ b/apio/managers/scons_filter.py
@@ -16,11 +16,12 @@ from apio.common.apio_styles import INFO, WARNING, SUCCESS, ERROR
 from apio.utils import util
 
 
-# -- A regex to detect iverilog warnings we want to filter out, per
+# -- A regex to detect iverilog warnings we want to filter out, per issues
+# -- below. Using .* instead of dir separator to cover linux and windows.
 # -- https://github.com/FPGAwars/apio/issues/557
 # -- https://github.com/FPGAwars/apio/issues/530
 IVERILOG_TIMING_WARNING_REGEX = re.compile(
-    r"oss-cad-suite/share/yosys.*warning.*Timing checks are not supported",
+    r"oss-cad-suite.*share.*yosys.*warning.*Timing checks are not supported",
     re.IGNORECASE,
 )
 

--- a/apio/managers/scons_filter.py
+++ b/apio/managers/scons_filter.py
@@ -18,6 +18,7 @@ from apio.utils import util
 
 # -- A regex to detect iverilog warnings we want to filter out, per
 # -- https://github.com/FPGAwars/apio/issues/557
+# -- https://github.com/FPGAwars/apio/issues/530
 IVERILOG_TIMING_WARNING_REGEX = re.compile(
     r"oss-cad-suite/share/yosys.*warning.*Timing checks are not supported",
     re.IGNORECASE,
@@ -108,19 +109,19 @@ class PnrRangeDetector(RangeDetector):
         return None
 
 
-class IVerilogRangeDetector(RangeDetector):
-    """Implements a RangeDetector for the iverolog command output."""
+# class IVerilogRangeDetector(RangeDetector):
+#     """Implements a RangeDetector for the iverolog command output."""
 
-    def classify_line(self, pipe_id: PipeId, line: str) -> RangeEvents:
-        # -- Range start: an iverolog command on stdout.
-        if pipe_id == PipeId.STDOUT and line.startswith("iverilog"):
-            return RangeEvents.START_AFTER
+#     def classify_line(self, pipe_id: PipeId, line: str) -> RangeEvents:
+#         # -- Range start: an iverolog command on stdout.
+#         if pipe_id == PipeId.STDOUT and line.startswith("iverilog"):
+#             return RangeEvents.START_AFTER
 
-        # Range end: The end message of nextnpr.
-        if pipe_id == PipeId.STDOUT and line.startswith("gtkwave"):
-            return RangeEvents.END_BEFORE
+#         # Range end: The end message of nextnpr.
+#         if pipe_id == PipeId.STDOUT and line.startswith("gtkwave"):
+#             return RangeEvents.END_BEFORE
 
-        return None
+#         return None
 
 
 class SconsFilter:
@@ -132,7 +133,8 @@ class SconsFilter:
     def __init__(self, colors_enabled: bool):
         self.colors_enabled = colors_enabled
         self._pnr_detector = PnrRangeDetector()
-        self._iverilog_detector = IVerilogRangeDetector()
+
+        # self._iverilog_detector = IVerilogRangeDetector()
         # self._iceprog_detector = IceProgRangeDetector()
 
         # -- We cache the values to avoid reevaluating sys env.
@@ -251,7 +253,8 @@ class SconsFilter:
 
         # -- Update the range detectors.
         in_pnr_verbose_range = self._pnr_detector.update(pipe_id, line)
-        in_iverolog_range = self._iverilog_detector.update(pipe_id, line)
+
+        # in_iverolog_range = self._iverilog_detector.update(pipe_id, line)
         # in_iceprog_range = self._iceprog_detector.update(pipe_id, line)
 
         # -- Handle the line while in the nextpnr verbose log range.
@@ -276,15 +279,15 @@ class SconsFilter:
 
         # -- Special handling of iverilog lines. We drop warning line spam
         # -- per Per https://github.com/FPGAwars/apio/issues/530
-        if (
-            in_iverolog_range
-            and pipe_id == PipeId.STDERR
-            and "cells_sim.v" in line
-            and "Timing checks are not supported" in line
-        ):
-            # -- Drop the line.
-            self._ignore_line(line)
-            return
+        # if (
+        #     in_iverolog_range
+        #     and pipe_id == PipeId.STDERR
+        #     and "cells_sim.v" in line
+        #     and "Timing checks are not supported" in line
+        # ):
+        #     # -- Drop the line.
+        #     self._ignore_line(line)
+        #     return
 
         # -- Special filter for https://github.com/FPGAwars/apio/issues/557
         if IVERILOG_TIMING_WARNING_REGEX.search(line):

--- a/apio/managers/scons_filter.py
+++ b/apio/managers/scons_filter.py
@@ -16,16 +16,6 @@ from apio.common.apio_styles import INFO, WARNING, SUCCESS, ERROR
 from apio.utils import util
 
 
-# -- A regex to detect iverilog warnings we want to filter out, per issues
-# -- below. Using .* instead of dir separator to cover linux and windows.
-# -- https://github.com/FPGAwars/apio/issues/557
-# -- https://github.com/FPGAwars/apio/issues/530
-IVERILOG_TIMING_WARNING_REGEX = re.compile(
-    r"oss-cad-suite.*share.*yosys.*warning.*Timing checks are not supported",
-    re.IGNORECASE,
-)
-
-
 class PipeId(Enum):
     """Represent the two output streams from the scons subprocess."""
 
@@ -108,21 +98,6 @@ class PnrRangeDetector(RangeDetector):
             return RangeEvents.END_AFTER
 
         return None
-
-
-# class IVerilogRangeDetector(RangeDetector):
-#     """Implements a RangeDetector for the iverolog command output."""
-
-#     def classify_line(self, pipe_id: PipeId, line: str) -> RangeEvents:
-#         # -- Range start: an iverolog command on stdout.
-#         if pipe_id == PipeId.STDOUT and line.startswith("iverilog"):
-#             return RangeEvents.START_AFTER
-
-#         # Range end: The end message of nextnpr.
-#         if pipe_id == PipeId.STDOUT and line.startswith("gtkwave"):
-#             return RangeEvents.END_BEFORE
-
-#         return None
 
 
 class SconsFilter:
@@ -276,25 +251,6 @@ class SconsFilter:
                 ],
             )
             self._output_line(line, line_color, terminator)
-            return
-
-        # -- Special handling of iverilog lines. We drop warning line spam
-        # -- per Per https://github.com/FPGAwars/apio/issues/530
-        # if (
-        #     in_iverolog_range
-        #     and pipe_id == PipeId.STDERR
-        #     and "cells_sim.v" in line
-        #     and "Timing checks are not supported" in line
-        # ):
-        #     # -- Drop the line.
-        #     self._ignore_line(line)
-        #     return
-
-        # -- Special filter for https://github.com/FPGAwars/apio/issues/557
-        if IVERILOG_TIMING_WARNING_REGEX.search(line):
-            # -- Ignore this line.
-            # cout(line, style=WARNING)
-            self._ignore_line(line)
             return
 
         # -- Handling the rest of the stdout and stdout lines.

--- a/apio/profile.py
+++ b/apio/profile.py
@@ -15,7 +15,7 @@ from typing import Dict, Optional, Any, List
 from pathlib import Path
 import requests
 from apio.common import apio_console
-from apio.common.apio_console import cout, cerror
+from apio.common.apio_console import cout
 from apio.common.apio_styles import INFO, EMPH3, ERROR
 from apio.utils import util, jsonc
 
@@ -548,9 +548,11 @@ class Profile:
             except Exception as e:
                 # -- Since local config file can be fixed and doesn't depend
                 # -- on availability of a remote server, we make this a fatal
-                # -- error instead of returning None.
-                cerror("Failed to read a local config file.", str(e))
-                sys.exit(1)
+                # -- error instead of a soft error.
+                self._handle_config_refresh_failure(
+                    msg=["Failed to read a local config file.", str(e)],
+                    error_is_fatal=True,
+                )
 
             # -- Local file read OK.
             return file_text

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -12,7 +12,7 @@
   // config is not available.
   //
   // To force an immediate config fetch, user can run 'apio packages update'.
-  "remote-config-retry-minutes": 60,
+  "remote-config-retry-minutes": 30,
 
   // URL of the apio remote config file. The placeholder {V} is replaced at
   // runtime with apio's version such as "0.9.7".

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -10,6 +10,8 @@
   // fall back to the cached config, and does not apply to cases where a
   // fresh config is required, e.g. by 'apio packages update' or if a cached
   // config is not available.
+  //
+  // To force an immediate config fetch, user can run 'apio packages update'.
   "remote-config-retry-minutes": 60,
 
   // URL of the apio remote config file. The placeholder {V} is replaced at

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -1,9 +1,16 @@
 // General config parameters.
 //
 {
-  // How many days we keep a catched remote config before we fetch a new onw.
+  // How many days we keep a cached remote config before we fetch a new onw.
   // Value of 1 means fetching once a day. 7 once every seven days, and so on.
   "remote-config-ttl-days" : 1,
+
+  // The time period in minutes after a config fetch failure until the next
+  // try. This applies only for optional remote config fetch where Apio can
+  // fall back to the cached config, and does not apply to cases where a
+  // fresh config is required, e.g. by 'apio packages update' or if a cached
+  // config is not available.
+  "remote-config-retry-minutes": 60,
 
   // URL of the apio remote config file. The placeholder {V} is replaced at
   // runtime with apio's version such as "0.9.7".

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -21,9 +21,9 @@
   // using the env var APIO_REMOTE_CONFIG_URL, including for reading from
   // a local file using the "file://" protocol spec.
 
-  "remote-config-url": "https://github.com/FPGAwars/apio/raw/develop/remote-config/apio-{V}.jsonc"
+  // "remote-config-url": "https://github.com/fpgawars/apio/raw/develop/remote-config/apio-{V}.jsonc"
 
-  // "remote-config-url": "https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
+  "remote-config-url": "https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
 
 }
 

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -12,7 +12,7 @@
   // config is not available.
   //
   // To force an immediate config fetch, user can run 'apio packages update'.
-  "remote-config-retry-minutes": 30,
+  "remote-config-retry-minutes": 60,
 
   // URL of the apio remote config file. The placeholder {V} is replaced at
   // runtime with apio's version such as "0.9.7".

--- a/apio/utils/cmd_util.py
+++ b/apio/utils/cmd_util.py
@@ -259,10 +259,10 @@ class ApioGroup(click.Group):
         assert isinstance(self.subgroups, list)
         assert isinstance(self.subgroups[0], ApioSubgroup)
 
-        # -- Override the static variable of the BaseCommand class to point
+        # -- Override the static variable of the Command class to point
         # -- to our custom ApioCmdContext. This causes the command to use
         # -- contexts of type ApioCmdContext instead of click.Context.
-        click.BaseCommand.context_class = ApioCmdContext
+        click.Command.context_class = ApioCmdContext
 
         # -- Pass the rest of the arg to init the base class.
         super().__init__(*args, **kwargs)

--- a/apio/utils/resource_util.py
+++ b/apio/utils/resource_util.py
@@ -90,9 +90,14 @@ PROGRAMMER_SCHEMA = {
 # -- JSON schema for validating config.jsonc.
 CONFIG_SCHEMA = {
     "type": "object",
-    "required": ["remote-config-ttl-days", "remote-config-url"],
+    "required": [
+        "remote-config-ttl-days",
+        "remote-config-retry-minutes",
+        "remote-config-url",
+    ],
     "properties": {
-        "remote-config-ttl-days": {"type": "integer", "minimum": 0},
+        "remote-config-ttl-days": {"type": "integer", "minimum": 1},
+        "remote-config-retry-minutes": {"type": "integer", "minimum": 0},
         "remote-config-url": {"type": "string"},
     },
     "additionalProperties": False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers=[
 ]
 requires-python = ">=3.11"
 requires = [
-    'click==8.1.8',
+    'click==8.2.1',
     'colorama==0.4.6',
     'configobj==5.0.9',
     'debugpy==1.8.11',

--- a/remote-config/apio-0.9.7.jsonc
+++ b/remote-config/apio-0.9.7.jsonc
@@ -13,7 +13,7 @@
     // -- Examples
     "examples": {
       "repository": {
-        "organization": "FPGAwars",
+        "organization": "fpgawars",
         "name": "apio-examples"
       },
       "release": {
@@ -22,14 +22,15 @@
         "package-file": "apio-examples-${YYYYMMDD}.tgz"
       }
     },
-    // -- Yosys HQ suite
+    // -- OSS cad suite
     "oss-cad-suite": {
       "repository": {
-        "organization": "FPGAwars",
+        // "organization": "fpgawars",
+        "organization": "zapta",
         "name": "tools-oss-cad-suite"
       },
       "release": {
-        "version": "2025.06.13",
+        "version": "2025.07.07",
         "release-tag": "${YYYY-MM-DD}",
         "package-file": "apio-oss-cad-suite-${PLATFORM}-${YYYYMMDD}.tgz"
       }
@@ -37,7 +38,7 @@
     // -- Graphviz
     "graphviz": {
       "repository": {
-        "organization": "FPGAwars",
+        "organization": "fpgawars",
         "name": "tools-graphviz"
       },
       "release": {
@@ -49,7 +50,7 @@
     // -- Verible
     "verible": {
       "repository": {
-        "organization": "FPGAwars",
+        "organization": "fpgawars",
         "name": "tools-verible"
       },
       "release": {
@@ -61,7 +62,7 @@
     // -- Drivers
     "drivers": {
       "repository": {
-        "organization": "FPGAwars",
+        "organization": "fpgawars",
         "name": "tools-drivers"
       },
       "release": {

--- a/remote-config/apio-0.9.7.jsonc
+++ b/remote-config/apio-0.9.7.jsonc
@@ -17,7 +17,7 @@
         "name": "apio-examples"
       },
       "release": {
-        "version": "2025.07.06",
+        "version": "2025.07.07",
         "release-tag": "${YYYY-MM-DD}",
         "package-file": "apio-examples-${YYYYMMDD}.tgz"
       }

--- a/remote-config/apio-0.9.7.jsonc
+++ b/remote-config/apio-0.9.7.jsonc
@@ -17,7 +17,7 @@
         "name": "apio-examples"
       },
       "release": {
-        "version": "2025.06.21",
+        "version": "2025.07.06",
         "release-tag": "${YYYY-MM-DD}",
         "package-file": "apio-examples-${YYYYMMDD}.tgz"
       }

--- a/scripts/COMMANDS.txt
+++ b/scripts/COMMANDS.txt
@@ -904,8 +904,7 @@ Usage: apio packages list [OPTIONS]
     apio packages list
 
 Options:
-  -v, --verbose  Show detailed output.
-  -h, --help     Show this message and exit.
+  -h, --help  Show this message and exit.
 
 
 

--- a/test/unit_tests/test_profile.py
+++ b/test/unit_tests/test_profile.py
@@ -120,6 +120,7 @@ def test_profile_loading_config_ok(apio_runner: ApioRunner):
             sb.home_dir,
             TEST_REMOTE_CONFIG_URL,
             5,  # TTL in days
+            60,  # Remote config retry mins.
             RemoteConfigPolicy.CACHED_OK,
         )
 
@@ -160,6 +161,7 @@ def test_profile_loading_config_stale_version(apio_runner: ApioRunner):
             sb.home_dir,
             TEST_REMOTE_CONFIG_URL,
             5,  # TTL in days
+            60,  # Remote config retry mins.
             RemoteConfigPolicy.CACHED_OK,
         )
 

--- a/test/unit_tests/test_resources.py
+++ b/test/unit_tests/test_resources.py
@@ -6,6 +6,9 @@ import re
 from test.conftest import ApioRunner
 from apio.apio_context import ApioContext, ApioContextScope, RemoteConfigPolicy
 from apio.utils.resource_util import (
+    validate_config,
+    validate_packages,
+    validate_platforms,
     _validate_board_info,
     _validate_fpga_info,
     _validate_programmer_info,
@@ -102,7 +105,7 @@ def test_resources_ids_and_order(apio_runner: ApioRunner):
             ), f"{programmer_id=}"
 
 
-def test_resources_validation(apio_runner: ApioRunner):
+def test_resources_are_valid(apio_runner: ApioRunner):
     """Validate resources against a schema."""
     with apio_runner.in_sandbox():
 
@@ -110,6 +113,10 @@ def test_resources_validation(apio_runner: ApioRunner):
             scope=ApioContextScope.NO_PROJECT,
             config_policy=RemoteConfigPolicy.CACHED_OK,
         )
+
+        validate_config(apio_ctx.config)
+        validate_packages(apio_ctx.all_packages)
+        validate_platforms(apio_ctx.platforms)
 
         for fpga_id, fpga_info in apio_ctx.fpgas.items():
             _validate_fpga_info(fpga_id, fpga_info)


### PR DESCRIPTION
Hi @cavearr, please take a look and accept.

Highlights

1. Now, when failing the daily fetch of the remote config, using the cache and not trying again for 1 hours. This is to not distract the user if working offline or there is a server issue.

2. Now reporting the age of the cached remote config in 'apio info system'.

3. Commented out redundant suppression of the iverilog 'timing' warning spam (a fix with the iverilog team is on the way).

4. Moved to the latest version of Python Click and addressed the deprecation of BaseCommand.
