### PR TITLE
Updated the ecp5 linter and the mkdocs docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,6 +68,7 @@
         "González",
         "gowin",
         "gtkwave",
+        "helpfull",
         "htmlcov",
         "hver",
         "hwid",

--- a/apio/profile.py
+++ b/apio/profile.py
@@ -614,13 +614,11 @@ class Profile:
             )
 
         except Exception as e:
-            if util.is_debug(1):
-                cout(str(e))
-
             self._handle_config_refresh_failure(
                 msg=[
                     "Downloading of the latest Apio remote config "
-                    "file failed."
+                    "file failed.",
+                    str(e),
                 ],
                 error_is_fatal=error_is_fatal,
             )

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -31,3 +31,8 @@
 //
 // export APIO_REMOTE_CONFIG_URL="file:///projects/apio-dev/repo/remote-config/apio-{V}.jsonc"
 
+// For using the remote config from zapta/apio (during transition)
+//
+// export APIO_REMOTE_CONFIG_URL="https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
+
+

--- a/apio/scons/plugin_ecp5.py
+++ b/apio/scons/plugin_ecp5.py
@@ -44,6 +44,8 @@ class PluginEcp5(PluginBase):
         self.database_path = trellis_path / "database"
         self.yosys_lib_dir = yosys_path / "ecp5"
         self.yosys_lib_file = yosys_path / "ecp5" / "cells_sim.v"
+        # -- For black-box cells such as EHXPLLL PLL.
+        self.yosys_bb_lib_file = yosys_path / "ecp5" / "cells_bb.v"
 
     def plugin_info(self) -> ArchPluginInfo:
         """Return plugin specific parameters."""
@@ -187,7 +189,7 @@ class PluginEcp5(PluginBase):
             action=verilator_lint_action(
                 self.apio_env,
                 lib_dirs=[self.yosys_lib_dir],
-                lib_files=[self.yosys_lib_file],
+                lib_files=[self.yosys_lib_file, self.yosys_bb_lib_file],
             ),
             src_suffix=SRC_SUFFIXES,
             source_scanner=self.verilog_src_scanner,

--- a/docs/additional-tools.md
+++ b/docs/additional-tools.md
@@ -1,0 +1,106 @@
+# Additional tools
+
+The `apio raw` command provides access to additional tools that are included
+in the apio packages, for example, in the `oss-cad-suite` package from the
+YosysHQ project.
+
+This page describes several additional tools available in Apio. The list is not exhaustive.
+
+> If you encounter a useful tool in the apio packages that is not listed
+> here please please file an issue in the
+> [Apio repository](https://github.com/fpgawars/apio/issues) to add it.
+
+---
+
+## ICE40 PLL generator
+
+The ICE40 PLL Generator is a command-line tool that creates an ICE40 PLL module from specified flags. It is used to run the design at a different, typically higher, frequency than that of the external clock.
+
+Get help text.
+
+```
+apio raw -- icepll -h
+```
+
+Generate a PLL module that converts a 12 MHz input to a 48 MHz output clock.
+
+```
+apio raw -- icepll -i 12 -o 48 -q -m -f pll.v
+apio format pll.v
+```
+
+> The Apio example alhambra-ii/pll shows a complete project that uses
+> an ICE40 PLL.
+
+> The Apio example alhambra/pll shows a complete project that uses
+> an ICE40 PLL. The `pll.v` file includes unused signal references added to satisfy `apio lint`.
+
+---
+
+## ECP5 PLL generator
+
+The ECP5 PLL Generator is a command-line tool that creates an ECP5 PLL module from specified flags. It is used to run the design at a different, typically higher, frequency than that of the external clock.
+
+Get help text.
+
+```
+apio raw -- ecppll -h
+```
+
+Generate a PLL module that converts a 25 MHz input to a 120 MHz output clock.
+
+```
+apio raw -- ecppll -i 25 -o 120 -f pll.v
+apio format pll.v
+```
+
+> The Apio example colorlight-5a-75b-v8/pll shows a complete project that uses
+> an ECP5 PLL. The `pll.v` file includes unused signal references added to satisfy `apio lint`.
+
+---
+
+## Gowin PLL generator
+
+The GOWIN PLL Generator is a command-line tool that creates a GOWIN PLL module from specified flags. It is used to run the design at a different, typically higher, frequency than that of the external clock.
+
+Get help text.
+
+```
+apio raw -- gowin_pll -h
+```
+
+Generate a PLL module for the Sipeed Nano 9K that converts a 27 MHz input to a 75 MHz output clock.
+
+```
+apio raw -- gowin_pll -d "GW1NR-9 C6/I5" -i 27 -o 75 -f pll.v
+apio format pll.v
+```
+
+> The Apio example sipeed-tang-nano-9k/pll shows a complete project that uses
+> an GOWIN PLL. The `pll.v` file includes unused signal references added to satisfy `apio lint`.
+
+---
+
+## Zadig (Windows only)
+
+Zadig is a third party Windows tool that allow to manage and replace USB 
+device drivers. Zadig is used by Apio to install and uninstall FPGA boards
+drivers on windows but can also be used independently using the command
+
+```
+apio raw -- zadig
+```
+
+---
+
+## Verible verilog diff
+
+verible verilog diff is a command line tool that finds the semantic differences
+between verilog files.
+
+Get help text.
+```
+apio raw -- verible-verilog-diff --helpfull
+```
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Apio command line: command-line.md
       - Using System Verilog: using-system-verilog.md
       - Using testbenches: using-testbenches.md
+      - Additional tools: additional-tools.md
   - Apio Development:
       - Apio repositories: apio-repositories.md
       - Development environment: development-environment.md

--- a/remote-config/apio-0.9.7.jsonc
+++ b/remote-config/apio-0.9.7.jsonc
@@ -17,7 +17,7 @@
         "name": "apio-examples"
       },
       "release": {
-        "version": "2025.07.08",
+        "version": "2025.07.09",
         "release-tag": "${YYYY-MM-DD}",
         "package-file": "apio-examples-${YYYYMMDD}.tgz"
       }


### PR DESCRIPTION
Hi @cavearr, please review and accept.

1. Added to the ecp5 linter a yosys lib for blackbox cells such as the ecp5 PLL.

2. Added to the Apio docs a new page with additional tools such as `ice40pll` that can be accessed via `apio raw --`.