### PR TITLE
Bumped Apio version to 1.0.0 and updated the docs.

### DIFF
--- a/apio/__init__.py
+++ b/apio/__init__.py
@@ -11,7 +11,7 @@
 # --------------------------------------------
 
 # -- Developer: Change this number when releasing a new version
-VERSION = (0, 9, 7)
+VERSION = (1, 0, 0)
 
 # -- Get the version as a string. Ex: "0.10.1"
 __version__ = ".".join([str(s) for s in VERSION])

--- a/apio/profile.py
+++ b/apio/profile.py
@@ -617,7 +617,7 @@ class Profile:
             error_msg = str(e)
 
         # -- Error codes such as 404 don't cause an exception so we handle
-        # -- them here seperatly.
+        # -- them here separately.
         if (error_msg is None) and (resp.status_code != 200):
             error_msg = (
                 f"Expected HTTP status code 200, got {resp.status_code}."

--- a/apio/profile.py
+++ b/apio/profile.py
@@ -612,13 +612,24 @@ class Profile:
             resp: requests.Response = requests.get(
                 self.remote_config_url, timeout=25
             )
-
+            error_msg = None
         except Exception as e:
+            error_msg = str(e)
+
+        # -- Error codes such as 404 don't cause an exception so we handle
+        # -- them here seperatly.
+        if (error_msg is None) and (resp.status_code != 200):
+            error_msg = (
+                f"Expected HTTP status code 200, got {resp.status_code}."
+            )
+
+        # -- If an error was found then handle it.
+        if error_msg is not None:
             self._handle_config_refresh_failure(
                 msg=[
                     "Downloading of the latest Apio remote config "
                     "file failed.",
-                    str(e),
+                    error_msg,
                 ],
                 error_is_fatal=error_is_fatal,
             )

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -21,9 +21,9 @@
   // using the env var APIO_REMOTE_CONFIG_URL, including for reading from
   // a local file using the "file://" protocol spec.
 
-  "remote-config-url": "https://github.com/fpgawars/apio/raw/develop/remote-config/apio-{V}.jsonc"
+  // "remote-config-url": "https://github.com/fpgawars/apio/raw/develop/remote-config/apio-{V}.jsonc"
 
-  // "remote-config-url": "https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
+  "remote-config-url": "https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
 
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,13 @@
 
 ![](assets/apio-illustration.png)
 
+!!! note
+    NOTE: This documentation is for Apio 1.0.0 and later. For
+    documentation of Apio 0.9.5 and older please see
+    <https://github.com/FPGAwars/apio/wiki>
+
+<br>
+
 **Apio** is an **easy-to-install** and **easy-to-use** open-source toolbox that simplifies FPGA development. It provides simple commands such as:
 
 - `apio lint` – to verify the code

--- a/docs/installing-apio.md
+++ b/docs/installing-apio.md
@@ -28,7 +28,7 @@ follow these steps:
 
 2.  Install Apio using pip:
 
-        pip install --force-reinstall apio
+        pip install --force-reinstall -U git+https://github.com/fpgawars/apio.git@develop
 
 3.  In a **new shell window**, run the following command to test your installation:
 
@@ -40,7 +40,7 @@ follow these steps:
 
 To install Apio on macOS Apple Silicon using an installer, follow these steps:
 
-1.  From the [latest release](https://github.com/FPGAwars/apio-dev-builds/releases) download the installer file:
+1.  From the [latest release](https://github.com/fpgawars/apio-dev-builds/releases) download the installer file:
 
         apio-darwin-arm64-[version]-[date]-installer.pkg
 
@@ -62,7 +62,7 @@ To install Apio on macOS Apple Silicon using an installer, follow these steps:
 To install Apio on macOS Apple Silicon using a file bundle,
 follow these steps:
 
-1.  From the [latest release](https://github.com/FPGAwars/apio-dev-builds/releases) download the file bundle:
+1.  From the [latest release](https://github.com/fpgawars/apio-dev-builds/releases) download the file bundle:
 
         apio-darwin-arm64-[version]-[date]-bundle.tgz
 
@@ -92,7 +92,7 @@ To install Apio on macOS Intel Silicon using a Pip package, follow these steps:
 
 2.  Install Apio using pip:
 
-        pip install --force-reinstall apio
+        pip install --force-reinstall -U git+https://github.com/fpgawars/apio.git@develop
 
 3.  In a **new shell window**, run the following command to test your installation:
 
@@ -114,7 +114,7 @@ To install Apio on Linux X86-64 using a Pip package, follow these steps:
 
 2.  Install Apio using pip:
 
-        pip install --force-reinstall apio
+        pip install --force-reinstall -U git+https://github.com/fpgawars/apio.git@develop
 
 3.  In a **new shell window**, run the following command to test your installation:
 
@@ -126,7 +126,7 @@ To install Apio on Linux X86-64 using a Pip package, follow these steps:
 
 To install Apio on Linux X86-64 using a Debian package, follow these steps:
 
-1.  From the [latest release](https://github.com/FPGAwars/apio-dev-builds/releases) download the Debian package file:
+1.  From the [latest release](https://github.com/fpgawars/apio-dev-builds/releases) download the Debian package file:
 
         apio-linux-x86-64-[version]-[date]-debian.deb
 
@@ -142,7 +142,7 @@ To install Apio on Linux X86-64 using a Debian package, follow these steps:
 
 To install Apio on Linux X86-64 using a file bundle, follow these steps:
 
-1.  From the [latest release](https://github.com/FPGAwars/apio-dev-builds/releases) download the file bundle:
+1.  From the [latest release](https://github.com/fpgawars/apio-dev-builds/releases) download the file bundle:
 
         apio-linux-x86-64-[version]-[date]-bundle.tgz
 
@@ -170,7 +170,7 @@ To install Apio on Linux ARM-64 using a Pip package, follow these steps:
 
 2.  Install Apio using pip:
 
-        pip install --force-reinstall apio
+        pip install --force-reinstall -U git+https://github.com/fpgawars/apio.git@develop
 
 3.  In a **new shell window**, run the following command to test your installation:
 
@@ -192,7 +192,7 @@ To install Apio on Windows X86-64 using a Pip package, follow these steps:
 
 2.  Install Apio using pip:
 
-        pip install --force-reinstall apio
+        pip install --force-reinstall -U git+https://github.com/fpgawars/apio.git@develop
 
 3.  In a **new command window**, run the following command to test your installation:
 
@@ -204,7 +204,7 @@ To install Apio on Windows X86-64 using a Pip package, follow these steps:
 
 To install Apio on Windows X86-64 using an installer, follow these steps:
 
-1.  From the [latest release](https://github.com/FPGAwars/apio-dev-builds/releases) download the installer file:
+1.  From the [latest release](https://github.com/fpgawars/apio-dev-builds/releases) download the installer file:
 
         apio-windows-amd64-[version]-[date]-installer.exe
 
@@ -221,7 +221,7 @@ To install Apio on Windows X86-64 using an installer, follow these steps:
 
 To install Apio on Windows X86-64 using a file bundle, follow these steps:
 
-1.  From the [latest release](https://github.com/FPGAwars/apio-dev-builds/releases) download the file bundle:
+1.  From the [latest release](https://github.com/fpgawars/apio-dev-builds/releases) download the file bundle:
 
         apio-windows-amd64-[version]-[date]-bundle.zip
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # The project name.
-site_name: Apio Docs
+site_name: Apio 1.x.x Documentation
 
 # The temporary directory with the generated site.
 site_dir: _site

--- a/remote-config/apio-0.9.7.jsonc
+++ b/remote-config/apio-0.9.7.jsonc
@@ -1,4 +1,4 @@
-// Remote config file for Apio 0.9.6
+// Remote config file for Apio 0.9.7
 //
 // Supported vars (see installer.py for details):
 //

--- a/remote-config/apio-1.0.0.jsonc
+++ b/remote-config/apio-1.0.0.jsonc
@@ -1,0 +1,74 @@
+// Remote config file for Apio 1.0.0
+//
+// Supported vars (see installer.py for details):
+//
+//   ${PLATFORM}         - platform tag (from platforms.jsonc)
+//   ${YYYY-MM-DD}       - version as YYYY-MM-DD
+//   ${YYYYMMDD}         - version as YYYYMMDD
+//
+// NOTE: Github has a cache propagation of about 1 min between the
+// time this file is submitted and until it's available for download.
+{
+  "packages": {
+    // -- Examples
+    "examples": {
+      "repository": {
+        "organization": "fpgawars",
+        "name": "apio-examples"
+      },
+      "release": {
+        "version": "2025.07.11",
+        "release-tag": "${YYYY-MM-DD}",
+        "package-file": "apio-examples-${YYYYMMDD}.tgz"
+      }
+    },
+    // -- OSS cad suite
+    "oss-cad-suite": {
+      "repository": {
+        "organization": "fpgawars",
+        "name": "tools-oss-cad-suite"
+      },
+      "release": {
+        "version": "2025.07.07",
+        "release-tag": "${YYYY-MM-DD}",
+        "package-file": "apio-oss-cad-suite-${PLATFORM}-${YYYYMMDD}.tgz"
+      }
+    },
+    // -- Graphviz
+    "graphviz": {
+      "repository": {
+        "organization": "fpgawars",
+        "name": "tools-graphviz"
+      },
+      "release": {
+        "version": "2025.06.13",
+        "release-tag": "${YYYY-MM-DD}",
+        "package-file": "apio-graphviz-${PLATFORM}-${YYYYMMDD}.tgz"
+      }
+    },
+    // -- Verible
+    "verible": {
+      "repository": {
+        "organization": "fpgawars",
+        "name": "tools-verible"
+      },
+      "release": {
+        "version": "2025.06.13",
+        "release-tag": "${YYYY-MM-DD}",
+        "package-file": "apio-verible-${PLATFORM}-${YYYYMMDD}.tgz"
+      }
+    },
+    // -- Drivers
+    "drivers": {
+      "repository": {
+        "organization": "fpgawars",
+        "name": "tools-drivers"
+      },
+      "release": {
+        "version": "2025.06.13",
+        "release-tag": "${YYYY-MM-DD}",
+        "package-file": "apio-drivers-${PLATFORM}-${YYYYMMDD}.tgz"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi @cavearr, please review and accept.

1. Bumped Apio version from 0.9.7 to 1.0.0

2. Updated the new docs to reflect the current status where the new apio is not yet available on PyPi.

3. Minor cleanupes.