### PR TITLE
add an ColorLight-i9 board with cmsisdap cable for openFPGALoader

### DIFF
--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -242,6 +242,15 @@
       "extra-args": "-c usb-blaster -v --file-type bin"
     }
   },
+  "colorlight-i9-v7-2-cmsis-dap": {
+    "legacy-name": "ColorLight-i9-v7.2_(CMSIS-DAP)",
+    "description": "ColorLight-i9",
+    "fpga-id": "lfe5u-45f-6bg381c",
+    "programmer": {
+      "id": "openfpgaloader",
+      "extra-args": "-c cmsisdap -v --file-type bin"
+    }
+  },
   "cynthion-r1-4": {
     "legacy-name": "Cynthion-r1.4",
     "description": "Cynthion r1.4",

--- a/docs/supported-boards.md
+++ b/docs/supported-boards.md
@@ -69,6 +69,7 @@
 | colorlight-i9-v7-2-ft2232h        | 45k  | ColorLight-i9               | LFE5U-45F-6BG381C    |
 | colorlight-i9-v7-2-ft232h         | 45k  | ColorLight-i9               | LFE5U-45F-6BG381C    |
 | colorlight-i9-v7-2-usb-blaster    | 45k  | ColorLight-i9               | LFE5U-45F-6BG381C    |
+| colorlight-i9-v7-2-cmsis-dap      | 45k  | ColorLight-i9               | LFE5U-45F-6BG381C    |
 | cynthion-r1-4                     | 12k  | Cynthion r1.4               | LFE5U-12F-6BG256C    |
 | ecp5-evaluation-board             | 85k  | ECP5-Evaluation-Board       | LFE5UM5G-85F-8BG381C |
 | ecp5-mini-12                      | 12k  | ECP5-Mini-12                | LFE5U-12F-6BG256C    |


### PR DESCRIPTION
I've got an ColorLight-i9 with ext-board.

OpenFPGALoder recognised this board via the commands:
- openFPGALoader --detect -b colorlight-i9
- openFPGALoader --detect -c cmsisdap

The output is (idcode is removed):
```
$ openFPGALoader --detect -c cmsisdap
empty
Found 1 compatible device:
	0x0d28 0x0204 0x3 DAPLink CMSIS-DAP
index 0:
	idcode <8-hex-number>
	manufacturer lattice
	family ECP5
	model  LFE5U-45
	irlength 8
```

As this configuration was not supported in apio and icestudio, i will add this to the project.

I hope i have changed all correctly and did not forget anything.
