### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 ![][linux-logo]&nbsp;&nbsp;&nbsp;![][macosx-logo]&nbsp;&nbsp;&nbsp;![][windows-logo]&nbsp;&nbsp;&nbsp;![][ubuntu-logo]&nbsp;&nbsp;&nbsp;![][raspbian-logo]
 
 
+**TL;DR**, Apio is an easy to use toolbox for FPGA development. For q quick start, visit the [Getting started with Apio](https://fpgawars.github.io/apio/quick-start) page.
+
 ## What is Apio?
 
 Apio is a powerful yet **easy-to-use toolbox for FPGA development using Verilog and System Verilog**. It’s simple to install, no toolchains, licenses, or makefiles required, and works across **Linux, Windows, and macOS**. Apio is **open source, free to use**, and supports every stage of the FPGA workflow, **from simulating and testing, to building and programming the FPGA**, using simple commands such as `apio test`, `apio build`, and `apio upload` that do what you expect them to do. Apio integrates smoothly with any text editor and works great with Visual Studio Code and GitHub. It currently supports over **80 FPGA boards**, custom boards can be easily added, and it includes over 60 **ready-to-use example projects**. Apio currently supports the **ICE40, ECP5, and GOWIN** FPGA architectures.

--- a/apio/resources/config.jsonc
+++ b/apio/resources/config.jsonc
@@ -21,10 +21,9 @@
   // using the env var APIO_REMOTE_CONFIG_URL, including for reading from
   // a local file using the "file://" protocol spec.
 
-  // "remote-config-url": "https://github.com/fpgawars/apio/raw/develop/remote-config/apio-{V}.jsonc"
+  "remote-config-url": "https://github.com/fpgawars/apio/raw/develop/remote-config/apio-{V}.jsonc"
 
-  "remote-config-url": "https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
-
+  // "remote-config-url": "https://github.com/zapta/apio/raw/develop/remote-config/apio-{V}.jsonc"
 }
 
 // For local testing, before submitting a new remote config file

--- a/docs/additional-tools.md
+++ b/docs/additional-tools.md
@@ -29,11 +29,9 @@ apio raw -- icepll -i 12 -o 48 -q -m -f pll.v
 apio format pll.v
 ```
 
-> The Apio example alhambra-ii/pll shows a complete project that uses
-> an ICE40 PLL.
-
-> The Apio example alhambra/pll shows a complete project that uses
-> an ICE40 PLL. The `pll.v` file includes unused signal references added to satisfy `apio lint`.
+> The Apio example `alhambra/pll` demonstrates a complete project that uses
+> an ICE40 PLL. The `pll.v` file in the example includes unused signal references added to satisfy `apio lint`.
+> This issue is tracked at <https://github.com/FPGAwars/apio/issues/669>.
 
 ---
 
@@ -54,8 +52,9 @@ apio raw -- ecppll -i 25 -o 120 -f pll.v
 apio format pll.v
 ```
 
-> The Apio example colorlight-5a-75b-v8/pll shows a complete project that uses
-> an ECP5 PLL. The `pll.v` file includes unused signal references added to satisfy `apio lint`.
+> The Apio example `colorlight-5a-75b-v8/pll` demonstrates a complete project that uses
+> an ECP5 PLL. The `pll.v` file in the example includes unused signal references added to satisfy `apio lint`.
+> This issue is tracked at <https://github.com/FPGAwars/apio/issues/670>.
 
 ---
 
@@ -76,8 +75,9 @@ apio raw -- gowin_pll -d "GW1NR-9 C6/I5" -i 27 -o 75 -f pll.v
 apio format pll.v
 ```
 
-> The Apio example sipeed-tang-nano-9k/pll shows a complete project that uses
-> an GOWIN PLL. The `pll.v` file includes unused signal references added to satisfy `apio lint`.
+> The Apio example `sipeed-tang-nano-9k/pll` demonstrates a complete project that uses
+> an GOWIN PLL. The `pll.v` file of the example includes unused signal references added to satisfy `apio lint`.
+> This is tracked in issue <>.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,15 @@
 
 ![](assets/apio-illustration.png)
 
-!!! note
-    NOTE: This documentation is for Apio 1.0.0 and later. For
-    documentation of Apio 0.9.5 and older please see
-    <https://github.com/FPGAwars/apio/wiki>
+> NOTE: This documentation is for Apio 1.0.0 and later. For
+> documentation of Apio 0.9.5 and older, see
+> <https://github.com/FPGAwars/apio/wiki>
 
-<br>
+
+
+> NOTE: You can skip this Apio's overview and jump directly to the
+> [Quick Start](quick-start.md) guide or or to the
+> [installation instructions](installing-apio.md).
 
 **Apio** is an **easy-to-install** and **easy-to-use** open-source toolbox that simplifies FPGA development. It provides simple commands such as:
 
@@ -178,5 +181,5 @@ Options:
 ---
 
 This concludes Apio's overview. We suggest continuing to the
-[Quick Start](quick-start.md) guide or jump to the
-[Installation](installing-apio.md) or
+[Quick Start](quick-start.md) guide or jump directly to the
+[installation instructions](installing-apio.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 
 
-> NOTE: You can skip this Apio's overview and jump directly to the
-> [Quick Start](quick-start.md) guide or or to the
-> [installation instructions](installing-apio.md).
+> NOTE: If you want to skip this overview of Apio, We recommend continuing with the
+[Quick Start](quick-start.md) guide or jumping directly to the
+[installation instructions](installing-apio.md).
 
 **Apio** is an **easy-to-install** and **easy-to-use** open-source toolbox that simplifies FPGA development. It provides simple commands such as:
 
@@ -180,6 +180,6 @@ Options:
 
 ---
 
-This concludes Apio's overview. We suggest continuing to the
-[Quick Start](quick-start.md) guide or jump directly to the
+This concludes the short overview of Apio. We recommend continuing with the
+[Quick Start](quick-start.md) guide or jumping directly to the
 [installation instructions](installing-apio.md).

--- a/docs/installing-apio.md
+++ b/docs/installing-apio.md
@@ -1,17 +1,14 @@
 > This page explains how to install Apio for end users.
 > If you’re an Apio developer, see the [Apio Development Environment](development-environment.md) page.
 
-Apio can be installed in a few ways:
+To install Apio, select your desired method from the Instructions column below and follow the instructions.
 
-| Method             | Description                                                | Platforms             |
-| :----------------- | :--------------------------------------------------------- | :-------------------- |
-| **Pip package**    | Installed using Python `pip` command. Requires Python.     | macOS, Linux, Windows |
-| **Installer**      | A standalone installation using an installer wizard.       | macOS, Windows        |
-| **Debian package** | A standalone installation using the `apt` package manager. | Linux                 |
-| **File bundle**    | A standalone file archive.                                 | macOS, Linux, Windows |
-
-To install Apio, select your platform and preferred installation method from the Table of Contents in the sidebar.
-If the sidebar is not visible, scroll down to find the installation guide for your platform.
+| Method        | Description                                                                                                                                     | Instructions                                                                                                                                                                                           |
+| :------------ | :---------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pip**       | Installation using the Python `pip` command. This method requires [Python](https://www.python.org/downloads) to be preinstalled on your system. | [macOS&nbsp;Apple&nbsp;Silicon](#mac-arm64-pip) <br> [macOS Intel Silicon](#mac-x86-pip) <br> [Linux X86-64](#linux-x86-pip) <br> [Linux ARM-64](#linux-arm64-pip) <br> [Windows](#windows-x86-64-pip) |
+| **Installer** | Installation using an installer wizard.                                                                                                         | [macOS&nbsp;Apple&nbsp;Silicon](#mac-arm64-installer) <br>[Windows](#windows-x86-64-installer)                                                                                                         |
+| **Debian**    | Installation using a Debian package and the `dpkg` package manager.                                                                             | [Linux X86-64](#linux-x86-debian)                                                                                                                                                                      |
+| **Bundle**    | Installation using a file archive that contains all the necessary files to run Apio.                                                            | [macOS Apple Silicon](#mac-arm64-bundle) <br> [Linux X86-64](#linux-x86-bundle) <br> [Windows](#windows-x86-64-bundle)                                                                                 |
 
 ---
 
@@ -182,9 +179,9 @@ To install Apio on Linux ARM-64 using a Pip package, follow these steps:
 
 ## Windows X86-64
 
-To install Apio on Windows X86-64 using a Pip package, follow these steps:
-
 ### Install using a Pip package <a id="windows-x86-64-pip"></a>
+
+To install Apio on Windows X86-64 using a Pip package, follow these steps:
 
 1.  Verify that you have Python installed by running:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -128,5 +128,5 @@ The example now runs on the FPGA board, and two LEDs should be flashing alternat
 
 ---
 
-This concludes the Apio quick start guide. We suggest reviewing the [Video tutorial](video-tutorial.md) or going directly to the [Installing Apio](installing-apio.md) page to install your
-copy of Apio.
+This concludes the Apio quick start guide, we suggest continuing to the [Video tutorial](video-tutorial.md)
+or go ahead and start your own Apio project.

--- a/docs/raw-tools.md
+++ b/docs/raw-tools.md
@@ -1,10 +1,10 @@
-# Additional tools
+# Raw tools
 
 The `apio raw` command provides access to additional tools that are included
 in the apio packages, for example, in the `oss-cad-suite` package from the
 YosysHQ project.
 
-This page describes several additional tools available in Apio. The list is not exhaustive.
+This page describes several such raw tools that are available in Apio. This list is not exhaustive.
 
 > If you encounter a useful tool in the apio packages that is not listed
 > here please please file an issue in the

--- a/docs/raw-tools.md
+++ b/docs/raw-tools.md
@@ -29,9 +29,23 @@ apio raw -- icepll -i 12 -o 48 -q -m -f pll.v
 apio format pll.v
 ```
 
-> The Apio example `alhambra/pll` demonstrates a complete project that uses
-> an ICE40 PLL. The `pll.v` file in the example includes unused signal references added to satisfy `apio lint`.
-> This issue is tracked at <https://github.com/FPGAwars/apio/issues/669>.
+The Apio example `alhambra/pll` demonstrates a `pll.v` module that
+was generated with this command.
+
+> Per [Apio issue 669](https://github.com/FPGAwars/apio/issues/669),
+> the generated module does not pass `apio lint` because it
+> doesn't specify the unused PLL signals. As a workaround, manually add the following
+> signals to the PLL instantiation in `pll.v`:
+
+```
+.PLLOUTGLOBAL(),
+.EXTFEEDBACK(),
+.LATCHINPUTVALUE(),
+.SDO(),
+.SDI(),
+.SCLK(),
+.DYNAMICDELAY()
+```
 
 ---
 
@@ -52,9 +66,24 @@ apio raw -- ecppll -i 25 -o 120 -f pll.v
 apio format pll.v
 ```
 
-> The Apio example `colorlight-5a-75b-v8/pll` demonstrates a complete project that uses
-> an ECP5 PLL. The `pll.v` file in the example includes unused signal references added to satisfy `apio lint`.
-> This issue is tracked at <https://github.com/FPGAwars/apio/issues/670>.
+The Apio example `colorlight-5a-75b-v8/pll` demonstrates a `pll.v` module that
+was generated with this command.
+
+> Per [Apio issue 670](https://github.com/FPGAwars/apio/issues/669),
+> the generated module does not pass `apio lint` because it
+> doesn't specify the unused PLL signals. As a workaround, manually add the following
+> signals to the PLL instantiation in `pll.v`:
+
+```
+.ENCLKOS(),
+.ENCLKOS2(),
+.ENCLKOS3(),
+.CLKOS(),
+.CLKOS2(),
+.CLKOS3(),
+.INTLOCK(),
+.REFCLK()
+```
 
 ---
 
@@ -75,15 +104,14 @@ apio raw -- gowin_pll -d "GW1NR-9 C6/I5" -i 27 -o 75 -f pll.v
 apio format pll.v
 ```
 
-> The Apio example `sipeed-tang-nano-9k/pll` demonstrates a complete project that uses
-> an GOWIN PLL. The `pll.v` file of the example includes unused signal references added to satisfy `apio lint`.
-> This is tracked in issue <>.
+The Apio example `sipeed-tang-nano-9k/pll` demonstrates a `pll.v` module that
+was generated with this command.
 
 ---
 
 ## Zadig (Windows only)
 
-Zadig is a third party Windows tool that allow to manage and replace USB 
+Zadig is a third party Windows tool that allow to manage and replace USB
 device drivers. Zadig is used by Apio to install and uninstall FPGA boards
 drivers on windows but can also be used independently using the command
 
@@ -99,8 +127,7 @@ verible verilog diff is a command line tool that finds the semantic differences
 between verilog files.
 
 Get help text.
+
 ```
 apio raw -- verible-verilog-diff --helpfull
 ```
-
-

--- a/docs/video-tutorial.md
+++ b/docs/video-tutorial.md
@@ -1,10 +1,10 @@
 # Apio Video Tutorial
 
-[Shawn Hymel](https://shawnhymel.com/) created an excellent video series introducing FPGA design using Apio 0.95. To view the series on YouTube, click the video thumbnail below.
+[Shawn Hymel](https://shawnhymel.com/) created an excellent video series introducing FPGA design using Apio 0.6.5. To view the series on YouTube, click the video thumbnail below.
 
 <br>
 
-> The Apio 0.6.5 commands used in the video series differ from the current Apio 1.x.x commands, but all their functionality has been preserved—and even improved. For details, see the [Apio 1.x.x command differences](migrating-from-apio-0xx.md#know-the-new-commands).
+> The Apio 0.6.5 commands used in the video series differ slightly from the enhanced set of Apio 1.x.x commands. For details, see the [Apio 1.x.x command differences](migrating-from-apio-0xx.md#know-the-new-commands).
 
 <br>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ nav:
       - Apio command line: command-line.md
       - Using System Verilog: using-system-verilog.md
       - Using testbenches: using-testbenches.md
-      - Additional tools: additional-tools.md
+      - Raw tools: raw-tools.md
   - Apio Development:
       - Apio repositories: apio-repositories.md
       - Development environment: development-environment.md


### PR DESCRIPTION
Hi @cavearr, please review and accept. This PR should trigger test workflow, even before it's being merged.

1. Updated the documentation

2. Redirected Apio 1.0.0 remote config to fpgawars/apio (was zapta/apio during the transition).