### PR TITLE
Fix verible-verilog-format typo: helpful=>helpfull

### DIFF
--- a/apio/commands/apio_format.py
+++ b/apio/commands/apio_format.py
@@ -56,7 +56,7 @@ Verible formatter directives:
 // verilog_format: on[/code]
 
 For a full list of Verible formatter flags, refer to the documentation page \
-online or use the command 'apio raw -- verible-verilog-format --helpful'.
+online or use the command 'apio raw -- verible-verilog-format --helpfull'.
 """
 
 # -- File types that the format support. 'sv' indicates System Verilog

--- a/docs/cmd-apio-format.md
+++ b/docs/cmd-apio-format.md
@@ -39,7 +39,7 @@ format-verible-options =
 ```
 
 For a full list of Verible formatter flags, refer to the documentation
-page online or use the command `apio raw -- verible-verilog-format --helpful`.
+page online or use the command `apio raw -- verible-verilog-format --helpfull`.
 
 <h3>Protecting code</h3>
 

--- a/scripts/COMMANDS.txt
+++ b/scripts/COMMANDS.txt
@@ -664,7 +664,7 @@ Usage: apio format [OPTIONS] [FILES]...
 
   For a full list of Verible formatter flags, refer to the documentation
   page online or use the command 'apio raw -- verible-verilog-format
-  --helpful'.
+  --helpfull'.
 
 Options:
   -e, --env name          Set the apio.ini env.


### PR DESCRIPTION
Fixed a verible-verilog-format argument misspelling.

See https://chipsalliance.github.io/verible/verilog_format.html