### PR TITLE
Fixing https://github.com/FPGAwars/apio/issues/689

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -123,6 +123,7 @@
         "scons",
         "sconsign",
         "sconstruct",
+        "sconstruction",
         "Shwan",
         "sipeed",
         "spammy",

--- a/apio/resources/boards.jsonc
+++ b/apio/resources/boards.jsonc
@@ -326,7 +326,6 @@
     }
   },
   "icepi-zero": {
-    "legacy-name": "Icepi Zero",
     "description": "Icepi Zero",
     "fpga-id": "lfe5u-25f-6bg256c",
     "programmer": {

--- a/apio/scons/plugin_base.py
+++ b/apio/scons/plugin_base.py
@@ -59,14 +59,11 @@ class PluginBase:
         """Finds and returns the constrain file path."""
         # -- Keep short references.
         apio_env = self.apio_env
-        params = apio_env.params
 
         # -- On first call, determine and cache.
         if self._constrain_file is None:
             self._constrain_file = get_constraint_file(
-                apio_env,
-                self.plugin_info().constrains_file_ext,
-                params.apio_env_params.top_module,
+                apio_env, self.plugin_info().constrains_file_ext
             )
         return self._constrain_file
 

--- a/apio/scons/plugin_util.py
+++ b/apio/scons/plugin_util.py
@@ -64,18 +64,13 @@ def map_params(params: Optional[List[Union[str, Path]]], fmt: str) -> str:
     return " ".join(mapped_params)
 
 
-def get_constraint_file(
-    apio_env: ApioEnv, file_ext: str, top_module: str
-) -> str:
+def get_constraint_file(apio_env: ApioEnv, file_ext: str) -> str:
     """Returns the name of the constrain file to use.
 
-    env is the sconstrution environment.
+    env is the sconstruction environment.
 
     file_ext is a string with the constrained file extension.
     E.g. ".pcf" for ice40.
-
-    top_module is the top module name. It's is used to construct the
-    default file name.
 
     Returns the file name if found or a default name otherwise otherwise.
     """
@@ -84,9 +79,8 @@ def get_constraint_file(
     n = len(files)
     # Case 1: No matching files.
     if n == 0:
-        result = f"{top_module.lower()}{file_ext}"
-        cwarning(f"No {file_ext} constraints file, assuming '{result}'.")
-        return result
+        cerror(f"No constrain file '*{file_ext}' found, expected exactly one.")
+        sys.exit(1)
     # Case 2: Exactly one file found.
     if n == 1:
         result = str(files[0])

--- a/test/unit_tests/scons/test_plugin_util.py
+++ b/test/unit_tests/scons/test_plugin_util.py
@@ -32,14 +32,18 @@ def test_get_constraint_file(
         # -- If not .pcf files, should assume main name + extension and
         # -- inform the user about it.
         capsys.readouterr()  # Reset capture
-        result = get_constraint_file(apio_env, ".pcf", "my_main")
+        with pytest.raises(SystemExit) as e:
+            result = get_constraint_file(apio_env, ".pcf")
         captured = capsys.readouterr()
-        assert "assuming 'my_main.pcf'" in cunstyle(captured.out)
-        assert result == "my_main.pcf"
+        assert e.value.code == 1
+        assert (
+            "Error: No constrain file '*.pcf' found, expected exactly one"
+            in cunstyle(captured.out)
+        )
 
         # -- If a single .pcf file, return it.
         sb.write_file("pinout.pcf", "content")
-        result = get_constraint_file(apio_env, ".pcf", "my_main")
+        result = get_constraint_file(apio_env, ".pcf")
         captured = capsys.readouterr()
         assert captured.out == ""
         assert result == "pinout.pcf"
@@ -48,7 +52,7 @@ def test_get_constraint_file(
         sb.write_file("other.pcf", "content")
         capsys.readouterr()  # Reset capture
         with pytest.raises(SystemExit) as e:
-            result = get_constraint_file(apio_env, ".pcf", "my_main")
+            result = get_constraint_file(apio_env, ".pcf")
         captured = capsys.readouterr()
         assert e.value.code == 1
         assert "Error: Found multiple '*.pcf'" in cunstyle(captured.out)


### PR DESCRIPTION
@cavearr, please review and approve. 

Now if there are no constrained files, failing immediately instead of assuming a default file name.