### PR TITLE
correct invalid 'main-module' instruction in migration guide to 'top-module'

### DIFF
--- a/docs/migrating-from-apio-0.9.5.md
+++ b/docs/migrating-from-apio-0.9.5.md
@@ -17,7 +17,7 @@ Apio CLI 1.x.x requires a project file called `apio.ini` in the directory of eac
 ```
 [env:default]
 board = <board>
-main-module = <my-module>
+top-module = <my-module>
 ```
 
 ## Delete calls to the verilog function `$dumpfile()`.


### PR DESCRIPTION
The sample apio.ini file in the migration guide erroneously referred to a main-module key, that should instead be top-module (as it was in 0.9.5 as well).

(Resubmitting pull request to correct branch and with a verified commit)