### PR TITLE
Added to the Apio CLI builder workflows a step that tests the

### DIFF
--- a/.github/actions/test-apio-bundle/action.yaml
+++ b/.github/actions/test-apio-bundle/action.yaml
@@ -1,0 +1,88 @@
+name: 'Test Apio File Bundle'
+description: 'Tests an Apio file bundle by installing packages and running basic commands in a temporary project'
+
+inputs:
+  apio-bundle-dir:
+    description: 'Relative path to the apio file bundle directory (e.g., apio)'
+    required: true
+  work-dir-name:
+    description: 'Name of the temporary working directory to create for testing'
+    required: true
+    default: 'test_project'
+
+runs:
+  using: 'composite'
+  steps:
+    # - name: Run Apio bundle test
+    #   shell: bash
+    #   run: |
+    #     # Resolve the absolute path of the apio bundle directory
+    #     apio_abs_dir="$(realpath "${{ inputs.apio-bundle-dir }}")"
+    #     echo "Adding to PATH (this step only): $apio_abs_dir"
+    #     export PATH="$PATH:$apio_abs_dir"
+
+    #     # Create and enter the test project directory
+    #     mkdir -p "${{ inputs.work-dir-name }}"
+    #     cd "${{ inputs.work-dir-name }}"
+
+    #     # Fetch an example project
+    #     apio example fetch alhambra-ii/getting-started
+    #     ls -al
+
+    #     # Enable command tracing for better debugging
+    #     set -x
+
+    #     # Install required packages
+    #     apio packages install
+
+    #     # Show system information
+    #     apio info system
+
+    #     # Run basic Apio commands
+    #     apio build
+    #     apio clean
+    #     apio lint
+    #     apio report
+    #   env:
+    #     # Ensure apio commands are available
+    #     PATH: ${{ env.PATH }}
+
+    - name: Test file bundle apio bin
+      shell: bash
+      run: |
+        # Enable command tracing
+        set -x
+
+        # Get a path to the apio bin in the bundle
+        ls -al "${{ inputs.apio-bundle-dir }}"
+        apio_bin="$(realpath "${{ inputs.apio-bundle-dir }}/apio")"
+        echo "apio_bin=$apio_bin"
+
+        # Create and enter the test directory
+        mkdir -p "${{ inputs.work-dir-name }}"
+        cd "${{ inputs.work-dir-name }}"
+
+        # Set a custom empty apio home.
+        export APIO_HOME_DIR="$(realpath _apio_home)"
+        echo "APIO_HOME_DIR=${APIO_HOME}"
+
+        # Make and change to the project dir
+        mkdir _project
+        cd _project
+
+        # Get packages
+        ${apio_bin} packages install
+
+        # Fetch a project
+        ${apio_bin} example fetch alhambra-ii/getting-started
+        ls -al
+
+        # Get system info
+        ${apio_bin} info system
+
+        # Run a few commands
+        ${apio_bin} build
+        ${apio_bin} clean
+        ${apio_bin} lint
+        ${apio_bin} report
+

--- a/.github/workflows/build-darwin-arm64.yaml
+++ b/.github/workflows/build-darwin-arm64.yaml
@@ -194,6 +194,17 @@ jobs:
           pwd
           ls -al
 
+      # -- Now that we are done with the file bundle directory
+      # -- let's test it.
+      - name: Uninstall all pip packages (including apio)
+        uses: fpgawars/apio-workflows/.github/actions/uninstall-all-pip-packages@main
+
+      - name: Test Apio file bundle
+        uses: ./_apio-repo/.github/actions/test-apio-bundle
+        with:
+          apio-bundle-dir: _dist/Apio
+          work-dir-name: _work_dir
+
       - name: Export the pyinstaller bundle as an artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-darwin-x86-64.yaml
+++ b/.github/workflows/build-darwin-x86-64.yaml
@@ -30,9 +30,6 @@ jobs:
           os: darwin
           arch: x86_64
 
-      # - name: Checkout this repo (for builder)
-      #   uses: actions/checkout@v4
-
       - name: Download build-info.json artifact from main job
         uses: actions/download-artifact@v4
         with:
@@ -84,6 +81,8 @@ jobs:
           ref: ${{env.APIO_COMMIT}}
           path: _apio-repo
 
+      # Having apio installed as a package is required for the pyinstaller
+      # build process.
       - name: Pip install apio
         run: |
           python -m pip install --upgrade pip
@@ -198,6 +197,17 @@ jobs:
                        "apio-cli-darwin-x86-64-${PACKAGE_TAG}-installer.pkg"
           pwd
           ls -al
+
+      # -- Now that we are done with the file bundle directory
+      # -- let's test it.
+      - name: Uninstall all pip packages (including apio)
+        uses: fpgawars/apio-workflows/.github/actions/uninstall-all-pip-packages@main
+
+      - name: Test Apio file bundle
+        uses: ./_apio-repo/.github/actions/test-apio-bundle
+        with:
+          apio-bundle-dir: _dist/Apio
+          work-dir-name: _work_dir
 
       - name: Export the pyinstaller bundle as an artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-linux-x86-64.yaml
+++ b/.github/workflows/build-linux-x86-64.yaml
@@ -158,7 +158,7 @@ jobs:
         run: |
           mkdir _debian
 
-          # -- /opt/apio
+          # -- /opt/apio. We mv rather than cp to maintain internal symlinks.
           mkdir -p _debian/opt/apio
           # We mv instead of cp to preserve symlinks.
           mv _dist/apio/apio _debian/opt/apio
@@ -186,6 +186,17 @@ jobs:
         run: |
           dpkg-deb --build --root-owner-group _debian "apio-cli-linux-x86-64-${PACKAGE_TAG}-debian.deb"
           ls -l
+
+      # -- Now that we are done with the file bundle directory
+      # -- let's test it.
+      - name: Uninstall all pip packages (including apio)
+        uses: fpgawars/apio-workflows/.github/actions/uninstall-all-pip-packages@main
+
+      - name: Test Apio file bundle
+        uses: ./_apio-repo/.github/actions/test-apio-bundle
+        with:
+          apio-bundle-dir: _debian/opt/apio
+          work-dir-name: _work_dir
 
       - name: Export the pyinstaller archive as an artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows-amd64.yaml
+++ b/.github/workflows/build-windows-amd64.yaml
@@ -174,6 +174,17 @@ jobs:
           mv innosetup-installer.exe "apio-cli-windows-amd64-${PACKAGE_TAG}-installer.exe"
           ls -al
 
+      # -- Now that we are done with the file bundle directory
+      # -- let's test it.
+      - name: Uninstall all pip packages (including apio)
+        uses: fpgawars/apio-workflows/.github/actions/uninstall-all-pip-packages@main
+
+      - name: Test Apio file bundle
+        uses: ./_apio-repo/.github/actions/test-apio-bundle
+        with:
+          apio-bundle-dir: _dist/Apio
+          work-dir-name: _work_dir
+
       - name: Export the pyinstaller bundle as an artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -167,6 +167,7 @@
         "pyxx",
         "rankdir",
         "readmemh",
+        "realpath",
         "recursesubdirs",
         "redirector",
         "scons",


### PR DESCRIPTION
generated pyinstaller file bundle. The test is not thorough, just running a few apio commands with the built apio binary.