### PR TITLE
Quality: APIO_DEBUG env var parsing crashes on non-numeric values

### DIFF
--- a/apio/__main__.py
+++ b/apio/__main__.py
@@ -9,7 +9,7 @@ import atexit
 # -- subprocess, we don't add here dependency on util.py and use a light
 # -- weight debug env var detection.
 # -- Set APIO_DEBUG=1 to enable.
-debug_enabled = int(os.environ.get("APIO_DEBUG", "0")) > 0
+debug_enabled = os.environ.get("APIO_DEBUG", "0").strip().lower() in ("1", "true", "yes")
 
 
 def on_exit(msg):


### PR DESCRIPTION
## Problem

`int(os.environ.get("APIO_DEBUG", "0"))` will raise an unhandled `ValueError` if the user sets `APIO_DEBUG` to any non-numeric string (e.g., `APIO_DEBUG=true`, `APIO_DEBUG=1`, `APIO_DEBUG=yes`). Since environment variables are user-controlled and this is the application entry point, this will crash the entire apio process before any command runs.


**Severity**: `high`
**File**: `apio/__main__.py`

## Solution

`int(os.environ.get("APIO_DEBUG", "0"))` will raise an unhandled `ValueError` if the user sets `APIO_DEBUG` to any non-numeric string (e.g., `APIO_DEBUG=true`, `APIO_DEBUG=1`, `APIO_DEBUG=yes`). Since environment variables are user-controlled and this is the application entry point, this will crash the entire apio process before any command runs.


## Changes

- `apio/__main__.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
