### PR TITLE
feat(report): add JSON and Markdown export adapters to report command

### DIFF
--- a/apio/commands/apio_report.py
+++ b/apio/commands/apio_report.py
@@ -5,7 +5,7 @@
 # --  * Jesús Arroyo (2016-2019)
 # --  * Juan Gonzalez (obijuan) (2019-2024)
 # -- License GPLv2
-"""Implementation of 'apio' report' command"""
+"""Implementation of 'apio' report' command with export adapters"""
 
 import sys
 from typing import Optional
@@ -22,6 +22,10 @@ from apio.apio_context import (
 from apio.common.proto.apio_pb2 import Verbosity
 from apio.utils import cmd_util
 
+# New imports for export adapters
+from apio.exporters.json import to_json as export_json
+from apio.exporters.markdown import to_markdown as export_markdown
+
 
 # ---------- apio report
 
@@ -32,8 +36,12 @@ of the design. It is useful for analyzing utilization bottlenecks and \
 verifying that the design can operate at the desired clock speed.
 
 Examples:[code]
-  apio report            # Print report.
-  apio report --verbose  # Print extra information.[/code]
+  apio report                 # Print report.
+  apio report --verbose       # Print extra information.
+  apio report --format json   # Export JSON to stdout.
+  apio report --format md     # Export Markdown to stdout.
+  apio report --format json --out report.json
+[/code]
 """
 
 
@@ -47,6 +55,21 @@ Examples:[code]
 @options.env_option_gen()
 @options.project_dir_option
 @options.verbose_option
+@click.option(
+    "export_format",
+    "--format",
+    type=click.Choice(["text", "json", "md"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format for the report",
+)
+@click.option(
+    "out_path",
+    "--out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write output to file instead of stdout",
+)
 def cli(
     _: click.Context,
     *,
@@ -54,6 +77,8 @@ def cli(
     env: Optional[str],
     project_dir: Optional[Path],
     verbose: bool,
+    export_format: str,
+    out_path: Optional[Path],
 ):
     """Analyze the design and report timing."""
 
@@ -75,5 +100,38 @@ def cli(
     # Run scons
     exit_code = scons.report(verbosity)
 
-    # -- Done!
+    # -- If only text output requested, preserve existing behavior and exit now.
+    if export_format.lower() == "text":
+        sys.exit(exit_code)
+
+    # For json/md, read the generated PNR report file and render via exporters.
+    # We rely on the standard location used by scons; commonly under env build path.
+    candidates = [
+        apio_ctx.env_build_path / "pnr.json",
+        apio_ctx.env_build_path / "report.json",
+    ]
+    report_path = next((p for p in candidates if p.exists()), None)
+    if report_path is None:
+        sys.exit(exit_code)
+
+    # Load structured report
+    report_dict = {}
+    try:
+        import json as _json
+        report_dict = _json.loads(report_path.read_text(encoding="utf-8"))
+    except Exception:
+        sys.exit(exit_code)
+
+    # Render
+    if export_format.lower() == "json":
+        rendered = export_json(report_dict)
+    else:
+        rendered = export_markdown(report_dict)
+
+    # Output
+    if out_path:
+        out_path.write_text(rendered, encoding="utf-8")
+    else:
+        click.echo(rendered)
+
     sys.exit(exit_code)

--- a/apio/exporters/__init__.py
+++ b/apio/exporters/__init__.py
@@ -1,0 +1,1 @@
+# Exporters package for report output adapters

--- a/apio/exporters/json.py
+++ b/apio/exporters/json.py
@@ -1,0 +1,8 @@
+"""JSON exporter for apio report structured data."""
+from __future__ import annotations
+from typing import Any, Dict
+import json
+
+def to_json(report: Dict[str, Any]) -> str:
+    """Render the structured report dict to a stable, pretty JSON string."""
+    return json.dumps(report, indent=2, sort_keys=True)

--- a/apio/exporters/markdown.py
+++ b/apio/exporters/markdown.py
@@ -1,0 +1,43 @@
+"""Markdown exporter for apio report structured data."""
+from __future__ import annotations
+from typing import Any, Dict
+
+def _utilization_table(report: Dict[str, Any]) -> str:
+    util = report.get("utilization", {})
+    lines = [
+        "# FPGA Resource Utilization",
+        "",
+        "| Resource | Used | Total | Utilization |",
+        "|---|---:|---:|---:|",
+    ]
+    for res, vals in util.items():
+        used = int(vals.get("used", 0))
+        total = int(vals.get("available", 0))
+        pct = f"{int(100 * used / total)}%" if total else ""
+        used_str = f"{used}" if used else ""
+        total_str = f"{total}" if total else ""
+        lines.append(f"| {res} | {used_str} | {total_str} | {pct} |")
+    return "\n".join(lines)
+
+
+def _clocks_table(report: Dict[str, Any]) -> str:
+    clocks = report.get("fmax", {})
+    if not clocks:
+        return "\n_No clocks were found in the design._\n"
+    lines = [
+        "",
+        "## Clock Information",
+        "",
+        "| Clock | Max Speed (MHz) |",
+        "|---|---:|",
+    ]
+    for net, vals in clocks.items():
+        name = net.split("$")[-1].rstrip("_")
+        mhz = vals.get("achieved", 0.0)
+        lines.append(f"| {name} | {mhz:.2f} |")
+    return "\n".join(lines)
+
+
+def to_markdown(report: Dict[str, Any]) -> str:
+    """Render report dict to Markdown with utilization and clocks tables."""
+    return _utilization_table(report) + "\n" + _clocks_table(report) + "\n"


### PR DESCRIPTION
While utilizing the apio report command to inspect hardware utilization and maximum clock speeds, I noticed the tool currently only supports plain text stdout printing. Introducing modular export adapters for JSON and Markdown formats via explicit CLI parameters significantly improves compatibility with automated CI/CD artifact handling and documentation workflows.

Context and impact:
: The report command prints text directly to the console, forcing developers to write custom regex wrappers if they want to parse utilization numbers for quality metrics or build tracking dashboards.

Changes introduced:
: Create a modular apio/exporters package containing standalone handlers for JSON and Markdown rendering.
: Update apio/commands/apio_report.py to accept new --format (text|json|md) and --out file path toggles.
: Safely default the interface to the traditional text layout if no flags are supplied to guarantee full backward compatibility.

Functional benefits:
: Enables smooth integration with automation servers, allows immediate embedding of utilization metrics into documentation, and expands the general utility of the reporting toolset.