### PR TITLE
Updated Apio 1.5.x to use the latest packages builds.

### DIFF
--- a/apio/managers/scons_manager.py
+++ b/apio/managers/scons_manager.py
@@ -24,6 +24,7 @@ from apio.managers.scons_filter import SconsFilter
 from apio.common.proto.apio_pb2 import (
     FORCE_PIPE,
     FORCE_TERMINAL,
+    XILINX,
     Verbosity,
     Environment,
     SconsParams,
@@ -92,6 +93,24 @@ class SConsManager:
 
         # -- Change to the project's folder.
         os.chdir(apio_ctx.project_dir)
+
+    def _fetch_support_files_on_demand(
+        self, scons_target, scons_params: SconsParams
+    ):
+        """Called before invoking scons to optionally fetch missing support
+        files on the file."""
+
+        # -- Only these targets may require support files. For all the rest
+        # -- we don't need to do anything.
+        if scons_target not in ["build", "report", "upload"]:
+            return
+
+        # -- Only xilinx architecture may requires support files. For all the
+        # -- rest we don't need to do anything.
+        if scons_params.arch != XILINX:
+            return
+
+        # -- TODO: Implement the xilinx on-demand chipdb file download.
 
     @on_exception(exit_code=1)
     def graph(
@@ -364,7 +383,7 @@ class SConsManager:
         return result
 
     def _run_scons_subprocess(
-        self, scons_command: str, *, scons_params: SconsParams
+        self, scons_target: str, *, scons_params: SconsParams
     ) -> Optional[int]:
         """Invoke an scons subprocess."""
 
@@ -372,6 +391,9 @@ class SConsManager:
 
         # -- Create a shortcut.
         apio_ctx = self.apio_ctx
+
+        # -- Fetch missing files on demand.
+        self._fetch_support_files_on_demand(scons_target, scons_params)
 
         # -- Pass to the scons process the name of the sconstruct file it
         # -- should use.
@@ -395,7 +417,7 @@ class SConsManager:
 
         if util.is_debug(1):
             cout("\nSCONS CALL:", style=EMPH3)
-            cout(f"* command:       {scons_command}")
+            cout(f"* target:        {scons_target}")
             cout(f"* variables:     {variables}")
             cout(f"* scons params: \n{scons_params}")
             cout()
@@ -434,7 +456,7 @@ class SConsManager:
         # -- deployment in case the scons binary is not on the PATH.
         cmd = (
             [sys.executable, "-m", "apio", "--scons"]
-            + ["-Q", scons_command]
+            + ["-Q", scons_target]
             + debug_options
             + variables
         )

--- a/apio/scons/plugin_xilinx.py
+++ b/apio/scons/plugin_xilinx.py
@@ -103,12 +103,16 @@ class PluginXilinx(PluginBase):
             target.append(apio_env.target + ".pnr")
             return target, source
 
-        package = xilinx_params.package
-        database = f"{package}.bin"
-        chipdb = Path(apio_env.params.environment.xilinx_chipdb_path)
+        # -- Get params.
+        chipdb_dir = Path(apio_env.params.environment.xilinx_chipdb_path)
+        package_name = xilinx_params.package
 
-        # -- Python file that is passed to nextpnr-xilinx for generating
-        # -- the report file
+        # -- The chipdb is one to one with the package name.
+        chipdb_file_path = chipdb_dir / f"{package_name}.bin"
+
+        # -- Find the path of the report_xilinx utility that is used to
+        # -- generate the report file hardware.pnr. It's embedded in the Apio
+        # -- source tree.
 
         # -- Get the full path of this file (plugin_xilinx.py)
         current_python_file = Path(__file__)
@@ -128,7 +132,7 @@ class PluginXilinx(PluginBase):
                 "{3} "
                 "{4}"
             ).format(
-                chipdb / database,
+                chipdb_file_path,
                 self.constrain_file(),
                 report_py,
                 # -- Honor --verbose-pnr like the other archs (ice40/ecp5/

--- a/remote-config/apio-1.5.x.jsonc
+++ b/remote-config/apio-1.5.x.jsonc
@@ -16,7 +16,7 @@
         "name": "apio-definitions"
       },
       "release": {
-        "tag": "2026-07-10",
+        "tag": "2026-08-07",
         "package": "apio-definitions-${YYYYMMDD}.tgz"
       }
     },
@@ -27,7 +27,7 @@
         "name": "apio-examples"
       },
       "release": {
-        "tag": "2026-07-10",
+        "tag": "2026-08-06",
         "package": "apio-examples-${YYYYMMDD}.tgz"
       }
     },
@@ -38,7 +38,7 @@
         "name": "tools-oss-cad-suite"
       },
       "release": {
-        "tag": "2026-03-24",
+        "tag": "2026-08-07",
         "package": "apio-oss-cad-suite-${PLATFORM}-${YYYYMMDD}.tgz"
       }
     },
@@ -49,7 +49,7 @@
         "name": "tools-openxc7"
       },
       "release": {
-        "tag": "2026-07-31",
+        "tag": "2026-08-07",
         "package": "apio-openxc7-${PLATFORM}-${YYYYMMDD}.tgz"
       }
     },
@@ -60,7 +60,7 @@
         "name": "tools-graphviz"
       },
       "release": {
-        "tag": "2025-12-26",
+        "tag": "2026-08-07",
         "package": "apio-graphviz-${PLATFORM}-${YYYYMMDD}.tgz"
       }
     },
@@ -71,7 +71,7 @@
         "name": "tools-verible"
       },
       "release": {
-        "tag": "2025-12-26",
+        "tag": "2026-08-07",
         "package": "apio-verible-${PLATFORM}-${YYYYMMDD}.tgz"
       }
     },
@@ -82,7 +82,7 @@
         "name": "tools-drivers"
       },
       "release": {
-        "tag": "2025-12-26",
+        "tag": "2026-08-07",
         "package": "apio-drivers-${PLATFORM}-${YYYYMMDD}.tgz"
       }
     }


### PR DESCRIPTION
Sync'ing to latest before comprehensive testing.

My assumption is that the libraries changes are backward compatible with Apio 1.5.0 which is published on PyPi. Otherwise we would need to bump Apio version to 1.6.x.