### PR TITLE
remote-config: openxc7 2026-08-11

### DIFF
--- a/remote-config/apio-1.5.x.jsonc
+++ b/remote-config/apio-1.5.x.jsonc
@@ -49,7 +49,7 @@
         "name": "tools-openxc7"
       },
       "release": {
-        "tag": "2026-08-10",
+        "tag": "2026-08-11",
         "package": "apio-openxc7-${PLATFORM}-${YYYYMMDD}.tgz"
       }
     },


### PR DESCRIPTION
Automated bump after promoting [tools-openxc7 2026-08-11](https://github.com/FPGAwars/tools-openxc7/releases/tag/2026-08-11). Also point to definitions 2026-08-07 (released boards ride with their toolchain).
