### PR TITLE
Apio now checks and shows the 'yosys-release-tags' of its packages.

### DIFF
--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -300,9 +300,11 @@ class ApioContext:
             assert packages_policy == PackagesPolicy.ENSURE_PACKAGES
 
             # -- Install missing packages. At this point, the fields that are
-            # -- required by self.packages_context are already initialized.
+            # -- required by self.packages_ctx are already initialized.
+            # --
+            # -- TODO: Set verbose=True if APIO_DEBUG is above some level.
             packages.install_missing_packages_on_the_fly(
-                self.packages_context, verbose=False
+                self.packages_ctx, verbose=False
             )
 
             # -- Load the definitions from the definitions file with possible
@@ -614,7 +616,7 @@ class ApioContext:
         return "unknown"
 
     @property
-    def packages_context(self) -> PackagesContext:
+    def packages_ctx(self) -> PackagesContext:
         """Return a PackagesContext with info extracted from this
         ApioContext."""
         return PackagesContext(

--- a/apio/commands/apio_api.py
+++ b/apio/commands/apio_api.py
@@ -19,6 +19,7 @@ import click
 from apio.commands import options
 
 # from apio.managers import packages
+from apio.managers import packages
 from apio.managers.examples import Examples, ExampleInfo
 from apio.common.apio_console import cout, cerror
 from apio.common.common_util import get_project_source_files
@@ -161,6 +162,9 @@ def _get_system_cli(
     # -- Add fields.
     section_dict["apio-cli-version"] = util.get_apio_version_str()
     section_dict["release-info"] = util.get_apio_release_info()
+    section_dict["yosys-release-tag"] = packages.get_yosys_release_tag(
+        apio_ctx.packages_ctx
+    )
     section_dict["python-version"] = util.get_python_version()
     section_dict["python-executable"] = sys.executable
     section_dict["platform-info"] = apio_platforms.get_system_info()
@@ -821,8 +825,7 @@ def _scan_devices_cli(
     """Implements the 'apio apio scan-devices' command."""
 
     # -- For now, the information is not in a project context. That may
-    # -- change in the future. We need the config since we use libusb from
-    # -- the packages.
+    # -- change in the future. We need the packages for the libusb operation.
     apio_ctx = ApioContext(
         project_policy=ProjectPolicy.NO_PROJECT,
         remote_config_policy=RemoteConfigPolicy.CACHED_OK,
@@ -835,9 +838,6 @@ def _scan_devices_cli(
     # -- Append user timestamp if specified.
     if timestamp:
         top_dict["timestamp"] = timestamp
-
-    # -- We need the packages for the 'libusb' backend.
-    # packages.install_missing_packages_on_the_fly(apio_ctx.packages_context)
 
     usb_devices: List[UsbDevice] = usb_util.scan_usb_devices(apio_ctx)
 

--- a/apio/commands/apio_info.py
+++ b/apio/commands/apio_info.py
@@ -18,6 +18,7 @@ from rich.color import ANSI_COLOR_NAMES
 from apio.common.apio_styles import BORDER, EMPH1, EMPH2, EMPH3, INFO
 from apio.utils import util, apio_platforms
 from apio.commands import options
+from apio.managers import packages
 from apio.apio_context import (
     ApioContext,
     PackagesPolicy,
@@ -125,6 +126,10 @@ def _system_cli():
     # -- Add rows
     table.add_row("Apio CLI version", util.get_apio_version_str())
     table.add_row("Release info", util.get_apio_release_info() or "(none)")
+    table.add_row(
+        "Yosys release tag",
+        packages.get_yosys_release_tag(apio_ctx.packages_ctx),
+    )
     table.add_row("Python version", util.get_python_version())
     table.add_row("Python executable", sys.executable)
     table.add_row("System info", apio_platforms.get_system_info())

--- a/apio/commands/apio_packages.py
+++ b/apio/commands/apio_packages.py
@@ -44,7 +44,7 @@ def print_packages_report(apio_ctx: ApioContext) -> bool:
     """
 
     # -- Scan the packages
-    scan = packages.scan_packages(apio_ctx.packages_context)
+    scan = packages.scan_packages(apio_ctx.packages_ctx)
 
     # -- Shortcuts to reduce clutter.
     get_installed_package_info = apio_ctx.profile.get_installed_package_info
@@ -215,12 +215,12 @@ def _install_cli(
 
     # -- First thing, fix broken packages, if any. This forces fetching
     # -- of the latest remote config file.
-    packages.scan_and_fix_packages(apio_ctx.packages_context)
+    packages.scan_and_fix_packages(apio_ctx.packages_ctx)
 
     # -- Install the packages, one by one.
     for package in apio_ctx.required_packages:
         packages.install_package(
-            apio_ctx.packages_context,
+            apio_ctx.packages_ctx,
             package_name=package,
             force_reinstall=force,
             verbose=verbose,
@@ -229,20 +229,27 @@ def _install_cli(
     # -- If verbose, print a full report.
     if verbose:
         package_ok = print_packages_report(apio_ctx)
-        sys.exit(0 if package_ok else 1)
+        if not package_ok:
+            sys.exit(1)
 
     # -- When not in verbose mode, we run a scan and print a short status.
-    scan = packages.scan_packages(apio_ctx.packages_context)
-    if not scan.is_all_ok():
-        cerror("Failed to install some packages.")
-        cout(
-            "Run 'apio packages list' to view the packages.",
-            style=INFO,
-        )
-        sys.exit(1)
+    else:
+        scan = packages.scan_packages(apio_ctx.packages_ctx)
+        if not scan.is_all_ok():
+            cerror("Failed to install some packages.")
+            cout(
+                "Run 'apio packages list' to view the packages.",
+                style=INFO,
+            )
+            sys.exit(1)
 
-    # -- Here when packages are ok.
-    cout("All Apio packages are installed OK.", style=SUCCESS)
+        # -- In the verbose case above, this is already printed by
+        # -- the print_packages_report() method.
+        cout("All Apio packages are installed OK.", style=SUCCESS)
+
+    # -- We believe that we have the exactly the correct packages
+    # -- installed. Perform a few final checks.
+    packages.check_packages(apio_ctx.packages_ctx)
 
 
 # ------ apio packages list
@@ -268,6 +275,8 @@ Examples:[code]
 def _list_cli():
     """Implements the 'apio packages list' command."""
 
+    # -- It's important that will command will use IGNORE_PACKAGES so we
+    # -- can list the current state of packages without mutating it.
     apio_ctx = ApioContext(
         project_policy=ProjectPolicy.NO_PROJECT,
         remote_config_policy=RemoteConfigPolicy.GET_FRESH,

--- a/apio/managers/drivers.py
+++ b/apio/managers/drivers.py
@@ -489,10 +489,6 @@ class Drivers:
             return exit_code
 
     def _ftdi_uninstall_windows(self) -> int:
-        # -- Check that the required packages exist.
-        # packages.install_missing_packages_on_the_fly(
-        #     self.apio_ctx.packages_context
-        # )
 
         cout("", "Launching the interactive Device Manager.")
         cmarkdown(FTDI_UNINSTALL_INSTRUCTIONS_WINDOWS)

--- a/apio/managers/packages.py
+++ b/apio/managers/packages.py
@@ -9,12 +9,13 @@ Used by the 'apio packages' command.
 
 import sys
 import os
+import json
 from dataclasses import dataclass
 from typing import Dict, List
 from pathlib import Path
 import shutil
 from apio.common.apio_console import cout, cerror, cstyle
-from apio.common.apio_styles import WARNING, ERROR, SUCCESS, EMPH3
+from apio.common.apio_styles import ERROR, SUCCESS, EMPH3, INFO
 from apio.managers.downloader import FileDownloader
 from apio.managers.unpacker import FileUnpacker
 from apio.utils import util
@@ -47,6 +48,13 @@ class PackagesContext:
         assert self.required_packages
         assert self.platform
         assert self.packages_dir
+
+    def package_dir(self, package_name) -> Path:
+        """Return the local root directory of the package with given name"""
+        # -- Validate the package name
+        assert package_name in self.required_packages, package_name
+        # -- Construct the path
+        return self.packages_dir / package_name
 
 
 def _construct_package_download_url(
@@ -202,15 +210,19 @@ def install_missing_packages_on_the_fly(
     """Install on the fly any missing packages. Does not print a thing if
     all packages are already ok. This function is intended for on demand
     package fetching by commands such as apio build, and thus is allowed
-    to use fetched remote config instead of fetching a fresh one."""
+    to use fetched remote config instead of fetching a fresh one. Exists with
+    error code if any error."""
 
     # -- Scan and fix broken package.
     # -- Since this is a on-the-fly operation, we don't require a fresh
     # -- remote config file for required packages versions.
     installed_ok = scan_and_fix_packages(packages_ctx)
 
-    # -- If all the packages are installed, we are done.
+    # -- If the packages are installed we are done, we are done.
     if installed_ok:
+        # -- Final sanity check of the packages.
+        check_packages(packages_ctx)
+        # -- Installed ok.
         return
 
     # -- Here when we need to install some packages. Since we just fixed
@@ -234,11 +246,14 @@ def install_missing_packages_on_the_fly(
     # -- Here all packages should be ok but we check again just in case.
     scan_results = scan_packages(packages_ctx)
     if not scan_results.is_all_ok():
-        cout(
-            "Warning: packages issues detected. Use "
-            "'apio packages list' to investigate.",
-            style=WARNING,
+        cerror(
+            "Packages issues detected. Use "
+            "'apio packages list' to investigate."
         )
+        sys.exit(1)
+
+    # -- Final sanity check of the packages.
+    check_packages(packages_ctx)
 
 
 def install_package(
@@ -470,6 +485,65 @@ class PackageScanResults:
         cout(f"  Orphan ids    {self.orphan_package_names}")
         cout(f"  Orphan dirs   {self.orphan_dir_names}")
         cout(f"  Orphan files  {self.orphan_file_names}")
+
+
+def read_package_build_info(
+    packages_ctx: PackagesContext, package_name: str
+) -> str:
+    """Returns the BUILD-INFO.json of the package as a dict. Fatal
+    error if doesn't exist or can't parse."""
+
+    build_info_path = (
+        packages_ctx.package_dir(package_name) / "BUILD-INFO.json"
+    )
+
+    # pylint: disable=broad-exception-caught
+
+    try:
+        with open(build_info_path, encoding="utf-8") as f:
+            build_info = json.load(f)
+    except Exception as e:
+        cerror(f"Reading/parsing [{build_info_path}] failed.", str(e))
+        sys.exit(1)
+
+    return build_info
+
+
+def get_yosys_release_tag(packages_ctx: PackagesContext) -> str:
+    """Return the version tag (e.g. "2026-03-21") of the underlying Yosys.
+    This value is extract from the BUILD-INFO.json file of the apio
+    oss-cad-suite package."""
+    build_info = read_package_build_info(packages_ctx, "oss-cad-suite")
+    return build_info["yosys-release-tag"]
+
+
+def check_packages(packages_ctx: PackagesContext):
+    """Called after the Apio packages were installed or fixed and are
+    believed to be correct. Performs additional validation of the apio packages
+    and exits with an error on any error."""
+
+    # -- Read the build info of the two packages.
+    build_info1 = read_package_build_info(packages_ctx, "oss-cad-suite")
+    build_info2 = read_package_build_info(packages_ctx, "openxc7")
+
+    # -- Extract the version of the underlying yosys
+    yosys_release_tag1 = build_info1["yosys-release-tag"]
+    yosys_release_tag2 = build_info2["yosys-release-tag"]
+
+    # -- Compare the versions.
+    if yosys_release_tag1 != yosys_release_tag2:
+        cerror(
+            'The packages "oss-cad-suite" and "openxc7" were built with '
+            'different "yosys-release-tag".',
+            f"Their respective BUILD-INFO.json files "
+            f'contain "{yosys_release_tag1}" vs "{yosys_release_tag2}"',
+        )
+        cout(
+            "This typically happens due to corrupt packages or bad remote "
+            "configuration by the Apio team.",
+            style=INFO,
+        )
+        sys.exit(1)
 
 
 def package_version_ok(

--- a/remote-config/apio-1.5.x.jsonc
+++ b/remote-config/apio-1.5.x.jsonc
@@ -7,6 +7,12 @@
 //
 // NOTE: Github has a cache propagation of about 1 min between the
 // time this file is submitted and until it's available for download.
+//
+// NOTE: Apio examines at runtie the BUILD-INFO.json files of the
+// oss-cad-suite and openxc7 packages and asserts that they have
+// the same "yosys-release-tag" value. That is, they were built
+// against the same release of the Yosys oss-cad-suite package.
+//
 {
   "packages": {
     // -- Definitions package

--- a/remote-config/apio-1.5.x.jsonc
+++ b/remote-config/apio-1.5.x.jsonc
@@ -49,7 +49,7 @@
         "name": "tools-openxc7"
       },
       "release": {
-        "tag": "2026-08-11",
+        "tag": "2026-08-13",
         "package": "apio-openxc7-${PLATFORM}-${YYYYMMDD}.tgz"
       }
     },


### PR DESCRIPTION
Added to Apio runtime support for the "yosys-release-tag" property. It now asserts that it's identical for the oss-cad-suite and openxc7 packages and also shows it in 'apio-info-system' and 'apio api get-system'. This is the first time Apio looks into BUILD-INFO.json files of downloaded packages.
