### PR TITLE
Add Shrike Lite SLG47910V architecture support

### DIFF
--- a/apio/common/proto/apio.proto
+++ b/apio/common/proto/apio.proto
@@ -23,6 +23,7 @@ enum ApioArch {
   ECP5 = 2;
   GOWIN = 3;
   XILINX = 4;
+  SHRIKE = 5;
 }
 
 enum TerminalMode {
@@ -64,7 +65,12 @@ message XilinxFpgaParams {
   required string speed = 4;
 }
 
-
+// Shrike Lite / Renesas SLG47910V specific fpga attributes.
+// Matches definition file fpgas.jsonc.
+message ShrikeFpgaParams {
+  required string family = 1;
+  required string package = 2;
+}
 
 // General fpga info.
 // Matches definition file fpgas.jsonc.
@@ -79,6 +85,7 @@ message FpgaInfo {
     Ecp5FpgaParams ecp5_params = 11;
     GowinFpgaParams gowin_params = 12;
     XilinxFpgaParams xilinx_params = 13;
+    ShrikeFpgaParams shrike_params = 14;
   }
 }
 

--- a/apio/common/proto/apio_pb2.py
+++ b/apio/common/proto/apio_pb2.py
@@ -27,19 +27,19 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\napio.proto\x12\x11\x61pio.common.proto\"0\n\x0fIce40FpgaParams\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0f\n\x07package\x18\x02 \x02(\t\">\n\x0e\x45\x63p5FpgaParams\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0f\n\x07package\x18\x02 \x02(\t\x12\r\n\x05speed\x18\x03 \x02(\t\"Z\n\x0fGowinFpgaParams\x12\x16\n\x0cyosys_family\x18\x01 \x01(\t:\x00\x12\x18\n\x0enextpnr_family\x18\x02 \x01(\t:\x00\x12\x15\n\rpacker_device\x18\x03 \x02(\t\"X\n\x10XilinxFpgaParams\x12\x10\n\x06\x66\x61mily\x18\x01 \x02(\t:\x00\x12\x12\n\nyosys_arch\x18\x02 \x02(\t\x12\x0f\n\x07package\x18\x03 \x02(\t\x12\r\n\x05speed\x18\x04 \x02(\t\"\xb3\x02\n\x08\x46pgaInfo\x12\x0f\n\x07\x66pga_id\x18\x01 \x02(\t\x12\x10\n\x08part_num\x18\x02 \x02(\t\x12\x0c\n\x04size\x18\x03 \x02(\t\x12:\n\x0cice40_params\x18\n \x01(\x0b\x32\".apio.common.proto.Ice40FpgaParamsH\x00\x12\x38\n\x0b\x65\x63p5_params\x18\x0b \x01(\x0b\x32!.apio.common.proto.Ecp5FpgaParamsH\x00\x12:\n\x0cgowin_params\x18\x0c \x01(\x0b\x32\".apio.common.proto.GowinFpgaParamsH\x00\x12<\n\rxilinx_params\x18\r \x01(\x0b\x32#.apio.common.proto.XilinxFpgaParamsH\x00\x42\x06\n\x04\x61rch\"I\n\tVerbosity\x12\x12\n\x03\x61ll\x18\x01 \x01(\x08:\x05\x66\x61lse\x12\x14\n\x05synth\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x12\n\x03pnr\x18\x03 \x01(\x08:\x05\x66\x61lse\"\x95\x02\n\x0b\x45nvironment\x12\x13\n\x0bplatform_id\x18\x01 \x02(\t\x12\x12\n\nis_windows\x18\x02 \x02(\x08\x12\x36\n\rterminal_mode\x18\x03 \x02(\x0e\x32\x1f.apio.common.proto.TerminalMode\x12\x12\n\ntheme_name\x18\x04 \x02(\t\x12\x13\n\x0b\x64\x65\x62ug_level\x18\x05 \x02(\x05\x12\x12\n\nyosys_path\x18\x06 \x02(\t\x12\x14\n\x0ctrellis_path\x18\x07 \x02(\t\x12\x16\n\x0escons_shell_id\x18\x08 \x02(\t\x12\x1e\n\x16xilinx_prjxray_db_path\x18\t \x02(\t\x12\x1a\n\x12xilinx_chipdb_path\x18\n \x02(\t\"\xef\x01\n\rApioEnvParams\x12\x10\n\x08\x65nv_name\x18\x01 \x02(\t\x12\x10\n\x08\x62oard_id\x18\x02 \x02(\t\x12\x12\n\ntop_module\x18\x03 \x02(\t\x12\x0f\n\x07\x64\x65\x66ines\x18\x04 \x03(\t\x12\x1b\n\x13yosys_extra_options\x18\x05 \x03(\t\x12\x1d\n\x15nextpnr_extra_options\x18\x06 \x03(\t\x12\x1d\n\x15gtkwave_extra_options\x18\x07 \x03(\t\x12\x1f\n\x17verilator_extra_options\x18\x08 \x03(\t\x12\x19\n\x0f\x63onstraint_file\x18\t \x01(\t:\x00\"d\n\nLintParams\x12\x14\n\ntop_module\x18\x01 \x01(\t:\x00\x12\x16\n\x07nosynth\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x14\n\x05novlt\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x12\n\nfile_names\x18\x04 \x03(\t\"\"\n\x0cReportParams\x12\x12\n\nreport_all\x18\x01 \x02(\x08\"o\n\x0bGraphParams\x12\x37\n\x0boutput_type\x18\x01 \x02(\x0e\x32\".apio.common.proto.GraphOutputType\x12\x12\n\ntop_module\x18\x02 \x01(\t\x12\x13\n\x0bopen_viewer\x18\x03 \x02(\x08\"d\n\tSimParams\x12\x18\n\x0etestbench_path\x18\x01 \x01(\t:\x00\x12\x11\n\tforce_sim\x18\x02 \x02(\x08\x12\x12\n\nno_gtkwave\x18\x03 \x02(\x08\x12\x16\n\x0e\x64\x65tach_gtkwave\x18\x04 \x02(\x08\"B\n\x0e\x41pioTestParams\x12\x18\n\x0etestbench_path\x18\x01 \x01(\t:\x00\x12\x16\n\x0e\x64\x65\x66\x61ult_option\x18\x02 \x02(\x08\"&\n\x0cUploadParams\x12\x16\n\x0eprogrammer_cmd\x18\x01 \x01(\t\"\xbe\x02\n\x0cTargetParams\x12\x31\n\x06report\x18\x01 \x01(\x0b\x32\x1f.apio.common.proto.ReportParamsH\x00\x12-\n\x04lint\x18\x02 \x01(\x0b\x32\x1d.apio.common.proto.LintParamsH\x00\x12/\n\x05graph\x18\x03 \x01(\x0b\x32\x1e.apio.common.proto.GraphParamsH\x00\x12+\n\x03sim\x18\x04 \x01(\x0b\x32\x1c.apio.common.proto.SimParamsH\x00\x12\x31\n\x04test\x18\x05 \x01(\x0b\x32!.apio.common.proto.ApioTestParamsH\x00\x12\x31\n\x06upload\x18\x06 \x01(\x0b\x32\x1f.apio.common.proto.UploadParamsH\x00\x42\x08\n\x06target\"\xe9\x02\n\x0bSconsParams\x12\x11\n\ttimestamp\x18\x01 \x02(\t\x12)\n\x04\x61rch\x18\x02 \x02(\x0e\x32\x1b.apio.common.proto.ApioArch\x12.\n\tfpga_info\x18\x03 \x02(\x0b\x32\x1b.apio.common.proto.FpgaInfo\x12/\n\tverbosity\x18\x04 \x01(\x0b\x32\x1c.apio.common.proto.Verbosity\x12\x33\n\x0b\x65nvironment\x18\x05 \x02(\x0b\x32\x1e.apio.common.proto.Environment\x12\x39\n\x0f\x61pio_env_params\x18\x06 \x02(\x0b\x32 .apio.common.proto.ApioEnvParams\x12\x1a\n\x0bnextpnr_gui\x18\x07 \x01(\x08:\x05\x66\x61lse\x12/\n\x06target\x18\x08 \x01(\x0b\x32\x1f.apio.common.proto.TargetParams*L\n\x08\x41pioArch\x12\x14\n\x10\x41RCH_UNSPECIFIED\x10\x00\x12\t\n\x05ICE40\x10\x01\x12\x08\n\x04\x45\x43P5\x10\x02\x12\t\n\x05GOWIN\x10\x03\x12\n\n\x06XILINX\x10\x04*_\n\x0cTerminalMode\x12\x18\n\x14TERMINAL_UNSPECIFIED\x10\x00\x12\x11\n\rAUTO_TERMINAL\x10\x01\x12\x12\n\x0e\x46ORCE_TERMINAL\x10\x02\x12\x0e\n\nFORCE_PIPE\x10\x03*B\n\x0fGraphOutputType\x12\x14\n\x10TYPE_UNSPECIFIED\x10\x00\x12\x07\n\x03SVG\x10\x01\x12\x07\n\x03PNG\x10\x02\x12\x07\n\x03PDF\x10\x03')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\napio.proto\x12\x11\x61pio.common.proto\"0\n\x0fIce40FpgaParams\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0f\n\x07package\x18\x02 \x02(\t\">\n\x0e\x45\x63p5FpgaParams\x12\x0c\n\x04type\x18\x01 \x02(\t\x12\x0f\n\x07package\x18\x02 \x02(\t\x12\r\n\x05speed\x18\x03 \x02(\t\"Z\n\x0fGowinFpgaParams\x12\x16\n\x0cyosys_family\x18\x01 \x01(\t:\x00\x12\x18\n\x0enextpnr_family\x18\x02 \x01(\t:\x00\x12\x15\n\rpacker_device\x18\x03 \x02(\t\"X\n\x10XilinxFpgaParams\x12\x10\n\x06\x66\x61mily\x18\x01 \x02(\t:\x00\x12\x12\n\nyosys_arch\x18\x02 \x02(\t\x12\x0f\n\x07package\x18\x03 \x02(\t\x12\r\n\x05speed\x18\x04 \x02(\t\"3\n\x10ShrikeFpgaParams\x12\x0e\n\x06\x66\x61mily\x18\x01 \x02(\t\x12\x0f\n\x07package\x18\x02 \x02(\t\"\xf1\x02\n\x08\x46pgaInfo\x12\x0f\n\x07\x66pga_id\x18\x01 \x02(\t\x12\x10\n\x08part_num\x18\x02 \x02(\t\x12\x0c\n\x04size\x18\x03 \x02(\t\x12:\n\x0cice40_params\x18\n \x01(\x0b\x32\".apio.common.proto.Ice40FpgaParamsH\x00\x12\x38\n\x0b\x65\x63p5_params\x18\x0b \x01(\x0b\x32!.apio.common.proto.Ecp5FpgaParamsH\x00\x12:\n\x0cgowin_params\x18\x0c \x01(\x0b\x32\".apio.common.proto.GowinFpgaParamsH\x00\x12<\n\rxilinx_params\x18\r \x01(\x0b\x32#.apio.common.proto.XilinxFpgaParamsH\x00\x12<\n\rshrike_params\x18\x0e \x01(\x0b\x32#.apio.common.proto.ShrikeFpgaParamsH\x00\x42\x06\n\x04\x61rch\"I\n\tVerbosity\x12\x12\n\x03\x61ll\x18\x01 \x01(\x08:\x05\x66\x61lse\x12\x14\n\x05synth\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x12\n\x03pnr\x18\x03 \x01(\x08:\x05\x66\x61lse\"\x95\x02\n\x0b\x45nvironment\x12\x13\n\x0bplatform_id\x18\x01 \x02(\t\x12\x12\n\nis_windows\x18\x02 \x02(\x08\x12\x36\n\rterminal_mode\x18\x03 \x02(\x0e\x32\x1f.apio.common.proto.TerminalMode\x12\x12\n\ntheme_name\x18\x04 \x02(\t\x12\x13\n\x0b\x64\x65\x62ug_level\x18\x05 \x02(\x05\x12\x12\n\nyosys_path\x18\x06 \x02(\t\x12\x14\n\x0ctrellis_path\x18\x07 \x02(\t\x12\x16\n\x0escons_shell_id\x18\x08 \x02(\t\x12\x1e\n\x16xilinx_prjxray_db_path\x18\t \x02(\t\x12\x1a\n\x12xilinx_chipdb_path\x18\n \x02(\t\"\xef\x01\n\rApioEnvParams\x12\x10\n\x08\x65nv_name\x18\x01 \x02(\t\x12\x10\n\x08\x62oard_id\x18\x02 \x02(\t\x12\x12\n\ntop_module\x18\x03 \x02(\t\x12\x0f\n\x07\x64\x65\x66ines\x18\x04 \x03(\t\x12\x1b\n\x13yosys_extra_options\x18\x05 \x03(\t\x12\x1d\n\x15nextpnr_extra_options\x18\x06 \x03(\t\x12\x1d\n\x15gtkwave_extra_options\x18\x07 \x03(\t\x12\x1f\n\x17verilator_extra_options\x18\x08 \x03(\t\x12\x19\n\x0f\x63onstraint_file\x18\t \x01(\t:\x00\"d\n\nLintParams\x12\x14\n\ntop_module\x18\x01 \x01(\t:\x00\x12\x16\n\x07nosynth\x18\x02 \x01(\x08:\x05\x66\x61lse\x12\x14\n\x05novlt\x18\x03 \x01(\x08:\x05\x66\x61lse\x12\x12\n\nfile_names\x18\x04 \x03(\t\"\"\n\x0cReportParams\x12\x12\n\nreport_all\x18\x01 \x02(\x08\"o\n\x0bGraphParams\x12\x37\n\x0boutput_type\x18\x01 \x02(\x0e\x32\".apio.common.proto.GraphOutputType\x12\x12\n\ntop_module\x18\x02 \x01(\t\x12\x13\n\x0bopen_viewer\x18\x03 \x02(\x08\"d\n\tSimParams\x12\x18\n\x0etestbench_path\x18\x01 \x01(\t:\x00\x12\x11\n\tforce_sim\x18\x02 \x02(\x08\x12\x12\n\nno_gtkwave\x18\x03 \x02(\x08\x12\x16\n\x0e\x64\x65tach_gtkwave\x18\x04 \x02(\x08\"B\n\x0e\x41pioTestParams\x12\x18\n\x0etestbench_path\x18\x01 \x01(\t:\x00\x12\x16\n\x0e\x64\x65\x66\x61ult_option\x18\x02 \x02(\x08\"&\n\x0cUploadParams\x12\x16\n\x0eprogrammer_cmd\x18\x01 \x01(\t\"\xbe\x02\n\x0cTargetParams\x12\x31\n\x06report\x18\x01 \x01(\x0b\x32\x1f.apio.common.proto.ReportParamsH\x00\x12-\n\x04lint\x18\x02 \x01(\x0b\x32\x1d.apio.common.proto.LintParamsH\x00\x12/\n\x05graph\x18\x03 \x01(\x0b\x32\x1e.apio.common.proto.GraphParamsH\x00\x12+\n\x03sim\x18\x04 \x01(\x0b\x32\x1c.apio.common.proto.SimParamsH\x00\x12\x31\n\x04test\x18\x05 \x01(\x0b\x32!.apio.common.proto.ApioTestParamsH\x00\x12\x31\n\x06upload\x18\x06 \x01(\x0b\x32\x1f.apio.common.proto.UploadParamsH\x00\x42\x08\n\x06target\"\xe9\x02\n\x0bSconsParams\x12\x11\n\ttimestamp\x18\x01 \x02(\t\x12)\n\x04\x61rch\x18\x02 \x02(\x0e\x32\x1b.apio.common.proto.ApioArch\x12.\n\tfpga_info\x18\x03 \x02(\x0b\x32\x1b.apio.common.proto.FpgaInfo\x12/\n\tverbosity\x18\x04 \x01(\x0b\x32\x1c.apio.common.proto.Verbosity\x12\x33\n\x0b\x65nvironment\x18\x05 \x02(\x0b\x32\x1e.apio.common.proto.Environment\x12\x39\n\x0f\x61pio_env_params\x18\x06 \x02(\x0b\x32 .apio.common.proto.ApioEnvParams\x12\x1a\n\x0bnextpnr_gui\x18\x07 \x01(\x08:\x05\x66\x61lse\x12/\n\x06target\x18\x08 \x01(\x0b\x32\x1f.apio.common.proto.TargetParams*X\n\x08\x41pioArch\x12\x14\n\x10\x41RCH_UNSPECIFIED\x10\x00\x12\t\n\x05ICE40\x10\x01\x12\x08\n\x04\x45\x43P5\x10\x02\x12\t\n\x05GOWIN\x10\x03\x12\n\n\x06XILINX\x10\x04\x12\n\n\x06SHRIKE\x10\x05*_\n\x0cTerminalMode\x12\x18\n\x14TERMINAL_UNSPECIFIED\x10\x00\x12\x11\n\rAUTO_TERMINAL\x10\x01\x12\x12\n\x0e\x46ORCE_TERMINAL\x10\x02\x12\x0e\n\nFORCE_PIPE\x10\x03*B\n\x0fGraphOutputType\x12\x14\n\x10TYPE_UNSPECIFIED\x10\x00\x12\x07\n\x03SVG\x10\x01\x12\x07\n\x03PNG\x10\x02\x12\x07\n\x03PDF\x10\x03')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'apio_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_APIOARCH']._serialized_start=2382
-  _globals['_APIOARCH']._serialized_end=2458
-  _globals['_TERMINALMODE']._serialized_start=2460
-  _globals['_TERMINALMODE']._serialized_end=2555
-  _globals['_GRAPHOUTPUTTYPE']._serialized_start=2557
-  _globals['_GRAPHOUTPUTTYPE']._serialized_end=2623
+  _globals['_APIOARCH']._serialized_start=2497
+  _globals['_APIOARCH']._serialized_end=2585
+  _globals['_TERMINALMODE']._serialized_start=2587
+  _globals['_TERMINALMODE']._serialized_end=2682
+  _globals['_GRAPHOUTPUTTYPE']._serialized_start=2684
+  _globals['_GRAPHOUTPUTTYPE']._serialized_end=2750
   _globals['_ICE40FPGAPARAMS']._serialized_start=33
   _globals['_ICE40FPGAPARAMS']._serialized_end=81
   _globals['_ECP5FPGAPARAMS']._serialized_start=83
@@ -48,28 +48,30 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_GOWINFPGAPARAMS']._serialized_end=237
   _globals['_XILINXFPGAPARAMS']._serialized_start=239
   _globals['_XILINXFPGAPARAMS']._serialized_end=327
-  _globals['_FPGAINFO']._serialized_start=330
-  _globals['_FPGAINFO']._serialized_end=637
-  _globals['_VERBOSITY']._serialized_start=639
-  _globals['_VERBOSITY']._serialized_end=712
-  _globals['_ENVIRONMENT']._serialized_start=715
-  _globals['_ENVIRONMENT']._serialized_end=992
-  _globals['_APIOENVPARAMS']._serialized_start=995
-  _globals['_APIOENVPARAMS']._serialized_end=1234
-  _globals['_LINTPARAMS']._serialized_start=1236
-  _globals['_LINTPARAMS']._serialized_end=1336
-  _globals['_REPORTPARAMS']._serialized_start=1338
-  _globals['_REPORTPARAMS']._serialized_end=1372
-  _globals['_GRAPHPARAMS']._serialized_start=1374
-  _globals['_GRAPHPARAMS']._serialized_end=1485
-  _globals['_SIMPARAMS']._serialized_start=1487
-  _globals['_SIMPARAMS']._serialized_end=1587
-  _globals['_APIOTESTPARAMS']._serialized_start=1589
-  _globals['_APIOTESTPARAMS']._serialized_end=1655
-  _globals['_UPLOADPARAMS']._serialized_start=1657
-  _globals['_UPLOADPARAMS']._serialized_end=1695
-  _globals['_TARGETPARAMS']._serialized_start=1698
-  _globals['_TARGETPARAMS']._serialized_end=2016
-  _globals['_SCONSPARAMS']._serialized_start=2019
-  _globals['_SCONSPARAMS']._serialized_end=2380
+  _globals['_SHRIKEFPGAPARAMS']._serialized_start=329
+  _globals['_SHRIKEFPGAPARAMS']._serialized_end=380
+  _globals['_FPGAINFO']._serialized_start=383
+  _globals['_FPGAINFO']._serialized_end=752
+  _globals['_VERBOSITY']._serialized_start=754
+  _globals['_VERBOSITY']._serialized_end=827
+  _globals['_ENVIRONMENT']._serialized_start=830
+  _globals['_ENVIRONMENT']._serialized_end=1107
+  _globals['_APIOENVPARAMS']._serialized_start=1110
+  _globals['_APIOENVPARAMS']._serialized_end=1349
+  _globals['_LINTPARAMS']._serialized_start=1351
+  _globals['_LINTPARAMS']._serialized_end=1451
+  _globals['_REPORTPARAMS']._serialized_start=1453
+  _globals['_REPORTPARAMS']._serialized_end=1487
+  _globals['_GRAPHPARAMS']._serialized_start=1489
+  _globals['_GRAPHPARAMS']._serialized_end=1600
+  _globals['_SIMPARAMS']._serialized_start=1602
+  _globals['_SIMPARAMS']._serialized_end=1702
+  _globals['_APIOTESTPARAMS']._serialized_start=1704
+  _globals['_APIOTESTPARAMS']._serialized_end=1770
+  _globals['_UPLOADPARAMS']._serialized_start=1772
+  _globals['_UPLOADPARAMS']._serialized_end=1810
+  _globals['_TARGETPARAMS']._serialized_start=1813
+  _globals['_TARGETPARAMS']._serialized_end=2131
+  _globals['_SCONSPARAMS']._serialized_start=2134
+  _globals['_SCONSPARAMS']._serialized_end=2495
 # @@protoc_insertion_point(module_scope)

--- a/apio/common/proto/apio_pb2.pyi
+++ b/apio/common/proto/apio_pb2.pyi
@@ -17,6 +17,7 @@ class ApioArch(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     ECP5: _ClassVar[ApioArch]
     GOWIN: _ClassVar[ApioArch]
     XILINX: _ClassVar[ApioArch]
+    SHRIKE: _ClassVar[ApioArch]
 
 class TerminalMode(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     __slots__ = ()
@@ -36,6 +37,7 @@ ICE40: ApioArch
 ECP5: ApioArch
 GOWIN: ApioArch
 XILINX: ApioArch
+SHRIKE: ApioArch
 TERMINAL_UNSPECIFIED: TerminalMode
 AUTO_TERMINAL: TerminalMode
 FORCE_TERMINAL: TerminalMode
@@ -85,8 +87,16 @@ class XilinxFpgaParams(_message.Message):
     speed: str
     def __init__(self, family: _Optional[str] = ..., yosys_arch: _Optional[str] = ..., package: _Optional[str] = ..., speed: _Optional[str] = ...) -> None: ...
 
+class ShrikeFpgaParams(_message.Message):
+    __slots__ = ("family", "package")
+    FAMILY_FIELD_NUMBER: _ClassVar[int]
+    PACKAGE_FIELD_NUMBER: _ClassVar[int]
+    family: str
+    package: str
+    def __init__(self, family: _Optional[str] = ..., package: _Optional[str] = ...) -> None: ...
+
 class FpgaInfo(_message.Message):
-    __slots__ = ("fpga_id", "part_num", "size", "ice40_params", "ecp5_params", "gowin_params", "xilinx_params")
+    __slots__ = ("fpga_id", "part_num", "size", "ice40_params", "ecp5_params", "gowin_params", "xilinx_params", "shrike_params")
     FPGA_ID_FIELD_NUMBER: _ClassVar[int]
     PART_NUM_FIELD_NUMBER: _ClassVar[int]
     SIZE_FIELD_NUMBER: _ClassVar[int]
@@ -94,6 +104,7 @@ class FpgaInfo(_message.Message):
     ECP5_PARAMS_FIELD_NUMBER: _ClassVar[int]
     GOWIN_PARAMS_FIELD_NUMBER: _ClassVar[int]
     XILINX_PARAMS_FIELD_NUMBER: _ClassVar[int]
+    SHRIKE_PARAMS_FIELD_NUMBER: _ClassVar[int]
     fpga_id: str
     part_num: str
     size: str
@@ -101,7 +112,8 @@ class FpgaInfo(_message.Message):
     ecp5_params: Ecp5FpgaParams
     gowin_params: GowinFpgaParams
     xilinx_params: XilinxFpgaParams
-    def __init__(self, fpga_id: _Optional[str] = ..., part_num: _Optional[str] = ..., size: _Optional[str] = ..., ice40_params: _Optional[_Union[Ice40FpgaParams, _Mapping]] = ..., ecp5_params: _Optional[_Union[Ecp5FpgaParams, _Mapping]] = ..., gowin_params: _Optional[_Union[GowinFpgaParams, _Mapping]] = ..., xilinx_params: _Optional[_Union[XilinxFpgaParams, _Mapping]] = ...) -> None: ...
+    shrike_params: ShrikeFpgaParams
+    def __init__(self, fpga_id: _Optional[str] = ..., part_num: _Optional[str] = ..., size: _Optional[str] = ..., ice40_params: _Optional[_Union[Ice40FpgaParams, _Mapping]] = ..., ecp5_params: _Optional[_Union[Ecp5FpgaParams, _Mapping]] = ..., gowin_params: _Optional[_Union[GowinFpgaParams, _Mapping]] = ..., xilinx_params: _Optional[_Union[XilinxFpgaParams, _Mapping]] = ..., shrike_params: _Optional[_Union[ShrikeFpgaParams, _Mapping]] = ...) -> None: ...
 
 class Verbosity(_message.Message):
     __slots__ = ("all", "synth", "pnr")

--- a/apio/managers/scons_manager.py
+++ b/apio/managers/scons_manager.py
@@ -35,6 +35,7 @@ from apio.common.proto.apio_pb2 import (
     Ecp5FpgaParams,
     GowinFpgaParams,
     XilinxFpgaParams,
+    ShrikeFpgaParams,
     ApioArch,
     GraphParams,
     ReportParams,
@@ -299,6 +300,15 @@ class SConsManager:
                         yosys_arch=params["yosys-arch"],
                         package=params["package"],
                         speed=params["speed"],
+                    )
+                )
+            case "shrike":
+                params = fpga_info["shrike-params"]
+                result.arch = ApioArch.SHRIKE
+                result.fpga_info.shrike_params.MergeFrom(
+                    ShrikeFpgaParams(
+                        family=params["family"],
+                        package=params["package"],
                     )
                 )
             case _:

--- a/apio/scons/plugin_shrike.py
+++ b/apio/scons/plugin_shrike.py
@@ -1,0 +1,363 @@
+# -*- coding: utf-8 -*-
+# -- This file is part of the Apio project
+# -- (C) 2016-2018 FPGAwars
+# -- Author Jesús Arroyo
+# -- License GPLv2
+
+"""Apio scons plugin for the Shrike (SLG47910V / ForgeFPGA) architecture."""
+
+# pylint: disable=duplicate-code
+
+import base64
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import zlib
+from pathlib import Path
+
+from SCons.Action import Action
+from SCons.Builder import BuilderBase, CompositeBuilder
+from SCons.Script import Builder
+
+from apio.common.common_util import SRC_SUFFIXES
+from apio.scons.apio_env import ApioEnv
+from apio.scons.plugin_base import ArchPluginInfo, PluginBase
+from apio.scons.plugin_util import (
+    announce_testbench_action,
+    basename,
+    has_testbench_name,
+    iverilog_action,
+    make_verilator_config_builder,
+    source_files_issue_scanner_action,
+    verilator_lint_action,
+)
+
+# ── Go Configure Software Hub toolchain paths ─────────────────────────────────
+_GCSW = Path("/opt/go-configure-sw-hub/bin/external")
+_YOSYS = str(_GCSW / "yosys/v59/yosys")
+_EDA_PLACER = str(_GCSW / "eda-placer/v23/eda-placer")
+_EFLX_COMPILER_INSTALL = str(_GCSW / "eda-placer/v23")
+
+# ── PNR flags (captured from GUI strace) ─────────────────────────────────────
+# Order matches the Go Configure GUI invocation exactly.
+_PNR_FLAGS = [
+    ("-ENABLE_BITSTREAM_OUTPUT_AXI",     "1"),
+    ("-ENABLE_BITSTREAM_OUTPUT_AXI_CRC", "0"),
+    ("-ENABLE_HIGH_DENSITY_PACKING",     "1"),
+    ("-ENABLE_HIGH_DENSITY_IO_PACKING",  "0"),
+    ("-CLK_CONCURRENT_OPT",              "1"),
+    ("-PLACE_AND_TRIAL_ROUTE",           "0"),
+    ("-PNR_TRIAL_ITER_TOTAL",            "20"),
+    ("-MAX_ROUTE_ITER",                  "300"),
+    ("-MAX_CPU",                         None),  # filled at runtime
+    ("-TIMING_ANALYSIS_CORNER",          "0"),
+]
+
+# ── SLG47910V Rev BB bitstream fixed headers ──────────────────────────────────
+_FMEM_HEADER = [
+    0xAA22FF11, 0x00000000,
+    0x22222222, 0x22222222, 0x22220000,
+    0x03000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000,
+]
+_OTP_HEADER = [
+    0x00000028, 0x00000000,
+    0xA5A5A5A5, 0x00000000, 0x00000000,
+    0x5A5A5A5A, 0x00000000,
+] + _FMEM_HEADER[2:10]   # 15 words total
+_MCU_PRE  = 320            # zero words before FLASH_MEM content
+_MCU_POST = 8              # zero words after
+
+
+# ── Inlined gen_fpga_data logic ───────────────────────────────────────────────
+
+def _encode_fpga_data(netlist: str, fp: str, io: str) -> str:
+    """Build the FPGA_DATA base64 blob that eda-placer expects as argv[2]."""
+    max_cpu = str(os.cpu_count() or 1)
+    eda_args = ["-edif", os.path.abspath(netlist), "-fp", os.path.abspath(fp)]
+    for flag, val in _PNR_FLAGS:
+        eda_args.append(flag)
+        eda_args.append(max_cpu if val is None else val)
+    eda_args += ["-io", os.path.abspath(io)]
+
+    encoded = [a.encode("utf-8") for a in eda_args]
+    inner  = struct.pack(">I", len(encoded))
+    inner += b"".join(struct.pack(">I", len(e)) for e in encoded)
+    inner += b"".join(encoded)
+    outer  = struct.pack(">I", len(inner)) + zlib.compress(inner)
+    return base64.b64encode(outer).decode("ascii")
+
+
+# ── Inlined gen_bitstreams logic ──────────────────────────────────────────────
+
+def _read_axi(path: Path) -> list:
+    """Parse EFLX_bitstream_AXI.log: 1024×11 hex 32-bit words."""
+    return [
+        int(line.strip(), 16)
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def _bswap32(w: int) -> int:
+    return struct.unpack("<I", struct.pack(">I", w))[0]
+
+
+def _write_bin(path: Path, words: list) -> None:
+    path.write_bytes(struct.pack(f">{len(words)}I", *words))
+
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+
+def _locate(candidates: list) -> str | None:
+    """Return the first existing path from a list, or None."""
+    for p in candidates:
+        if Path(p).exists():
+            return str(p)
+    return None
+
+
+class PluginShrike(PluginBase):
+    """Apio scons plugin for the Shrike (SLG47910V / ForgeFPGA) architecture."""
+
+    def __init__(self, apio_env: ApioEnv):
+        super().__init__(apio_env)
+        # No architecture simulation library needed for Shrike.
+        self.sim_lib_files  = []
+        self.lint_lib_files = []
+
+    def plugin_info(self) -> ArchPluginInfo:
+        return ArchPluginInfo(
+            constrains_file_suffix=".pcf",   # io_map.pcf tracks IO changes
+            pnr_file_suffix=".axi",          # sentinel file for the AXI log
+            bitstream_file_suffix=".bin",    # FLASH_MEM format bitstream
+        )
+
+    # @overrides
+    def synth_builder(self) -> BuilderBase | CompositeBuilder:
+        """Write synth_script.ys then run Yosys v59 → hardware.edif."""
+        apio_env   = self.apio_env
+        params     = apio_env.params
+        build_path = apio_env.env_build_path
+        top        = params.apio_env_params.top_module
+
+        def synth_action(target, source, env):
+            _ = env
+
+            # Absolute source paths so Yosys finds them regardless of cwd.
+            src_paths = " ".join(
+                f'"{Path(str(s)).resolve()}"'
+                for s in source
+                if str(s).endswith((".v", ".sv"))
+            )
+            if not src_paths:
+                print("ERROR: no Verilog source files found.", file=sys.stderr)
+                return 1
+
+            edif_name = Path(str(target[0])).name   # e.g. "hardware.edif"
+
+            script = "\n".join([
+                f"read_verilog -sv {src_paths}",
+                "hierarchy -check",
+                "flatten -noscopeinfo",
+                f"synth_xilinx -nobram -noiopad -nodsp -abc9 -top {top}",
+                "clean",
+                "autoname",
+                'write_verilog "post_synth_results.v"',
+                f'write_edif "{edif_name}"',
+                "tee -q -o post_synth_report.txt stat",
+            ])
+
+            (build_path / "synth_script.ys").write_text(script)
+
+            result = subprocess.run(
+                [_YOSYS, "-e", "(.*)is implicitly declared.", "-Q",
+                 "-s", "synth_script.ys"],
+                cwd=str(build_path),
+            )
+            return result.returncode
+
+        return Builder(
+            action=Action(synth_action, "Shrike Synthesis (Yosys v59)"),
+            suffix=".edif",
+            src_suffix=SRC_SUFFIXES,
+            source_scanner=self.verilog_src_scanner,
+        )
+
+    # @overrides
+    def pnr_builder(self) -> BuilderBase | CompositeBuilder:
+        """Encode FPGA_DATA blob, run eda-placer v23 → hardware.axi sentinel."""
+        apio_env    = self.apio_env
+        build_path  = apio_env.env_build_path
+        # scons_manager.py calls os.chdir(project_dir) before SCons starts.
+        project_dir = Path.cwd()
+
+        def pnr_action(target, source, env):
+            _ = env
+
+            # source[0] = hardware.edif   source[1] = io_map.pcf (dependency)
+            netlist = str(source[0])
+
+            # io_spec_in.txt and floorplanspec.fp may live in the project root
+            # (Apio-native project) or in ffpga/build/ (shrike-gen project).
+            fp = _locate([
+                project_dir / "floorplanspec.fp",
+                project_dir / "ffpga" / "build" / "floorplanspec.fp",
+            ])
+            io = _locate([
+                project_dir / "io_spec_in.txt",
+                project_dir / "ffpga" / "build" / "io_spec_in.txt",
+            ])
+
+            for val, label in [(netlist, "netlist.edif"),
+                               (fp,      "floorplanspec.fp"),
+                               (io,      "io_spec_in.txt")]:
+                if not val:
+                    print(f"ERROR: required file not found: {label}",
+                          file=sys.stderr)
+                    return 1
+
+            blob = _encode_fpga_data(netlist, fp, io)
+
+            rundir = Path(tempfile.mkdtemp(prefix="eflx_"))
+            try:
+                out_dir = rundir / "out"
+                out_dir.mkdir()
+
+                env_vars = os.environ.copy()
+                env_vars["EFLX_COMPILER_INSTALL"] = _EFLX_COMPILER_INSTALL
+
+                log_path = build_path / "PNR_STDOUT.log"
+                with log_path.open("w") as log_f:
+                    result = subprocess.run(
+                        [_EDA_PLACER, "FPGA_DATA", blob, "0"],
+                        cwd=str(out_dir),
+                        env=env_vars,
+                        stdout=log_f,
+                        stderr=subprocess.STDOUT,
+                    )
+
+                if result.returncode != 0:
+                    print(f"ERROR: eda-placer failed — see {log_path}",
+                          file=sys.stderr)
+                    return result.returncode
+
+                # Copy regular eda-placer output files to the Apio build dir.
+                # eda-placer may also create directories such as "ta_message";
+                # those are auxiliary output and must not be passed to shutil.copy().
+                for f in out_dir.iterdir():
+                    if f.is_file():
+                        shutil.copy2(str(f), str(build_path / f.name))
+
+                # Write the SCons sentinel (hardware.axi) using the AXI log.
+                axi_src  = build_path / "EFLX_bitstream_AXI.log"
+                sentinel = Path(str(target[0]))
+                if axi_src.exists():
+                    shutil.copy(str(axi_src), str(sentinel))
+                else:
+                    sentinel.write_text("# eda-placer AXI sentinel\n")
+
+            finally:
+                shutil.rmtree(str(rundir), ignore_errors=True)
+
+            return 0
+
+        return Builder(
+            action=Action(pnr_action, "Shrike Place-and-Route (eda-placer v23)"),
+            suffix=".axi",
+            src_suffix=".edif",
+        )
+
+    # @overrides
+    def bitstream_builder(self) -> BuilderBase | CompositeBuilder:
+        """Parse EFLX_bitstream_AXI.log → hardware.bin (FLASH_MEM format)."""
+        apio_env   = self.apio_env
+        build_path = apio_env.env_build_path
+
+        def bitstream_action(target, source, env):
+            _ = env
+
+            axi_path = build_path / "EFLX_bitstream_AXI.log"
+            if not axi_path.exists():
+                print(f"ERROR: AXI log not found: {axi_path}", file=sys.stderr)
+                return 1
+
+            axi      = _read_axi(axi_path)
+            bswapped = [_bswap32(w) for w in axi]
+
+            fmem = _FMEM_HEADER + bswapped
+            mcu  = [0] * _MCU_PRE + fmem + [0] * _MCU_POST
+            otp  = _OTP_HEADER + bswapped
+
+            # Primary output tracked by SCons (FLASH_MEM format).
+            _write_bin(Path(str(target[0])), mcu)
+
+            # Secondary outputs alongside it.
+            _write_bin(build_path / "hardware_fpga.bin", fmem)
+            _write_bin(build_path / "FPGA_bitstream_OTP.bin", otp)
+
+            print(f"Bitstream: {Path(str(target[0])).name} "
+                  f"(+ MCU and OTP variants)")
+            return 0
+
+        return Builder(
+            action=Action(bitstream_action, "Shrike Bitstream Generation"),
+            suffix=".bin",
+            src_suffix=".axi",
+        )
+
+    # @overrides
+    def testbench_compile_builder(self) -> BuilderBase | CompositeBuilder:
+        """Testbench compile using iverilog (no Shrike-specific lib needed)."""
+        apio_env = self.apio_env
+        params   = apio_env.params
+
+        assert apio_env.targeting_one_of("sim", "test")
+        assert (params.target.HasField("sim") or
+                params.target.HasField("test"))
+
+        def action_generator(target, source, env, for_signature):
+            _ = (source, env, for_signature)
+            testbench_file = str(target[0])
+            assert has_testbench_name(testbench_file), testbench_file
+            testbench_name = basename(testbench_file)
+            return [
+                announce_testbench_action(),
+                source_files_issue_scanner_action(),
+                iverilog_action(
+                    apio_env,
+                    verbose=params.verbosity.all,
+                    vcd_output_name=testbench_name,
+                    is_interactive=apio_env.targeting_one_of("sim"),
+                    lib_dirs=[],
+                    lib_files=[],
+                ),
+            ]
+
+        return Builder(
+            generator=action_generator,
+            suffix=".out",
+            src_suffix=SRC_SUFFIXES,
+            source_scanner=self.verilog_src_scanner,
+        )
+
+    # @overrides
+    def lint_config_builder(self) -> BuilderBase:
+        """Lint config — no Shrike-specific primitives need suppression."""
+        assert self.apio_env.targeting_one_of("lint")
+        # Pass current dir as lib dir; no rules to suppress.
+        return make_verilator_config_builder(Path("."), rules_to_supress=[])
+
+    # @overrides
+    def lint_builder(self) -> BuilderBase | CompositeBuilder:
+        """Lint using system verilator (best-effort; requires v4.200+)."""
+        return Builder(
+            action=verilator_lint_action(
+                self.apio_env, lib_dirs=[], lib_files=[]
+            ),
+            src_suffix=SRC_SUFFIXES,
+            source_scanner=self.verilog_src_scanner,
+        )

--- a/apio/scons/scons_handler.py
+++ b/apio/scons/scons_handler.py
@@ -19,6 +19,7 @@ from apio.scons.plugin_ice40 import PluginIce40
 from apio.scons.plugin_ecp5 import PluginEcp5
 from apio.scons.plugin_gowin import PluginGowin
 from apio.scons.plugin_xilinx import PluginXilinx
+from apio.scons.plugin_shrike import PluginShrike
 from apio.common.proto.apio_pb2 import (
     SimParams,
     SconsParams,
@@ -26,6 +27,7 @@ from apio.common.proto.apio_pb2 import (
     ECP5,
     GOWIN,
     XILINX,
+    SHRIKE,
 )
 from apio.common import apio_console
 from apio.scons.apio_env import ApioEnv
@@ -101,6 +103,8 @@ class SconsHandler:
             plugin = PluginGowin(apio_env)
         elif params.arch == XILINX:
             plugin = PluginXilinx(apio_env)
+        elif params.arch == SHRIKE:
+            plugin = PluginShrike(apio_env)
         else:
             cout(
                 f"Apio SConstruct dispatch error: unknown arch [{params.arch}]"

--- a/apio/utils/resource_util.py
+++ b/apio/utils/resource_util.py
@@ -71,7 +71,7 @@ FPGA_SCHEMA = schema = {
         "part-num": {"type": "string"},
         "arch": {
             "type": "string",
-            "enum": ["ice40", "ecp5", "gowin", "xilinx"],
+            "enum": ["ice40", "ecp5", "gowin", "xilinx", "shrike"],
         },
         "size": {"type": "string"},
         "ice40-params": {
@@ -112,6 +112,15 @@ FPGA_SCHEMA = schema = {
                 "speed": {"type": "string"},
             },
             "required": ["family", "yosys-arch", "package", "speed"],
+            "additionalProperties": False,
+        },
+        "shrike-params": {
+            "type": "object",
+            "properties": {
+                "family": {"type": "string"},
+                "package": {"type": "string"},
+            },
+            "required": ["family", "package"],
             "additionalProperties": False,
         },
     },


### PR DESCRIPTION
## Add Shrike Lite SLG47910V Architecture Support

This PR adds native Shrike architecture support to Apio for the Renesas SLG47910V FPGA used by the Vicharak Shrike Lite board.

### What is included

- Add `SHRIKE` as a new Apio FPGA architecture.
- Add `ShrikeFpgaParams` for the SLG47910V-specific `family` and `package` parameters.
- Add Shrike architecture handling to `SConsManager`.
- Add Shrike architecture dispatch to `SconsHandler`.
- Add a dedicated `PluginShrike` SCons backend.
- Add Shrike-specific synthesis, place-and-route, and bitstream generation.
- Add Shrike support to Apio resource and architecture handling.
- Regenerate the protobuf Python bindings.

### Shrike build flow

The Shrike Lite (`SLG47910V`) flow differs from the standard iCE40 flow and follows the existing Renesas ForgeFPGA / Shrike toolchain workflow:

```text
Verilog / SystemVerilog
        +
     PCF constraints
        |
        v
   Apio Shrike backend
        |
        +--> Yosys synthesis
        |
        +--> EDA placer / P&R
        |
        +--> AXI bitstream output
        |
        v
 Shrike bitstream generation
        |
        +--> FLASH_MEM bitstream
        +--> FPGA bitstream
        +--> OTP bitstream
        |
        v
      RP2040
        |
        v
    SLG47910V
```

The Shrike backend generates the required intermediate artifacts as well as the final bitstream outputs used by the SLG47910V workflow. This includes the primary `FLASH_MEM` output together with the corresponding `FPGA` and `OTP` bitstream variants.

The implementation is based on the existing Shrike workflow and tooling provided by:

- https://github.com/trholding/shrike-gen

### Related device definitions

Support for the corresponding FPGA device and board definitions is being added separately in the `FPGAwars/apio-definitions` repository.

Device definition:

- FPGA ID: `slg47910v`
- Architecture: `shrike`
- Part: `SLG47910V`
- Family: `04`
- Package: `26`

The `apio-definitions` changes remain intentionally separate from this PR. This PR adds the core Shrike architecture support to Apio, while the device and board definitions are introduced independently through the definitions repository.

### Files changed

- `apio/common/proto/apio.proto`
- `apio/common/proto/apio_pb2.py`
- `apio/common/proto/apio_pb2.pyi`
- `apio/managers/scons_manager.py`
- `apio/scons/scons_handler.py`
- `apio/scons/plugin_shrike.py`
- `apio/utils/resource_util.py`

### References

- https://github.com/trholding/shrike-gen
- https://vicharak-in.github.io/shrike/
- https://github.com/FPGAwars/apio-definitions