### PR TITLE
Suppressed the exportation of a few env variables.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -174,6 +174,7 @@
         "popd",
         "posargs",
         "prevalidated",
+        "PRJXRAY",
         "productbuild",
         "prój",
         "protoc",

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -471,18 +471,18 @@ class ApioContext:
             # -- NOTE: There is no need to expand values in the "unset-env"
             # -- section since it contains env names only.
 
-            # -- Expand the values in the "path" section, if any.
-            path_section = package_env.get("path", [])
-            for i, path_template in enumerate(path_section):
-                path_section[i] = ApioContext._expand_env_values(
+            # -- Expand the values in the "add-to-path" section, if any.
+            add_to_path_section = package_env.get("add-to-path", [])
+            for i, path_template in enumerate(add_to_path_section):
+                add_to_path_section[i] = ApioContext._expand_env_values(
                     path_template, package_path
                 )
 
-            # -- Expand the values in the "set-vars" section, if any.
-            set_vars_section = package_env.get("set-vars", {})
-            for var_name, var_value in set_vars_section.items():
-                set_vars_section[var_name] = ApioContext._expand_env_values(
-                    var_value, package_path
+            # -- Expand the values in the "set-env-vars" section, if any.
+            set_env_vars_section = package_env.get("set-env-vars", {})
+            for var_name, var_value in set_env_vars_section.items():
+                set_env_vars_section[var_name] = (
+                    ApioContext._expand_env_values(var_value, package_path)
                 )
 
     def get_package_dir(self, package_name: str) -> Path:
@@ -606,19 +606,19 @@ class ApioContext:
             package_env = package_config["env"]
 
             # -- Collect the env vars to unset.
-            unset_vars_section = package_env.get("unset-vars", [])
-            for var_name in unset_vars_section:
+            unset_env_vars_section = package_env.get("unset-env-vars", [])
+            for var_name in unset_env_vars_section:
                 # -- Detect duplicates.
                 assert var_name not in unset_vars, var_name
                 unset_vars.append(var_name)
 
             # -- Collect the path values.
-            package_paths = package_env.get("path", [])
+            package_paths = package_env.get("add-to-path", [])
             paths.extend(package_paths)
 
             # -- Collect the env vars to set (name, value) pairs.
-            set_vars_section = package_env.get("set-vars", {})
-            for var_name, var_value in set_vars_section.items():
+            set_env_vars_section = package_env.get("set-env-vars", {})
+            for var_name, var_value in set_env_vars_section.items():
                 # -- Detect duplicates.
                 assert var_name not in set_vars, var_name
                 set_vars[var_name] = var_value

--- a/apio/apio_context.py
+++ b/apio/apio_context.py
@@ -478,11 +478,18 @@ class ApioContext:
                     path_template, package_path
                 )
 
-            # -- Expand the values in the "set-env-vars" section, if any.
-            set_env_vars_section = package_env.get("set-env-vars", {})
-            for var_name, var_value in set_env_vars_section.items():
-                set_env_vars_section[var_name] = (
+            # -- Expand the values in the "add-env-vars" section, if any.
+            add_env_vars_section = package_env.get("add-env-vars", {})
+            for var_name, var_value in add_env_vars_section.items():
+                add_env_vars_section[var_name] = (
                     ApioContext._expand_env_values(var_value, package_path)
+                )
+
+            # -- Expand the values in the "define-consts" section, if any.
+            define_consts_section = package_env.get("define-consts", {})
+            for const_name, const_value in define_consts_section.items():
+                define_consts_section[const_name] = (
+                    ApioContext._expand_env_values(const_value, package_path)
                 )
 
     def get_package_dir(self, package_name: str) -> Path:
@@ -605,9 +612,9 @@ class ApioContext:
             assert "env" in package_config
             package_env = package_config["env"]
 
-            # -- Collect the env vars to unset.
-            unset_env_vars_section = package_env.get("unset-env-vars", [])
-            for var_name in unset_env_vars_section:
+            # -- Collect the env vars to delete.
+            delete_env_vars_section = package_env.get("delete-env-vars", [])
+            for var_name in delete_env_vars_section:
                 # -- Detect duplicates.
                 assert var_name not in unset_vars, var_name
                 unset_vars.append(var_name)
@@ -616,9 +623,9 @@ class ApioContext:
             package_paths = package_env.get("add-to-path", [])
             paths.extend(package_paths)
 
-            # -- Collect the env vars to set (name, value) pairs.
-            set_env_vars_section = package_env.get("set-env-vars", {})
-            for var_name, var_value in set_env_vars_section.items():
+            # -- Collect the env vars to add (name, value) pairs.
+            add_env_vars_section = package_env.get("add-env-vars", {})
+            for var_name, var_value in add_env_vars_section.items():
                 # -- Detect duplicates.
                 assert var_name not in set_vars, var_name
                 set_vars[var_name] = var_value

--- a/apio/commands/apio_api.py
+++ b/apio/commands/apio_api.py
@@ -874,10 +874,13 @@ def _get_packages_cli(
 
     for package_name in package_manager.required_packages:
         metadata = package_manager.installed_packages[package_name]
+        config = apio_ctx.all_packages[package_name]
         build_info = package_manager.read_package_build_info(package_name)
         section_dict[package_name] = {
-            **metadata,
+            "description": config["description"],
+            "installation": metadata,
             "build-info": build_info,
+            "env": config["env"],
         }
 
     # -- Write out

--- a/apio/managers/scons_manager.py
+++ b/apio/managers/scons_manager.py
@@ -305,15 +305,17 @@ class SConsManager:
 
         # -- Populate the Environment params.
         assert apio_ctx.platform_id, "Missing platform_id in apio context"
-        oss_set_vars = apio_ctx.all_packages["oss-cad-suite"]["env"][
-            "set-vars"
+        oss_set_env_vars = apio_ctx.all_packages["oss-cad-suite"]["env"][
+            "set-env-vars"
         ]
-        assert "YOSYS_LIB" in oss_set_vars, oss_set_vars
-        assert "TRELLIS" in oss_set_vars, oss_set_vars
+        assert "YOSYS_LIB" in oss_set_env_vars, oss_set_env_vars
+        assert "TRELLIS" in oss_set_env_vars, oss_set_env_vars
 
-        openxc7_set_vars = apio_ctx.all_packages["openxc7"]["env"]["set-vars"]
-        assert "PRJXRAY_DB_DIR" in openxc7_set_vars, open
-        assert "CHIPDB_DIR" in openxc7_set_vars, open
+        openxc7_set_env_vars = apio_ctx.all_packages["openxc7"]["env"][
+            "set-env-vars"
+        ]
+        assert "PRJXRAY_DB_DIR" in openxc7_set_env_vars, open
+        assert "CHIPDB_DIR" in openxc7_set_env_vars, open
 
         result.environment.MergeFrom(
             Environment(
@@ -326,11 +328,11 @@ class SConsManager:
                 ),
                 theme_name=apio_console.current_theme_name(),
                 debug_level=util.debug_level(),
-                yosys_path=oss_set_vars["YOSYS_LIB"],
-                trellis_path=oss_set_vars["TRELLIS"],
+                yosys_path=oss_set_env_vars["YOSYS_LIB"],
+                trellis_path=oss_set_env_vars["TRELLIS"],
                 scons_shell_id=apio_ctx.scons_shell_id,
-                xilinx_prjxray_db_path=openxc7_set_vars["PRJXRAY_DB_DIR"],
-                xilinx_chipdb_path=openxc7_set_vars["CHIPDB_DIR"],
+                xilinx_prjxray_db_path=openxc7_set_env_vars["PRJXRAY_DB_DIR"],
+                xilinx_chipdb_path=openxc7_set_env_vars["CHIPDB_DIR"],
             )
         )
         assert result.environment.IsInitialized(), result

--- a/apio/managers/scons_manager.py
+++ b/apio/managers/scons_manager.py
@@ -305,17 +305,17 @@ class SConsManager:
 
         # -- Populate the Environment params.
         assert apio_ctx.platform_id, "Missing platform_id in apio context"
-        oss_set_env_vars = apio_ctx.all_packages["oss-cad-suite"]["env"][
-            "set-env-vars"
+        oss_define_consts = apio_ctx.all_packages["oss-cad-suite"]["env"][
+            "define-consts"
         ]
-        assert "YOSYS_LIB" in oss_set_env_vars, oss_set_env_vars
-        assert "TRELLIS" in oss_set_env_vars, oss_set_env_vars
+        assert "YOSYS_LIB" in oss_define_consts, oss_define_consts
+        assert "TRELLIS" in oss_define_consts, oss_define_consts
 
-        openxc7_set_env_vars = apio_ctx.all_packages["openxc7"]["env"][
-            "set-env-vars"
+        openxc7_define_consts = apio_ctx.all_packages["openxc7"]["env"][
+            "define-consts"
         ]
-        assert "PRJXRAY_DB_DIR" in openxc7_set_env_vars, open
-        assert "CHIPDB_DIR" in openxc7_set_env_vars, open
+        assert "PRJXRAY_DB_DIR" in openxc7_define_consts, openxc7_define_consts
+        assert "CHIPDB_DIR" in openxc7_define_consts, openxc7_define_consts
 
         result.environment.MergeFrom(
             Environment(
@@ -328,11 +328,11 @@ class SConsManager:
                 ),
                 theme_name=apio_console.current_theme_name(),
                 debug_level=util.debug_level(),
-                yosys_path=oss_set_env_vars["YOSYS_LIB"],
-                trellis_path=oss_set_env_vars["TRELLIS"],
+                yosys_path=oss_define_consts["YOSYS_LIB"],
+                trellis_path=oss_define_consts["TRELLIS"],
                 scons_shell_id=apio_ctx.scons_shell_id,
-                xilinx_prjxray_db_path=openxc7_set_env_vars["PRJXRAY_DB_DIR"],
-                xilinx_chipdb_path=openxc7_set_env_vars["CHIPDB_DIR"],
+                xilinx_prjxray_db_path=openxc7_define_consts["PRJXRAY_DB_DIR"],
+                xilinx_chipdb_path=openxc7_define_consts["CHIPDB_DIR"],
             )
         )
         assert result.environment.IsInitialized(), result

--- a/apio/resources/packages.jsonc
+++ b/apio/resources/packages.jsonc
@@ -47,7 +47,9 @@
         "%p/bin",
         "%p/lib"
       ],
-      "set-env-vars": {
+      // These are internal values that are used by Apio and they are not
+      // exported as env vars.
+      "define-consts": {
         "PRJXRAY_DB_DIR": "%p/share/nextpnr/external/prjxray-db",
         "CHIPDB_DIR": "%p/chipdb"
       }
@@ -57,7 +59,7 @@
   "oss-cad-suite": {
     "description": "Yosys HQ oss-cad-suite",
     "env": {
-      "unset-env-vars": [
+      "delete-env-vars": [
         // Delete this var, if exists. This isolate the oss-cad-suite
         // embedded python from the local python.
         "PYTHONPATH"
@@ -66,11 +68,13 @@
         "%p/bin",
         "%p/lib"
       ],
-      "set-env-vars": {
-        "VERILATOR_ROOT": "%p/share/verilator",
-        "ICEBOX": "%p/share/icebox",
-        "TRELLIS": "%p/share/trellis",
-        "YOSYS_LIB": "%p/share/yosys"
+      "add-env-vars": {
+        "VERILATOR_ROOT": "%p/share/verilator"
+        // "ICEBOX": "%p/share/icebox"
+      },
+      "define-consts": {
+          "TRELLIS": "%p/share/trellis",
+          "YOSYS_LIB": "%p/share/yosys"
       }
     }
   },

--- a/apio/resources/packages.jsonc
+++ b/apio/resources/packages.jsonc
@@ -22,7 +22,7 @@
     ],
     "description": "Drivers tools for Windows",
     "env": {
-      "path": [
+      "add-to-path": [
         "%p/bin"
       ]
     }
@@ -34,7 +34,7 @@
     ],
     "description": "Graphviz tool for Windows",
     "env": {
-      "path": [
+      "add-to-path": [
         "%p/bin"
       ]
     }
@@ -43,11 +43,11 @@
   "openxc7": {
     "description": "Openxc7 toolchain (Xilinx FPGAs)",
     "env": {
-      "path": [
+      "add-to-path": [
         "%p/bin",
         "%p/lib"
       ],
-      "set-vars": {
+      "set-env-vars": {
         "PRJXRAY_DB_DIR": "%p/share/nextpnr/external/prjxray-db",
         "CHIPDB_DIR": "%p/chipdb"
       }
@@ -57,16 +57,16 @@
   "oss-cad-suite": {
     "description": "Yosys HQ oss-cad-suite",
     "env": {
-      "unset-vars": [
+      "unset-env-vars": [
         // Delete this var, if exists. This isolate the oss-cad-suite
         // embedded python from the local python.
         "PYTHONPATH"
       ],
-      "path": [
+      "add-to-path": [
         "%p/bin",
         "%p/lib"
       ],
-      "set-vars": {
+      "set-env-vars": {
         "VERILATOR_ROOT": "%p/share/verilator",
         "ICEBOX": "%p/share/icebox",
         "TRELLIS": "%p/share/trellis",
@@ -78,7 +78,7 @@
   "verible": {
     "description": "Chips Alliance Verible toolset",
     "env": {
-      "path": [
+      "add-to-path": [
         "%p/bin"
       ]
     }

--- a/apio/resources/packages.jsonc
+++ b/apio/resources/packages.jsonc
@@ -58,7 +58,7 @@
     "description": "Yosys HQ oss-cad-suite",
     "env": {
       "unset-vars": [
-        // Delete this var, if exists, o isolate the oss-cad-suite
+        // Delete this var, if exists. This isolate the oss-cad-suite
         // embedded python from the local python.
         "PYTHONPATH"
       ],
@@ -71,11 +71,6 @@
         "ICEBOX": "%p/share/icebox",
         "TRELLIS": "%p/share/trellis",
         "YOSYS_LIB": "%p/share/yosys"
-        // TODO: Delete after testing. Was used for the --gui option
-        // but may impacted other functionalities.
-        //
-        // For 'apio build -g' on windows.
-        // "QT_PLUGIN_PATH": "%p/lib/qt5/plugins"
       }
     }
   },

--- a/apio/resources/packages.jsonc
+++ b/apio/resources/packages.jsonc
@@ -15,6 +15,44 @@
     "description": "Apio project examples",
     "env": {}
   },
+  // "drivers" package
+  "drivers": {
+    "restricted-to-platforms": [
+      "windows-amd64"
+    ],
+    "description": "Drivers tools for Windows",
+    "env": {
+      "path": [
+        "%p/bin"
+      ]
+    }
+  },
+  // "graphviz" package
+  "graphviz": {
+    "restricted-to-platforms": [
+      "windows-amd64"
+    ],
+    "description": "Graphviz tool for Windows",
+    "env": {
+      "path": [
+        "%p/bin"
+      ]
+    }
+  },
+  // "openxc7" package
+  "openxc7": {
+    "description": "Openxc7 toolchain (Xilinx FPGAs)",
+    "env": {
+      "path": [
+        "%p/bin",
+        "%p/lib"
+      ],
+      "set-vars": {
+        "PRJXRAY_DB_DIR": "%p/share/nextpnr/external/prjxray-db",
+        "CHIPDB_DIR": "%p/chipdb"
+      }
+    }
+  },
   // "oss-cad-suite" package
   "oss-cad-suite": {
     "description": "Yosys HQ oss-cad-suite",
@@ -41,47 +79,9 @@
       }
     }
   },
-  // "openxc7" package
-  "openxc7": {
-    "description": "Openxc7 toolchain (Xilinx FPGAs)",
-    "env": {
-      "path": [
-        "%p/bin",
-        "%p/lib"
-      ],
-      "set-vars": {
-        "PRJXRAY_DB_DIR": "%p/share/nextpnr/external/prjxray-db",
-        "CHIPDB_DIR": "%p/chipdb"
-      }
-    }
-  },
-  // "graphviz" package
-  "graphviz": {
-    "restricted-to-platforms": [
-      "windows-amd64"
-    ],
-    "description": "Graphviz tool for Windows",
-    "env": {
-      "path": [
-        "%p/bin"
-      ]
-    }
-  },
   // "verible" package
   "verible": {
-    "description": "Chips Aliance Verible toolset",
-    "env": {
-      "path": [
-        "%p/bin"
-      ]
-    }
-  },
-  // "drivers" package
-  "drivers": {
-    "restricted-to-platforms": [
-      "windows-amd64"
-    ],
-    "description": "Drivers tools for Windows",
+    "description": "Chips Alliance Verible toolset",
     "env": {
       "path": [
         "%p/bin"

--- a/apio/utils/resource_util.py
+++ b/apio/utils/resource_util.py
@@ -54,12 +54,15 @@ PACKAGES_SCHEMA = {
                 "env": {
                     "type": "object",
                     "properties": {
-                        "path": {"type": "array", "items": {"type": "string"}},
-                        "unset-vars": {
+                        "add-to-path": {
                             "type": "array",
                             "items": {"type": "string"},
                         },
-                        "set-vars": {
+                        "unset-env-vars": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "set-env-vars": {
                             "type": "object",
                             "additionalProperties": {"type": "string"},
                         },

--- a/apio/utils/resource_util.py
+++ b/apio/utils/resource_util.py
@@ -58,11 +58,15 @@ PACKAGES_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                         },
-                        "unset-env-vars": {
+                        "delete-env-vars": {
                             "type": "array",
                             "items": {"type": "string"},
                         },
-                        "set-env-vars": {
+                        "add-env-vars": {
+                            "type": "object",
+                            "additionalProperties": {"type": "string"},
+                        },
+                        "define-consts": {
                             "type": "object",
                             "additionalProperties": {"type": "string"},
                         },

--- a/tests/unit_tests/commands/test_apio_raw.py
+++ b/tests/unit_tests/commands/test_apio_raw.py
@@ -28,7 +28,7 @@ def test_raw(apio_runner: ApioRunner):
         sb.assert_result_ok(result)
         assert "Environment settings:" in result.output
         assert "PATH" in result.output
-        assert "YOSYS_LIB" in result.output
+        assert "VERILATOR_ROOT" in result.output
 
         # -- Run 'apio raw -- echo hello'.
         result = sb.invoke_apio_cmd(
@@ -53,7 +53,7 @@ def test_raw(apio_runner: ApioRunner):
         result = sb.invoke_apio_cmd(apio, ["raw", "-v"], in_subprocess=True)
         sb.assert_result_ok(result)
         assert "Environment settings:" in result.output
-        assert "YOSYS_LIB" in result.output
+        assert "VERILATOR_ROOT" in result.output
 
 
 def test_raw_preserves_argv_and_cwd(apio_runner: ApioRunner):


### PR DESCRIPTION
Per https://github.com/FPGAwars/apio/issues/910, some env variables that are set by Apio are unnecessary and are were exported in the pass as a way to transfer parameters to scons, before we switched to the protocol buffers message.

This PR redefined some of the vars and consts that are no exported in the env. Also, some cleanup around the packages file `packages.jsonc`.