### PR TITLE
Decoupled the remote configs monitor script from Apio dependencies

### DIFF
--- a/.github/workflows/monitor-remote-configs.yaml
+++ b/.github/workflows/monitor-remote-configs.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Set up latest Python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
       - name: Install json5
         run: |

--- a/.github/workflows/monitor-remote-configs.yaml
+++ b/.github/workflows/monitor-remote-configs.yaml
@@ -23,8 +23,6 @@ jobs:
         shell: bash
 
     steps:
-
-
       - name: Checkout Apio's main branch
         uses: actions/checkout@v4
         with:
@@ -33,12 +31,9 @@ jobs:
       - name: Set up latest Python
         uses: actions/setup-python@v6
 
-      # -- This provides the check_remote_configs.py script the module
-      # -- apio.utils.jsonc.
-      - name: Install Apio
+      - name: Install json5
         run: |
-          pip install invoke
-          invoke install-apio
+          pip install json5
 
       - name: Run scripts/check_remote_configs.py
         env:

--- a/.github/workflows/monitor-remote-configs.yaml
+++ b/.github/workflows/monitor-remote-configs.yaml
@@ -33,9 +33,9 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install json5
+      - name: Install python dependencies
         run: |
-          pip install json5
+          pip install json5 requests
 
       - name: Run scripts/check_remote_configs.py
         env:

--- a/scripts/check_remote_configs.py
+++ b/scripts/check_remote_configs.py
@@ -4,15 +4,16 @@ the 'remote-config' directory of the apio repository and for each remote
 config file it verified all the packages versions referred by it do exist
 and are stable.
 
+Requires installation of json5.
+
 The program exists with an error status upon any error.
 """
 
 import os
 import sys
-import json
 from typing import Dict
 import requests
-from apio.utils import jsonc
+import json5
 
 # -- The github repo that contains the remote configs in its 'main' branch.
 REMOTE_CONFIG_REPO = "fpgawars/apio"
@@ -101,11 +102,13 @@ def check_package(package_name: str, package_config: Dict):
     print("Release exists and is stable")
 
 
-def check_remote_config(jsonc_text: Dict):
+def check_remote_config(jsonc_text: str):
     """Check a given remote config file given its content as a parsed json
     dict."""
-    json_text = jsonc.to_json(jsonc_text)
-    json_data = json.loads(json_text)
+
+    # -- Since the remote config files are .jsonc files with comments,
+    # -- we use a json5 parser.
+    json_data = json5.loads(jsonc_text)
 
     # -- Sanity check the package count
     assert 5 <= len(json_data["packages"]) <= 15
@@ -150,6 +153,9 @@ def main():
         if file_name in SKIP_FILES:
             print(f"Skipping {file_name}")
             continue
+
+        # if file_name != "apio-1.6.x.jsonc":
+        #     continue
 
         # -- Announce remote config file name.
         print(f"\n\n===== Remote Config {file_name} =====\n")

--- a/scripts/check_remote_configs.py
+++ b/scripts/check_remote_configs.py
@@ -4,16 +4,17 @@ the 'remote-config' directory of the apio repository and for each remote
 config file it verified all the packages versions referred by it do exist
 and are stable.
 
-Requires installation of json5.
-
 The program exists with an error status upon any error.
 """
 
+# -- Standard python
 import os
 import sys
 from typing import Dict
-import requests
+
+# -- Third party
 import json5
+import requests
 
 # -- The github repo that contains the remote configs in its 'main' branch.
 REMOTE_CONFIG_REPO = "fpgawars/apio"


### PR DESCRIPTION
Previously it required Apio installation for parsing .jsonc files using the Apio jsonc module, now it uses json5.