### PR TITLE
monitor: check the on-demand device databases of a release

### DIFF
--- a/scripts/check_remote_configs.py
+++ b/scripts/check_remote_configs.py
@@ -25,16 +25,24 @@ SKIP_FILES = ["README.md"]
 # -- Connect and read timeouts in secs
 TIMEOUT = (10, 60)
 
-# -- Prefix of the parts index asset published by packages whose device
-# -- databases are fetched on demand (openxc7). The rest of the asset name
-# -- is the release tag's date, the same rule apio uses for every asset.
+# -- Names under which a release publishes its parts index: the name the
+# -- document has inside the package, and the dated asset name apio derives
+# -- from the tag. Both are accepted, so that renaming the asset to the
+# -- former does not need this script and the toolchain to change at once.
+PARTS_INDEX_NAME = "PARTS-INDEX.json"
 PARTS_INDEX_PREFIX = "apio-xilinx-parts-index-"
+
+# -- Packages whose device databases are fetched on demand, and the first
+# -- release tag that is. Their earlier releases carried the databases
+# -- inside the package and need no index; from these tags on, a release
+# -- without one is broken, not old.
+PARTS_INDEX_REQUIRED_FROM = {"openxc7": "2026-08-29"}
 
 # -- The parts index schema that apio's loader
 # -- (apio/managers/xilinx_chipdb.py) knows how to read. A release with a
 # -- different schema renamed or reshaped the fields the loader uses, so
 # -- bump this together with the loader.
-PARTS_INDEX_SCHEMA = 5
+PARTS_INDEX_SCHEMA_VERSION = 5
 
 
 def github_api_headers() -> dict[str, str]:
@@ -103,7 +111,7 @@ def check_package(package_name: str, package_config: Dict):
 
     # -- If this package fetches its device databases on demand, check that
     # -- the databases its index promises are actually published.
-    check_parts_index(tag, assets)
+    check_parts_index(package_name, tag, assets)
 
 
 def check_parts_index_content(index_name: str, index: Dict, assets: Dict):
@@ -158,7 +166,43 @@ def check_parts_index_content(index_name: str, index: Dict, assets: Dict):
     )
 
 
-def check_parts_index(tag: str, assets: Dict):
+def find_parts_index(package_name: str, tag: str, assets: Dict) -> str:
+    """Return the name of the release's parts index asset, or None if the
+    release has none and is not required to have one."""
+
+    # -- Preferred name, the one the document has inside the package.
+    if PARTS_INDEX_NAME in assets:
+        return PARTS_INDEX_NAME
+
+    # -- Dated name. Asset names are derived from the tag's date, so it
+    # -- must be the one named after this tag: an index from another
+    # -- release describes another release's assets.
+    dated = [n for n in assets if n.startswith(PARTS_INDEX_PREFIX)]
+    assert len(dated) <= 1, dated
+    if dated:
+        expected_name = PARTS_INDEX_PREFIX + tag.replace("-", "") + ".json"
+        if dated[0] != expected_name:
+            print(
+                f"Error: expected index '{expected_name}', "
+                f"found '{dated[0]}'"
+            )
+            sys.exit(1)
+        return dated[0]
+
+    # -- No index. For a package that fetches its databases on demand that
+    # -- is a broken release, not an old one, so do not pass it silently.
+    required_from = PARTS_INDEX_REQUIRED_FROM.get(package_name)
+    if required_from and tag >= required_from:
+        print(
+            f"Error: release '{tag}' of package '{package_name}' has no "
+            f"parts index, and releases from '{required_from}' on need one"
+        )
+        sys.exit(1)
+
+    return None
+
+
+def check_parts_index(package_name: str, tag: str, assets: Dict):
     """Check the on-demand device databases of a release, if it has any.
 
     Packages whose device databases are fetched on demand (openxc7)
@@ -166,25 +210,12 @@ def check_parts_index(tag: str, assets: Dict):
     for a given part. 'assets' maps the release's asset names to their
     github metadata."""
 
-    # -- Packages without on-demand databases publish no index.
-    index_names = [n for n in assets if n.startswith(PARTS_INDEX_PREFIX)]
-    if not index_names:
+    index_name = find_parts_index(package_name, tag, assets)
+    if index_name is None:
         return
-    assert len(index_names) == 1, index_names
-    index_name = index_names[0]
 
     print()
     print(f"Checking parts index [{index_name}]")
-
-    # -- Asset names are derived from the tag's date, so the index of this
-    # -- release must be the one named after this tag.
-    expected_name = PARTS_INDEX_PREFIX + tag.replace("-", "") + ".json"
-    if index_name != expected_name:
-        print(
-            f"Error: expected index '{expected_name}', "
-            f"found '{index_name}'"
-        )
-        sys.exit(1)
 
     # -- Fetch the index. It is a small json (tens of KB). No github token
     # -- here: the download url redirects to blob storage, which rejects a
@@ -197,10 +228,10 @@ def check_parts_index(tag: str, assets: Dict):
 
     # -- A different schema means the fields apio's loader reads were
     # -- renamed or reshaped.
-    if index.get("schema") != PARTS_INDEX_SCHEMA:
+    if index.get("schema") != PARTS_INDEX_SCHEMA_VERSION:
         print(
             f"Error: {index_name} has schema {index.get('schema')}, but "
-            f"apio's loader expects schema {PARTS_INDEX_SCHEMA}"
+            f"apio's loader expects schema {PARTS_INDEX_SCHEMA_VERSION}"
         )
         sys.exit(1)
 

--- a/scripts/check_remote_configs.py
+++ b/scripts/check_remote_configs.py
@@ -25,6 +25,17 @@ SKIP_FILES = ["README.md"]
 # -- Connect and read timeouts in secs
 TIMEOUT = (10, 60)
 
+# -- Prefix of the parts index asset published by packages whose device
+# -- databases are fetched on demand (openxc7). The rest of the asset name
+# -- is the release tag's date, the same rule apio uses for every asset.
+PARTS_INDEX_PREFIX = "apio-xilinx-parts-index-"
+
+# -- The parts index schema that apio's loader
+# -- (apio/managers/xilinx_chipdb.py) knows how to read. A release with a
+# -- different schema renamed or reshaped the fields the loader uses, so
+# -- bump this together with the loader.
+PARTS_INDEX_SCHEMA = 5
+
 
 def github_api_headers() -> dict[str, str]:
     """Construct HTTP headers to pass to the github API. If the env
@@ -84,11 +95,125 @@ def check_package(package_name: str, package_config: Dict):
     else:
         print("Release is not a pre-release")
 
-    asset_names = [asset["name"] for asset in data["assets"]]
-    for asset_name in asset_names:
+    assets = {asset["name"]: asset for asset in data["assets"]}
+    for asset_name in assets:
         print(f"- {asset_name}")
 
     print("Release exists and is stable")
+
+    # -- If this package fetches its device databases on demand, check that
+    # -- the databases its index promises are actually published.
+    check_parts_index(tag, assets)
+
+
+def check_parts_index_content(index_name: str, index: Dict, assets: Dict):
+    """Check the content of a parts index against the release that
+    publishes it. 'assets' maps the release's asset names to their github
+    metadata."""
+
+    # -- The document counts what it contains. A mismatch means the index
+    # -- was built from a different set of parts than it describes.
+    parts = index["parts"]
+    generated = {n: p for n, p in parts.items() if p["generated"]}
+    databases = {p["chipdb"] for p in generated.values()}
+    for key, actual in [
+        ("part-count", len(parts)),
+        ("generated-count", len(generated)),
+        ("chipdb-count", len(databases)),
+    ]:
+        if index.get(key) != actual:
+            print(
+                f"Error: {index_name}: {key} is {index.get(key)}, "
+                f"but the document describes {actual}"
+            )
+            sys.exit(1)
+
+    # -- Every part that has a database must have it published, at the size
+    # -- the index promises. Apio is dead in the water for a part whose
+    # -- asset is missing or truncated, and nothing else would notice.
+    # -- One check per FILE: the speed grades of a part share one asset.
+    checked = {}
+    for part_name, part in generated.items():
+        asset_name = part["asset"]
+        if asset_name in checked:
+            continue
+        checked[asset_name] = part_name
+        asset = assets.get(asset_name)
+        if asset is None:
+            print(
+                f"Error: part '{part_name}' needs asset "
+                f"'{asset_name}', which this release does not publish"
+            )
+            sys.exit(1)
+        if asset["size"] != part["asset-size"]:
+            print(
+                f"Error: asset '{asset_name}' is {asset['size']} "
+                f"bytes, but the index says {part['asset-size']}"
+            )
+            sys.exit(1)
+
+    print(
+        f"Parts index OK ({len(parts)} parts, {len(generated)} of them "
+        f"with a database, in {len(checked)} assets)"
+    )
+
+
+def check_parts_index(tag: str, assets: Dict):
+    """Check the on-demand device databases of a release, if it has any.
+
+    Packages whose device databases are fetched on demand (openxc7)
+    publish an index asset that tells apio which database file to download
+    for a given part. 'assets' maps the release's asset names to their
+    github metadata."""
+
+    # -- Packages without on-demand databases publish no index.
+    index_names = [n for n in assets if n.startswith(PARTS_INDEX_PREFIX)]
+    if not index_names:
+        return
+    assert len(index_names) == 1, index_names
+    index_name = index_names[0]
+
+    print()
+    print(f"Checking parts index [{index_name}]")
+
+    # -- Asset names are derived from the tag's date, so the index of this
+    # -- release must be the one named after this tag.
+    expected_name = PARTS_INDEX_PREFIX + tag.replace("-", "") + ".json"
+    if index_name != expected_name:
+        print(
+            f"Error: expected index '{expected_name}', "
+            f"found '{index_name}'"
+        )
+        sys.exit(1)
+
+    # -- Fetch the index. It is a small json (tens of KB). No github token
+    # -- here: the download url redirects to blob storage, which rejects a
+    # -- forwarded Authorization header.
+    resp = requests.get(
+        assets[index_name]["browser_download_url"], timeout=TIMEOUT
+    )
+    resp.raise_for_status()
+    index = resp.json()
+
+    # -- A different schema means the fields apio's loader reads were
+    # -- renamed or reshaped.
+    if index.get("schema") != PARTS_INDEX_SCHEMA:
+        print(
+            f"Error: {index_name} has schema {index.get('schema')}, but "
+            f"apio's loader expects schema {PARTS_INDEX_SCHEMA}"
+        )
+        sys.exit(1)
+
+    # -- The index names the release it belongs to. A mismatch sends apio
+    # -- to the assets of another release.
+    if index.get("release-tag") != tag:
+        print(
+            f"Error: {index_name} belongs to release "
+            f"'{index.get('release-tag')}', not '{tag}'"
+        )
+        sys.exit(1)
+
+    check_parts_index_content(index_name, index, assets)
 
 
 def check_remote_config(jsonc_text: str):

--- a/scripts/check_remote_configs.py
+++ b/scripts/check_remote_configs.py
@@ -25,24 +25,28 @@ SKIP_FILES = ["README.md"]
 # -- Connect and read timeouts in secs
 TIMEOUT = (10, 60)
 
-# -- Names under which a release publishes its parts index: the name the
-# -- document has inside the package, and the dated asset name apio derives
-# -- from the tag. Both are accepted, so that renaming the asset to the
-# -- former does not need this script and the toolchain to change at once.
-PARTS_INDEX_NAME = "PARTS-INDEX.json"
-PARTS_INDEX_PREFIX = "apio-xilinx-parts-index-"
+# -- The package whose device databases apio fetches on demand. The parts
+# -- index and everything below is specific to it; if a second package ever
+# -- adopts the pattern, this is the place to generalize from.
+OPENXC7_PACKAGE = "openxc7"
 
-# -- Packages whose device databases are fetched on demand, and the first
-# -- release tag that is. Their earlier releases carried the databases
-# -- inside the package and need no index; from these tags on, a release
-# -- without one is broken, not old.
-PARTS_INDEX_REQUIRED_FROM = {"openxc7": "2026-08-29"}
+# -- Names under which an openxc7 release publishes its parts index: the
+# -- name the document has inside the package, and the dated asset name
+# -- releases up to 2026-08-31 used. Both are accepted, so that the rename
+# -- did not need this script and the toolchain to change at once.
+OPENXC7_PARTS_INDEX_NAME = "PARTS-INDEX.json"
+OPENXC7_PARTS_INDEX_PREFIX = "apio-xilinx-parts-index-"
+
+# -- The first openxc7 release whose packages carry no device databases.
+# -- Earlier ones shipped them inside the package and need no index; from
+# -- this tag on, a release without one is broken, not old.
+OPENXC7_PARTS_INDEX_REQUIRED_FROM = "2026-08-29"
 
 # -- The parts index schema that apio's loader
 # -- (apio/managers/xilinx_chipdb.py) knows how to read. A release with a
 # -- different schema renamed or reshaped the fields the loader uses, so
 # -- bump this together with the loader.
-PARTS_INDEX_SCHEMA_VERSION = 5
+OPENXC7_PARTS_INDEX_SCHEMA_VERSION = 5
 
 
 def github_api_headers() -> dict[str, str]:
@@ -109,13 +113,17 @@ def check_package(package_name: str, package_config: Dict):
 
     print("Release exists and is stable")
 
-    # -- If this package fetches its device databases on demand, check that
-    # -- the databases its index promises are actually published.
-    check_parts_index(package_name, tag, assets)
+    # -- The on-demand device databases are an openxc7 thing: only that
+    # -- package publishes a parts index, and only it is checked.
+    is_openxc7 = package_name == OPENXC7_PACKAGE
+    if is_openxc7:
+        check_openxc7_parts_index(tag, assets)
 
 
-def check_parts_index_content(index_name: str, index: Dict, assets: Dict):
-    """Check the content of a parts index against the release that
+def check_openxc7_parts_index_content(
+    index_name: str, index: Dict, assets: Dict
+):
+    """Check the content of an openxc7 parts index against the release that
     publishes it. 'assets' maps the release's asset names to their github
     metadata."""
 
@@ -166,21 +174,23 @@ def check_parts_index_content(index_name: str, index: Dict, assets: Dict):
     )
 
 
-def find_parts_index(package_name: str, tag: str, assets: Dict) -> str:
-    """Return the name of the release's parts index asset, or None if the
-    release has none and is not required to have one."""
+def find_openxc7_parts_index(tag: str, assets: Dict) -> str:
+    """Return the name of the openxc7 release's parts index asset, or None
+    if the release has none and is not required to have one."""
 
     # -- Preferred name, the one the document has inside the package.
-    if PARTS_INDEX_NAME in assets:
-        return PARTS_INDEX_NAME
+    if OPENXC7_PARTS_INDEX_NAME in assets:
+        return OPENXC7_PARTS_INDEX_NAME
 
     # -- Dated name. Asset names are derived from the tag's date, so it
     # -- must be the one named after this tag: an index from another
     # -- release describes another release's assets.
-    dated = [n for n in assets if n.startswith(PARTS_INDEX_PREFIX)]
+    dated = [n for n in assets if n.startswith(OPENXC7_PARTS_INDEX_PREFIX)]
     assert len(dated) <= 1, dated
     if dated:
-        expected_name = PARTS_INDEX_PREFIX + tag.replace("-", "") + ".json"
+        expected_name = (
+            OPENXC7_PARTS_INDEX_PREFIX + tag.replace("-", "") + ".json"
+        )
         if dated[0] != expected_name:
             print(
                 f"Error: expected index '{expected_name}', "
@@ -191,26 +201,26 @@ def find_parts_index(package_name: str, tag: str, assets: Dict) -> str:
 
     # -- No index. For a package that fetches its databases on demand that
     # -- is a broken release, not an old one, so do not pass it silently.
-    required_from = PARTS_INDEX_REQUIRED_FROM.get(package_name)
-    if required_from and tag >= required_from:
+    packages_carry_no_databases = tag >= OPENXC7_PARTS_INDEX_REQUIRED_FROM
+    if packages_carry_no_databases:
         print(
-            f"Error: release '{tag}' of package '{package_name}' has no "
-            f"parts index, and releases from '{required_from}' on need one"
+            f"Error: {OPENXC7_PACKAGE} release '{tag}' has no parts index, "
+            f"and releases from '{OPENXC7_PARTS_INDEX_REQUIRED_FROM}' on "
+            "need one"
         )
         sys.exit(1)
 
     return None
 
 
-def check_parts_index(package_name: str, tag: str, assets: Dict):
-    """Check the on-demand device databases of a release, if it has any.
+def check_openxc7_parts_index(tag: str, assets: Dict):
+    """Check the on-demand device databases of an openxc7 release.
 
-    Packages whose device databases are fetched on demand (openxc7)
-    publish an index asset that tells apio which database file to download
-    for a given part. 'assets' maps the release's asset names to their
-    github metadata."""
+    Its packages carry no device databases: the parts index asset tells
+    apio which database file to download for a given part. 'assets' maps
+    the release's asset names to their github metadata."""
 
-    index_name = find_parts_index(package_name, tag, assets)
+    index_name = find_openxc7_parts_index(tag, assets)
     if index_name is None:
         return
 
@@ -228,10 +238,11 @@ def check_parts_index(package_name: str, tag: str, assets: Dict):
 
     # -- A different schema means the fields apio's loader reads were
     # -- renamed or reshaped.
-    if index.get("schema") != PARTS_INDEX_SCHEMA_VERSION:
+    if index.get("schema") != OPENXC7_PARTS_INDEX_SCHEMA_VERSION:
         print(
-            f"Error: {index_name} has schema {index.get('schema')}, but "
-            f"apio's loader expects schema {PARTS_INDEX_SCHEMA_VERSION}"
+            f"Error: {index_name} has schema {index.get('schema')}, "
+            "but apio's loader expects schema "
+            f"{OPENXC7_PARTS_INDEX_SCHEMA_VERSION}"
         )
         sys.exit(1)
 
@@ -244,7 +255,7 @@ def check_parts_index(package_name: str, tag: str, assets: Dict):
         )
         sys.exit(1)
 
-    check_parts_index_content(index_name, index, assets)
+    check_openxc7_parts_index_content(index_name, index, assets)
 
 
 def check_remote_config(jsonc_text: str):


### PR DESCRIPTION
Follows up on #947: you suggested adding the openxc7 chipdb verification to `monitor-remote-configs`, and this is it. One file, `scripts/check_remote_configs.py`; the workflow itself is unchanged.

**Why.** For openxc7 "the release exists and is stable" no longer means apio can build: since the on-demand model the packages carry no device databases, and apio downloads the one a board needs from a per-part release asset that `PARTS-INDEX.json` names. If one of those assets is missing or was published truncated, apio is dead for that FPGA and nothing notices until a user hits it — the monitor is the natural place to catch it.

**What it checks**, for any release that publishes a parts index (packages without one are untouched, so this is a no-op everywhere else):

- the index is the one named after the release's tag (apio's date rule);
- its `schema` is the one `apio/managers/xilinx_chipdb.py` reads — a bump means the fields the loader uses were renamed, and the message says so;
- its `release-tag` is this release (an index from another release would send apio to another release's assets);
- `part-count`/`generated-count`/`chipdb-count` match what the document actually describes;
- every part that has a database has its asset **published, at the size the index promises**.

**Cost.** Sizes come from the release metadata the script already fetches, so the only extra request is the index itself (a few tens of KB) — and the asset loop deduplicates by file, because the speed grades of a part share one database: 15 checks instead of 56 for today's openxc7 release. Byte-level (sha256) verification stays where it is cheap to do once, in the toolchain repo's promotion gate.

**Verified against the live configs** (`GITHUB_TOKEN` set, full run green, exit 0):

```
===== Remote Config apio-1.5.x.jsonc =====
Checking package [openxc7] release [2026-08-20]          <- predates the model, no index, skipped
===== Remote Config apio-1.6.x.jsonc =====
Checking package [openxc7] release [2026-08-31]
Checking parts index [apio-xilinx-parts-index-20260831.json]
Parts index OK (154 parts, 56 of them with a database, in 15 assets)
Done (Check OK 5 remote configs).
```

And the failure paths, exercised with a doctored index so they are not just theory:

```
asset missing  : exit 1 · Error: part 'xc7a35tcsg324-1' needs asset 'a.bin.tgz', which this release does not publish
asset truncated: exit 1 · Error: asset 'a.bin.tgz' is 99 bytes, but the index says 100
bad counts     : exit 1 · Error: i.json: generated-count is 7, but the document describes 1
foreign index  : exit 1 · Error: expected index 'apio-xilinx-parts-index-20260831.json', found '…-20260830.json'
```

Lint: `black`, `flake8` and `pylint` at the `tox.ini` versions — clean, pylint 10.00/10.

One judgement call worth your opinion: a schema bump on our side makes this monitor **red**, deliberately — that is exactly the case where apio's loader would silently stop finding the sizes. If you would rather it warned instead of failing, say so and I will change it. I did not add tests: `scripts/` has none today and I did not want to bring a new layout in with this; happy to add them if you want them.
