### PR TITLE
Fixed stale option names on the 'apio lint' doc page

### DIFF
--- a/docs/cmd-apio-lint.md
+++ b/docs/cmd-apio-lint.md
@@ -25,7 +25,7 @@ synthesizable portion of the design. To lint code that is hidden by
 `SYNTHESIS`, use the `--nosynth option`.
 
 To customize the behavior of the `verilator` linter, add the option
-`verilator-extra-option` in the project file `apio.ini` with the extra
+`verilator-extra-options` in the project file `apio.ini` with the extra
 options you would like to use. 
 
 <h3>Options</h3>
@@ -33,9 +33,6 @@ options you would like to use.
 ```
 --nosynth               Do not define the SYNTHESIS macro.
 --novlt                 Disable warning suppression .vlt file.
---nostyle               Disable all style warnings
---nowarn nowarn         Disable specific warning(s)
---warn warn             Enable specific warning(s)
 -t, --top-module name   Restrict linting to this module and its dependencies
 -e, --env name          Use a named environment from apio.ini
 -p, --project-dir path  Specify the project root directory


### PR DESCRIPTION
## Problem

`docs/cmd-apio-lint.md` documents three options that `apio lint` does not accept, and names an `apio.ini` option that does not exist. Both are user visible on the published site: <https://fpgawars.github.io/apio/docs/cmd-apio-lint/>.

**1. `--nostyle`, `--nowarn`, `--warn` no longer exist.**
`apio/commands/apio_lint.py` defines only `--nosynth` and `--novlt` (plus the shared `top-module` / `env` / `project-dir` generators), and `ignore_unknown_options` is set only on `apio raw`, never on `apio lint`, so click rejects them outright:

```
$ apio lint --nostyle
Error: No such option: --nostyle (Possible options: --nosynth, --novlt)

$ apio lint --nowarn foo
Error: No such option: --nowarn

$ apio lint --warn foo
Error: No such option: --warn
```

The repo's own committed help dump agrees — `COMMANDS.txt:1054-1060` lists only `--nosynth`, `--novlt`, `-t`, `-e`, `-p`, `-h`. A repo-wide `git grep -nE 'nostyle|nowarn'` finds them only in this doc page and in the cSpell word list in `.vscode/settings.json`; zero hits in any `.py`.

**2. `verilator-extra-option` should be `verilator-extra-options` (plural).**
The real key is defined in `apio/managers/project.py:96` as `verilator-extra-options`, and `_validate_env_section()` calls `fatal_error("Unknown option ...")` for anything not in `ENV_OPTIONS_SPEC`, so the singular spelling from the doc aborts the command. `docs/project-file.md:243-253` already uses the correct plural.

**Provenance:** both slips come from the same commit, dfd98b0 ("Added apio.ini option 'verilator-extra-options'. Also, dropped the 'apio lint' options to control verilator linting"). Its diff of this page rewrites the `--nosynth` line directly above the three dead entries while leaving them in place, and introduces the `verilator-extra-option` prose in the singular.

## Change

Docs only, one file, 4 lines:

- deleted the `--nostyle` / `--nowarn` / `--warn` entries from the `<h3>Options</h3>` block;
- `verilator-extra-option` -> `verilator-extra-options`.

The remaining six option lines already match the real parser, so I left their wording untouched.

## Verification

```
$ python -m venv .venv && .venv/bin/pip install -e .

$ apio lint -h
Options:
  --nosynth               Do not define the SYNTHESIS macro.
  --novlt                 Disable warning suppression .vlt file.
  -t, --top-module name   Restrict linting to this module and its
                          dependencies.
  -e, --env name          Set the apio.ini env.
  -p, --project-dir path  Set the root directory for the project.
  -h, --help              Show this message and exit.

$ python -c "from apio.managers.project import ENV_OPTIONS_SPEC; \
    print('verilator-extra-option ' in ENV_OPTIONS_SPEC, \
          'verilator-extra-options' in ENV_OPTIONS_SPEC)"
False True

$ git grep -nE 'nostyle|nowarn' -- '*.py'       # (no output, exit 1)
$ git grep -n 'ignore_unknown_options'
apio/commands/apio_raw.py:100:    context_settings={"ignore_unknown_options": True},
```

Docs build, per `docs/updating-the-docs.md`:

```
$ pip install mkdocs-material && mkdocs build --strict --site-dir site/docs
INFO    -  Documentation built in 3.89 seconds

$ grep -c 'nostyle\|nowarn' site/docs/cmd-apio-lint/index.html
0
$ grep -o 'verilator-extra-option[s]*' site/docs/cmd-apio-lint/index.html
verilator-extra-options
```

## Notes / limitations

- `docs/updating-the-docs.md` asks contributors to confirm the fork's `publish-mkdocs-docs`, `pages-build-deployment`, `monitor-apio-latest` and `test` workflows are green and that the fork's Pages site shows the change. `publish-docs.yaml` only triggers on pushes to `main` (plus schedule / manual dispatch), so it does not run for a topic branch on a fork; instead I ran the workflow's own docs step locally (`mkdocs build --strict`) and checked the generated HTML, as quoted above. No Python is touched, so `test` is unaffected. Happy to enable Pages on the fork and re-verify if you would like that done first.
- `apio/commands/apio_lint.py:65` carries the same `verilator-extra-option` singular typo in `APIO_LINT_HELP` (and therefore `COMMANDS.txt:1051`). I deliberately left it out of this PR: `COMMANDS.txt` is regenerated by `scripts/update-commands-txt.sh`, so that one is better fixed together with a regeneration on your side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
