### PR TITLE
Bumped openxc7 in remote config 1.6.x 2026-08-31 -> 2026-09-07

### DIFF
--- a/apio/managers/xilinx_chipdb.py
+++ b/apio/managers/xilinx_chipdb.py
@@ -20,7 +20,12 @@ from apio.utils import util
 # -- its size. According to source on the internet, if using sha256, there
 # -- is no need to check also the size.
 
-# -- The expected version of the PARTS-INDEX.json schema. This stored
+# -- The name of the Xilinx parts index file at the root of the openxc7
+# -- package.
+PARTS_INDEX_FILE_NAME = "XILINX-PARTS-INDEX.json"
+
+
+# -- The expected version of the parts index schema. This stored
 # -- in the "schema" field at the top level. If the schema changes, we
 # -- may need to adapt the code below.
 EXPECTED_SCHEMA_VERSION = 5
@@ -52,7 +57,7 @@ def chipdb_file_on_demand(
     # -- Read the xilinx parts index from the file PARTS_INDEX.json at the
     # -- root of the openxc7 package.
     openxc7_dir = apio_ctx.get_package_dir("openxc7")
-    parts_index_path = openxc7_dir / "PARTS-INDEX.json"
+    parts_index_path = openxc7_dir / PARTS_INDEX_FILE_NAME
     with open(parts_index_path, encoding="utf-8") as f:
         json_data = json.load(f)
 

--- a/remote-config/apio-1.6.x.jsonc
+++ b/remote-config/apio-1.6.x.jsonc
@@ -55,7 +55,7 @@
         "organization": "fpgawars"
       },
       "release": {
-        "tag": "2026-08-31",
+        "tag": "2026-09-07",
         "package": "apio-openxc7-${PLATFORM}-${YYYYMMDD}.tgz"
       }
     },

--- a/scripts/check_remote_configs.py
+++ b/scripts/check_remote_configs.py
@@ -34,7 +34,7 @@ OPENXC7_PACKAGE = "openxc7"
 # -- name the document has inside the package, and the dated asset name
 # -- releases up to 2026-08-31 used. Both are accepted, so that the rename
 # -- did not need this script and the toolchain to change at once.
-OPENXC7_PARTS_INDEX_NAME = "PARTS-INDEX.json"
+OPENXC7_PARTS_INDEX_NAME = "XILINX-PARTS-INDEX.json"
 OPENXC7_PARTS_INDEX_PREFIX = "apio-xilinx-parts-index-"
 
 # -- The first openxc7 release whose packages carry no device databases.

--- a/tests/integration_tests/test_xilinx_parts.py
+++ b/tests/integration_tests/test_xilinx_parts.py
@@ -1,5 +1,5 @@
 """
-Tests related to the openxc7 package's PARTS-INDEX.json file.
+Tests related to the openxc7 package's XILINX-PARTS-INDEX.json file.
 """
 
 import json
@@ -15,7 +15,7 @@ from apio.common.proto.apio_common_pb2 import ApioArch
 
 def test_fpgas_yosys_part_num(apio_runner: ApioRunner):
     """Tests that all xilinx fpgas has a valid yosys-part value, that is,
-    it's listed on PARTS-INDEX.json as a generated part."""
+    it's listed on XILINX-PARTS-INDEX.json as a generated part."""
 
     with apio_runner.in_sandbox():
 
@@ -27,7 +27,9 @@ def test_fpgas_yosys_part_num(apio_runner: ApioRunner):
         )
 
         # -- Read the parts index of the Apio's openxc7 package
-        index_path = apio_ctx.get_package_dir("openxc7") / "PARTS-INDEX.json"
+        index_path = (
+            apio_ctx.get_package_dir("openxc7") / "XILINX-PARTS-INDEX.json"
+        )
         index_data = json.loads(index_path.read_text(encoding="utf-8"))
         assert index_data["schema"] == 5, index_data["schema"]
         parts = index_data["parts"]


### PR DESCRIPTION
Bumped remote config 1.6.x to a new openxc7 package that renamed PARS-INDEX.json to XILINX-PARTS-INDEX.json and generates more part.s 2026-08-31 -> 2026-09-07